### PR TITLE
feat: clipboard preview notification + SSH notification bridge

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/shunmei/cc-clip/internal/doctor"
 	"github.com/shunmei/cc-clip/internal/exitcode"
 	"github.com/shunmei/cc-clip/internal/service"
+	"github.com/shunmei/cc-clip/internal/session"
 	"github.com/shunmei/cc-clip/internal/setup"
 	"github.com/shunmei/cc-clip/internal/shim"
 	"github.com/shunmei/cc-clip/internal/token"
@@ -192,39 +193,46 @@ func cmdServe() {
 
 	tm := token.NewManager(ttl)
 
-	var session token.Session
+	var sess token.Session
 	var reused bool
 	var err error
 
 	if rotateToken {
-		session, err = tm.Generate()
+		sess, err = tm.Generate()
 		if err != nil {
 			log.Fatalf("failed to generate token: %v", err)
 		}
 		log.Printf("Token rotated (--rotate-token): new token generated")
 	} else {
-		session, reused, err = tm.LoadOrGenerate(ttl)
+		sess, reused, err = tm.LoadOrGenerate(ttl)
 		if err != nil {
 			log.Fatalf("failed to load or generate token: %v", err)
 		}
 		if reused {
-			log.Printf("Token reused from existing file (expires %s)", session.ExpiresAt.Format(time.RFC3339))
+			log.Printf("Token reused from existing file (expires %s)", sess.ExpiresAt.Format(time.RFC3339))
 		} else {
 			log.Printf("Token generated (no valid existing token found)")
 		}
 	}
 
-	tokenPath, err := token.WriteTokenFile(session.Token, session.ExpiresAt)
+	tokenPath, err := token.WriteTokenFile(sess.Token, sess.ExpiresAt)
 	if err != nil {
 		log.Fatalf("failed to write token file: %v", err)
 	}
 
 	clipboard := daemon.NewClipboardReader()
-	srv := daemon.NewServer(addr, clipboard, tm)
+	store := session.NewStore(12 * time.Hour)
+	srv := daemon.NewServer(addr, clipboard, tm, store)
 
 	log.Printf("Token written to: %s", tokenPath)
-	log.Printf("Token expires at: %s", session.ExpiresAt.Format(time.RFC3339))
+	log.Printf("Token expires at: %s", sess.ExpiresAt.Format(time.RFC3339))
 	log.Printf("Starting daemon on %s", addr)
+
+	// Start notification delivery and session cleanup in background
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.RunNotifier(ctx, daemon.NewDarwinNotifier())
+	go store.RunCleanup(ctx, 30*time.Minute)
 
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("server error: %v", err)
@@ -505,11 +513,17 @@ func runConnect(opts connectOpts) {
 		fmt.Println("[4/7] Skipping binary upload (--token-only)")
 		fmt.Println("[5/7] Skipping shim install (--token-only)")
 
-		fmt.Printf("[6/7] Syncing token...\n")
+		fmt.Printf("[6/7] Syncing token and session...\n")
 		if err := shim.WriteRemoteTokenViaSession(session, daemonToken); err != nil {
 			log.Fatalf("      failed to write token: %v", err)
 		}
 		fmt.Println("      token synced from local daemon")
+
+		if sid, genErr := shim.GenerateSessionID(); genErr == nil {
+			if writeErr := shim.WriteRemoteSessionID(session, sid); writeErr == nil {
+				fmt.Printf("      session ID: %s\n", sid[:16])
+			}
+		}
 
 		connectVerifyTunnel(session, port, host)
 		return
@@ -614,12 +628,23 @@ func runConnect(opts connectOpts) {
 		pathFixed = true
 	}
 
-	// Step 6: Always sync token
-	fmt.Printf("[6/7] Syncing token...\n")
+	// Step 6: Sync token and session ID
+	fmt.Printf("[6/7] Syncing token and session...\n")
 	if err := shim.WriteRemoteTokenViaSession(session, daemonToken); err != nil {
 		log.Fatalf("      failed to write token: %v", err)
 	}
 	fmt.Println("      token synced from local daemon")
+
+	sessionID, err := shim.GenerateSessionID()
+	if err != nil {
+		log.Printf("      warning: failed to generate session ID: %v", err)
+	} else {
+		if err := shim.WriteRemoteSessionID(session, sessionID); err != nil {
+			log.Printf("      warning: failed to write session ID: %v", err)
+		} else {
+			fmt.Printf("      session ID: %s\n", sessionID[:16])
+		}
+	}
 
 	// Update remote deploy state
 	localHash, _ := shim.LocalBinaryHash(localBin)

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -60,6 +65,8 @@ func main() {
 		cmdSetup()
 	case "service":
 		cmdService()
+	case "notify":
+		cmdNotify()
 	case "x11-bridge":
 		cmdX11Bridge()
 	case "version", "--version", "-v":
@@ -133,6 +140,14 @@ Diagnostics:
   doctor             Local health check
   doctor --host H    Full end-to-end check via SSH
   version            Show version
+
+Notifications:
+  notify             Send a notification to the local daemon
+    --title          Notification title
+    --body           Notification body
+    --urgency        Urgency level (default: 1)
+    --from-codex     Parse Codex JSON payload (extracts last-assistant-message)
+    --port           Daemon port (default: 18339, env: CC_CLIP_PORT)
 
 Internal (used by deploy):
   x11-bridge         X11 clipboard bridge daemon (started by connect --codex)
@@ -231,7 +246,7 @@ func cmdServe() {
 	// Start notification delivery and session cleanup in background
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go srv.RunNotifier(ctx, daemon.NewDarwinNotifier())
+	go srv.RunNotifier(ctx, daemon.BuildDeliveryChain())
 	go store.RunCleanup(ctx, 30*time.Minute)
 
 	if err := srv.ListenAndServe(); err != nil {
@@ -462,11 +477,12 @@ type connectOpts struct {
 	force     bool
 	tokenOnly bool
 	codex     bool
+	noNotify  bool
 }
 
 func cmdConnect() {
 	if len(os.Args) < 3 {
-		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only]")
+		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify]")
 	}
 	runConnect(connectOpts{
 		host:      os.Args[2],
@@ -474,6 +490,7 @@ func cmdConnect() {
 		force:     hasFlag("force"),
 		tokenOnly: hasFlag("token-only"),
 		codex:     hasFlag("codex"),
+		noNotify:  hasFlag("no-notify"),
 	})
 }
 
@@ -669,6 +686,14 @@ func runConnect(opts connectOpts) {
 	// Step 7: Verify tunnel
 	connectVerifyTunnel(session, port, host)
 
+	// Notification bridge setup (unless --no-notify)
+	if !opts.noNotify {
+		connectNotifySetup(session, port, daemonToken, newState)
+		if err := shim.WriteRemoteState(session, newState); err != nil {
+			log.Printf("      warning: could not write remote deploy state: %v", err)
+		}
+	}
+
 	// Steps 8-11: Codex support (only if --codex flag is set)
 	if opts.codex {
 		codexOk := runConnectCodex(session, opts, needsUpload, newState)
@@ -682,6 +707,166 @@ func runConnect(opts connectOpts) {
 			os.Exit(1)
 		}
 	}
+}
+
+// connectNotifySetup performs notification bridge setup:
+// 1. Generate nonce and register with local daemon
+// 2. Write nonce to remote
+// 3. Install hook script on remote
+// 4. Print Claude Code hook config
+// 5. Detect and configure Codex notify (if ~/.codex exists)
+// 6. Run health probe
+func connectNotifySetup(session *shim.SSHSession, port int, daemonToken string, state *shim.DeployState) {
+	fmt.Println()
+	fmt.Println("Notification bridge setup:")
+
+	// Step N1: Generate nonce
+	fmt.Println("  [N1] Generating notification nonce...")
+	notifyNonce, err := shim.GenerateNotificationNonce()
+	if err != nil {
+		log.Printf("      warning: failed to generate notification nonce: %v", err)
+		return
+	}
+
+	// Register nonce with the local daemon via HTTP
+	if err := registerNonceWithDaemon(port, daemonToken, notifyNonce); err != nil {
+		log.Printf("      warning: failed to register nonce with daemon: %v", err)
+		return
+	}
+	fmt.Printf("      nonce: %s...\n", notifyNonce[:16])
+
+	// Step N2: Write nonce to remote
+	fmt.Println("  [N2] Writing nonce to remote...")
+	if err := shim.WriteRemoteNotificationNonce(session, notifyNonce); err != nil {
+		log.Printf("      warning: failed to write remote nonce: %v", err)
+		return
+	}
+	fmt.Println("      nonce synced")
+
+	// Step N3: Install hook script
+	fmt.Println("  [N3] Installing hook script...")
+	if err := shim.InstallRemoteHookScript(session, port); err != nil {
+		log.Printf("      warning: failed to install hook script: %v", err)
+		return
+	}
+	fmt.Println("      cc-clip-hook installed to ~/.local/bin/cc-clip-hook")
+
+	hookInstalled := true
+
+	// Step N4: Print Claude Code hook config
+	fmt.Println("  [N4] Claude Code hook configuration:")
+	fmt.Println("      Add the following to your Claude Code settings (hooks):")
+	fmt.Println()
+	for _, line := range strings.Split(claudeHookConfigJSON(), "\n") {
+		fmt.Printf("      %s\n", line)
+	}
+	fmt.Println()
+
+	// Step N5: Detect and configure Codex notify
+	codexInjected := false
+	if shim.RemoteHasCodex(session) {
+		fmt.Println("  [N5] Codex detected, injecting notify config...")
+		if err := shim.EnsureRemoteCodexNotifyConfig(session); err != nil {
+			log.Printf("      warning: codex config injection failed: %v", err)
+		} else {
+			codexInjected = true
+			fmt.Println("      ~/.codex/config.toml updated")
+		}
+	} else {
+		fmt.Println("  [N5] Codex not detected, skipping config injection")
+	}
+
+	// Step N6: Health probe
+	fmt.Println("  [N6] Running notification health probe...")
+	healthVerified := false
+	if err := runNotificationHealthProbe(port, notifyNonce); err != nil {
+		log.Printf("      warning: health probe failed: %v", err)
+	} else {
+		healthVerified = true
+		fmt.Println("      health probe passed")
+	}
+
+	// Update deploy state
+	state.Notify = &shim.NotifyDeployState{
+		Enabled:        true,
+		HookInstalled:  hookInstalled,
+		CodexInjected:  codexInjected,
+		HealthVerified: healthVerified,
+	}
+}
+
+// registerNonceWithDaemon sends the notification nonce to the local daemon
+// via POST /register-nonce, authenticated with the clipboard bearer token.
+func registerNonceWithDaemon(port int, bearerToken, nonce string) error {
+	payload := fmt.Sprintf(`{"nonce":%q}`, nonce)
+	url := fmt.Sprintf("http://127.0.0.1:%d/register-nonce", port)
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearerToken)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip/connect")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("daemon returned status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// runNotificationHealthProbe sends a test notification to the local daemon
+// via /notify and checks for 204. This proves the nonce is registered and
+// the notification pipeline works end-to-end.
+func runNotificationHealthProbe(port int, nonce string) error {
+	payload := `{"title":"cc-clip","body":"Notification bridge connected","urgency":0}`
+	url := fmt.Sprintf("http://127.0.0.1:%d/notify", port)
+
+	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+nonce)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip-hook/0.1")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("health probe request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("expected 204, got %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func claudeHookConfigJSON() string {
+	return `{
+  "hooks": {
+    "Notification": [
+      {
+        "type": "command",
+        "command": "cc-clip-hook"
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "cc-clip-hook"
+      }
+    ]
+  }
+}`
 }
 
 func cmdSetup() {
@@ -1285,6 +1470,122 @@ func dumpRemoteLog(session *shim.SSHSession, logPath string) {
 		}
 		fmt.Println("      --- end ---")
 	}
+}
+
+// --- Notify subcommand ---
+
+// cmdNotify sends a generic notification to the local cc-clip daemon.
+func cmdNotify() {
+	fs := flag.NewFlagSet("notify", flag.ExitOnError)
+	title := fs.String("title", "", "notification title")
+	body := fs.String("body", "", "notification body")
+	urgency := fs.Int("urgency", 1, "notification urgency (0=low, 1=normal, 2=critical)")
+	fromCodex := fs.String("from-codex", "", "Codex notify JSON payload")
+	fromCodexStdin := fs.Bool("from-codex-stdin", false, "read Codex notify JSON payload from stdin")
+	_ = fs.Parse(os.Args[2:])
+
+	msg := daemon.GenericMessagePayload{
+		Title:   *title,
+		Body:    *body,
+		Urgency: *urgency,
+	}
+
+	switch {
+	case *fromCodex != "" && *fromCodexStdin:
+		log.Fatal("notify failed: --from-codex and --from-codex-stdin are mutually exclusive")
+	case *fromCodex != "":
+		parsed, err := parseCodexNotifyPayload(*fromCodex)
+		if err != nil {
+			log.Fatalf("invalid codex notify payload: %v", err)
+		}
+		msg = parsed
+	case *fromCodexStdin:
+		payload, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Fatalf("failed to read codex payload from stdin: %v", err)
+		}
+		parsed, err := parseCodexNotifyPayload(string(payload))
+		if err != nil {
+			log.Fatalf("invalid codex notify payload: %v", err)
+		}
+		msg = parsed
+	}
+
+	port := getPort()
+	if err := postGenericNotification(port, msg); err != nil {
+		log.Fatalf("notify failed: %v", err)
+	}
+}
+
+// parseCodexNotifyPayload extracts a GenericMessagePayload from the Codex
+// JSON format. Codex passes {"last-assistant-message": "..."} as its notify
+// payload. The extracted message becomes the body with title "Codex".
+func parseCodexNotifyPayload(payload string) (daemon.GenericMessagePayload, error) {
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return daemon.GenericMessagePayload{}, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	lastMsg, _ := raw["last-assistant-message"].(string)
+
+	return daemon.GenericMessagePayload{
+		Title:   "Codex",
+		Body:    lastMsg,
+		Urgency: 1,
+	}, nil
+}
+
+// postGenericNotification sends a generic notification to the local cc-clip daemon.
+// It reads the notification nonce from ~/.cache/cc-clip/notify.nonce for auth.
+func postGenericNotification(port int, msg daemon.GenericMessagePayload) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	nonceFile := filepath.Join(home, ".cache", "cc-clip", "notify.nonce")
+	nonceBytes, err := os.ReadFile(nonceFile)
+	if err != nil {
+		return fmt.Errorf("cannot read nonce file %s: %w", nonceFile, err)
+	}
+	nonce := strings.TrimSpace(string(nonceBytes))
+
+	payload := struct {
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+		Urgency int    `json:"urgency"`
+	}{
+		Title:   msg.Title,
+		Body:    msg.Body,
+		Urgency: msg.Urgency,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal notification: %w", err)
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/notify", port)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+nonce)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip-notify/0.1")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send notification: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("daemon returned HTTP %d", resp.StatusCode)
+	}
+
+	return nil
 }
 
 // cmdX11Bridge runs the X11 clipboard bridge daemon (internal command).

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,11 +22,18 @@ func TestStopLocalProcessDoesNotKillUnexpectedCommand(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("failed to start helper process: %v", err)
 	}
+
+	// Use sync.Once to ensure cmd.Wait() is called exactly once,
+	// preventing a data race between the cleanup and the goroutine.
+	var waitOnce sync.Once
+	var waitErr error
+	doWait := func() { waitOnce.Do(func() { waitErr = cmd.Wait() }) }
+
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
-		_ = cmd.Wait()
+		doWait()
 	})
 
 	pidFile := filepath.Join(t.TempDir(), "helper.pid")
@@ -36,14 +44,15 @@ func TestStopLocalProcessDoesNotKillUnexpectedCommand(t *testing.T) {
 	stopLocalProcess(pidFile, "Xvfb")
 	time.Sleep(100 * time.Millisecond)
 
-	waitDone := make(chan error, 1)
+	waitDone := make(chan struct{}, 1)
 	go func() {
-		waitDone <- cmd.Wait()
+		doWait()
+		waitDone <- struct{}{}
 	}()
 
 	select {
-	case err := <-waitDone:
-		t.Fatalf("unexpected command should still be running, but exited early: %v", err)
+	case <-waitDone:
+		t.Fatalf("unexpected command should still be running, but exited early: %v", waitErr)
 	case <-time.After(200 * time.Millisecond):
 	}
 

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/shunmei/cc-clip/internal/daemon"
+	"github.com/shunmei/cc-clip/internal/session"
+	"github.com/shunmei/cc-clip/internal/token"
 )
 
 func TestStopLocalProcessDoesNotKillUnexpectedCommand(t *testing.T) {
@@ -92,6 +98,202 @@ func TestReleaseVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNotifyFromCodexParsesLastAssistantMessage(t *testing.T) {
+	payload := `{"last-assistant-message":"Bridge implementation complete"}`
+	msg, err := parseCodexNotifyPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Body != "Bridge implementation complete" {
+		t.Fatalf("unexpected body %q", msg.Body)
+	}
+	if msg.Title != "Codex" {
+		t.Fatalf("expected title %q, got %q", "Codex", msg.Title)
+	}
+}
+
+func TestNotifyFromCodexRejectsInvalidJSON(t *testing.T) {
+	_, err := parseCodexNotifyPayload(`{invalid`)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestNotifyFromCodexHandlesEmptyMessage(t *testing.T) {
+	payload := `{"last-assistant-message":""}`
+	msg, err := parseCodexNotifyPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg.Body != "" {
+		t.Fatalf("expected empty body, got %q", msg.Body)
+	}
+}
+
+func TestNotifyFromCodexHandlesMissingField(t *testing.T) {
+	payload := `{"some-other-field":"value"}`
+	msg, err := parseCodexNotifyPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Missing field => empty body
+	if msg.Body != "" {
+		t.Fatalf("expected empty body for missing field, got %q", msg.Body)
+	}
+}
+
+func TestParseCodexNotifyPayloadReturnType(t *testing.T) {
+	payload := `{"last-assistant-message":"test"}`
+	msg, err := parseCodexNotifyPayload(payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Verify the return type is GenericMessagePayload
+	var _ daemon.GenericMessagePayload = msg
+}
+
+func TestRegisterNonceWithDaemonIntegration(t *testing.T) {
+	tm := token.NewManager(time.Hour)
+	sess, err := tm.Generate()
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+	store := session.NewStore(12 * time.Hour)
+	srv := daemon.NewServer("127.0.0.1:0", &testClipboard{}, tm, store)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	port := extractPort(t, ts.URL)
+	testNonce := "test-nonce-0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+
+	if err := registerNonceWithDaemon(port, sess.Token, testNonce); err != nil {
+		t.Fatalf("registerNonceWithDaemon failed: %v", err)
+	}
+
+	// Verify the nonce works by sending a health probe
+	if err := runNotificationHealthProbe(port, testNonce); err != nil {
+		t.Fatalf("health probe failed after nonce registration: %v", err)
+	}
+}
+
+func TestRunNotificationHealthProbeFailsWithBadNonce(t *testing.T) {
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := daemon.NewServer("127.0.0.1:0", &testClipboard{}, tm, store)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	port := extractPort(t, ts.URL)
+
+	err := runNotificationHealthProbe(port, "bad-nonce")
+	if err == nil {
+		t.Fatal("expected health probe to fail with unregistered nonce")
+	}
+}
+
+func TestPostGenericNotificationDeliversExpectedPayload(t *testing.T) {
+	tm := token.NewManager(time.Hour)
+	_, err := tm.Generate()
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+	store := session.NewStore(12 * time.Hour)
+	srv := daemon.NewServer("127.0.0.1:0", &testClipboard{}, tm, store)
+	nonce := "test-notify-nonce-0123456789abcdef0123456789abcdef0123456789abcdef"
+	srv.RegisterNotificationNonce(nonce)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	port := extractPort(t, ts.URL)
+
+	home := t.TempDir()
+	cacheDir := filepath.Join(home, ".cache", "cc-clip")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "notify.nonce"), []byte(nonce+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write nonce file: %v", err)
+	}
+
+	oldHome := os.Getenv("HOME")
+	if err := os.Setenv("HOME", home); err != nil {
+		t.Fatalf("failed to set HOME: %v", err)
+	}
+	defer func() {
+		_ = os.Setenv("HOME", oldHome)
+	}()
+
+	msg := daemon.GenericMessagePayload{
+		Title:   "Build complete",
+		Body:    "All tests passed",
+		Urgency: 1,
+	}
+	if err := postGenericNotification(port, msg); err != nil {
+		t.Fatalf("postGenericNotification failed: %v", err)
+	}
+
+	select {
+	case env := <-srv.NotifyChannel():
+		if env.GenericMessage == nil {
+			t.Fatal("expected GenericMessage payload")
+		}
+		if env.GenericMessage.Title != msg.Title {
+			t.Fatalf("expected title %q, got %q", msg.Title, env.GenericMessage.Title)
+		}
+		if env.GenericMessage.Body != msg.Body {
+			t.Fatalf("expected body %q, got %q", msg.Body, env.GenericMessage.Body)
+		}
+		if env.GenericMessage.Urgency != msg.Urgency {
+			t.Fatalf("expected urgency %d, got %d", msg.Urgency, env.GenericMessage.Urgency)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected notification to be enqueued")
+	}
+}
+
+func TestClaudeHookConfigJSONIncludesNotificationAndStop(t *testing.T) {
+	cfg := claudeHookConfigJSON()
+	if !strings.Contains(cfg, `"Notification"`) {
+		t.Fatalf("expected Notification hook in config, got %q", cfg)
+	}
+	if !strings.Contains(cfg, `"Stop"`) {
+		t.Fatalf("expected Stop hook in config, got %q", cfg)
+	}
+	if strings.Count(cfg, `"command": "cc-clip-hook"`) != 2 {
+		t.Fatalf("expected hook command to appear twice, got %q", cfg)
+	}
+}
+
+// testClipboard is a minimal mock for daemon.ClipboardReader.
+type testClipboard struct{}
+
+func (c *testClipboard) Type() (daemon.ClipboardInfo, error) {
+	return daemon.ClipboardInfo{Type: daemon.ClipboardEmpty}, nil
+}
+
+func (c *testClipboard) ImageBytes() ([]byte, error) {
+	return nil, nil
+}
+
+// extractPort extracts the port number from an httptest server URL.
+func extractPort(t *testing.T, url string) int {
+	t.Helper()
+	// URL format: http://127.0.0.1:PORT
+	parts := strings.Split(url, ":")
+	if len(parts) < 3 {
+		t.Fatalf("unexpected URL format: %s", url)
+	}
+	port, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil {
+		t.Fatalf("failed to parse port from URL %s: %v", url, err)
+	}
+	return port
 }
 
 func TestIsNumeric(t *testing.T) {

--- a/docs/plans/2026-03-31-clipboard-preview-notification-design.md
+++ b/docs/plans/2026-03-31-clipboard-preview-notification-design.md
@@ -1,0 +1,261 @@
+# Clipboard Preview Notification Design
+
+**Date:** 2026-03-31
+**Status:** Design Complete, Pending Implementation
+**Version:** v0.5.0 (planned)
+
+## Problem
+
+When pasting images into Claude Code or Codex CLI through cc-clip, users cannot see what was pasted. During batch pasting, this leads to duplicate or missed images with no way to detect either.
+
+The root cause is that the entire cc-clip pipeline is a transparent byte relay with no observable state or deduplication semantics.
+
+## Solution
+
+Add local macOS notification preview triggered as a side effect of daemon serving image requests. Each notification shows a thumbnail, sequence number, and duplicate indicator. Zero additional user action required.
+
+## Constraints
+
+- Must not add operational burden (no confirmation dialogs)
+- Must not interfere with existing image transfer (no stdout pollution)
+- Terminal inline preview is not viable: Claude Code and Codex CLI are TUI applications that sit between the terminal emulator and image data, blocking escape sequence rendering
+- Must work with both the shim path (Claude Code) and x11-bridge path (Codex CLI)
+
+## Architecture
+
+```
+cc-clip connect <host>
+  +-- Generate session_id (UUID)
+  +-- Write to remote ~/.cache/cc-clip/session.id
+  +-- Shim reads session.id, includes in every request
+
+Remote shim: GET /clipboard/image
+  Headers: Authorization: Bearer <token>
+           X-CC-Clip-Session: <session-id>
+           User-Agent: cc-clip/0.x
+
+Local daemon receives request
+  +-- Existing: return image bytes (unchanged)
+  +-- New (async):
+      +-- Store.AnalyzeAndRecord(sessionID, imageData)
+      |     +-- Assign seq number
+      |     +-- Compute SHA-256 fingerprint
+      |     +-- Compare against last 5 images (ring buffer)
+      |     +-- Update session state
+      +-- Emit TransferEvent to notifyCh
+      +-- Notifier goroutine consumes event
+            +-- Generate thumbnail temp file
+            +-- Trigger macOS UserNotification with attachment
+```
+
+### Notification Content
+
+```
+Title:    cc-clip #3
+Subtitle: a1b2c3d4 . 1920x1080 . PNG
+Body:     (only if duplicate) "Duplicate of #1"
+Attachment: thumbnail image
+```
+
+## Components
+
+### 1. Session Management (`internal/session/`)
+
+```go
+type ImageRecord struct {
+    Seq         int
+    Fingerprint string    // SHA-256 first 16 hex chars (8 bytes)
+    Width       int
+    Height      int
+    Format      string
+    At          time.Time
+}
+
+type Session struct {
+    ID         string
+    Recent     [5]ImageRecord  // ring buffer
+    Cursor     int             // ring write position
+    Count      int             // valid entries (0-5)
+    SeqNext    int             // next seq (starts at 1)
+    LastAccess time.Time
+}
+
+type Store struct {
+    mu       sync.Mutex
+    sessions map[string]*Session
+    ttl      time.Duration  // default 12h
+}
+```
+
+**Key method:**
+
+```go
+// AnalyzeAndRecord atomically: find duplicate + assign seq + write ring buffer + update lastAccess
+func (s *Store) AnalyzeAndRecord(sessionID string, fingerprint string, width, height int, format string) TransferEvent
+```
+
+- Computes full SHA-256, stores first 16 hex
+- Scans only `Count` valid entries in ring buffer (not empty slots)
+- Session auto-created on first access
+- Background cleanup goroutine every 30 minutes removes sessions with `LastAccess > TTL`
+
+### 2. Notifier Interface (`internal/daemon/notifier.go`)
+
+```go
+type TransferEvent struct {
+    SessionID   string
+    Seq         int
+    Fingerprint string
+    ImageData   []byte
+    Format      string
+    Width       int
+    Height      int
+    DuplicateOf int  // 0 = unique, N = matches seq N
+}
+
+type Notifier interface {
+    Notify(ctx context.Context, event TransferEvent) error
+}
+```
+
+### 3. Platform Implementations (v1)
+
+| File | Build Tag | Implementation |
+|------|-----------|---------------|
+| `notify_darwin.go` | `darwin` | terminal-notifier (with thumbnail + click-to-open), osascript fallback |
+| `notify_other.go` | `!darwin` | no-op |
+
+**v1 notification stack:**
+- **Primary (terminal-notifier installed):** text notification with small `-contentImage` thumbnail + `-open` click-to-preview in Preview.app. Saves full image to `~/.cache/cc-clip/previews/`.
+- **Fallback (no terminal-notifier):** osascript text-only notification with same preview directory.
+
+**Design note:** The original design specified `UNUserNotificationCenter` + `UNNotificationAttachment` via CGo for native thumbnail support. This was abandoned because `UNUserNotificationCenter` requires a Bundle ID (`bundleProxyForCurrentProcess is nil` crash on CLI processes). A Swift .app bundle wrapper was attempted but macOS notification permission flow does not reliably trigger from background/LSUIElement apps. `terminal-notifier` provides the best available thumbnail support for CLI tools on macOS.
+
+**v1 user experience:**
+- Zero-effort: seq number, fingerprint, dimensions, duplicate flag in notification text
+- One-click: click notification to open full image in Preview.app
+- Browse: `open ~/.cache/cc-clip/previews/` to view all transferred images
+
+**v1.1 (future):** Revisit native `UNNotificationAttachment` thumbnails via a properly signed .app helper or Shortcuts integration.
+
+### 4. Async Delivery Pipeline
+
+```go
+// In Server struct
+notifyCh chan TransferEvent  // buffered, cap=8
+
+// In handleClipboardImage, after writing response:
+select {
+case s.notifyCh <- event:
+default:
+    // channel full: drop notification, never block image transfer
+}
+
+// Background goroutine:
+func (s *Server) runNotifier(ctx context.Context, n Notifier) {
+    for {
+        select {
+        case evt := <-s.notifyCh:
+            _ = n.Notify(ctx, evt)
+        case <-ctx.Done():
+            return
+        }
+    }
+}
+```
+
+**Design invariant:** Image transfer latency is never affected by notification delivery.
+
+### 5. Protocol Extension
+
+**Shim change:** Add `X-CC-Clip-Session` header to curl requests.
+
+```bash
+# In _cc_clip_fetch_binary():
+curl -sf \
+  -H "Authorization: Bearer $token" \
+  -H "User-Agent: cc-clip/0.1" \
+  -H "X-CC-Clip-Session: $session_id" \
+  -o "$tmpfile" \
+  "http://127.0.0.1:${CC_CLIP_PORT:-18339}/clipboard/image"
+```
+
+**Session ID lifecycle:**
+- Generated by `cc-clip connect <host>` as UUID
+- Written to remote `~/.cache/cc-clip/session.id`
+- Shim reads from file on each request (same pattern as token)
+- New connect = new session ID = counter resets
+
+### 6. Deduplication
+
+- Compare fingerprint against `session.Recent[0..Count-1]`
+- Match found: `DuplicateOf = matched.Seq`
+- No match: `DuplicateOf = 0`
+- Window: last 5 images per session
+- Intentional re-paste after 5+ images will not trigger false positive
+
+## File Change List
+
+| File | Type | Description |
+|------|------|-------------|
+| `internal/session/session.go` | New | Session, ImageRecord, Store, AnalyzeAndRecord, RunCleanup |
+| `internal/session/session_test.go` | New | Ring buffer, dedup, TTL, concurrency tests (9 tests) |
+| `internal/daemon/notifier.go` | New | Notifier interface, NotifyEvent, NopNotifier |
+| `internal/daemon/notify_darwin.go` | New | terminal-notifier primary + osascript fallback + preview dir |
+| `internal/daemon/notify_other.go` | New | no-op for non-darwin |
+| `internal/daemon/notify_test.go` | New | Async delivery, channel-full, duplicate detection tests (4 tests) |
+| `internal/daemon/server.go` | Modify | Add session store, notifyCh, RunNotifier (with recover), w.Write error check before notification |
+| `internal/daemon/server_test.go` | Modify | Adapt to new NewServer signature |
+| `internal/shim/template.go` | Modify | Add CC_CLIP_SESSION_FILE, _cc_clip_session_header, X-CC-Clip-Session to curl |
+| `internal/shim/ssh.go` | Modify | Add GenerateSessionID + WriteRemoteSessionID |
+| `internal/shim/install_test.go` | Modify | Verify shim contains session header |
+| `internal/x11bridge/bridge.go` | Modify | Add readSessionID + X-CC-Clip-Session header to both HTTP requests |
+| `cmd/cc-clip/main.go` | Modify | Rename session→sess, add session store, DarwinNotifier, RunCleanup, deploy session ID |
+| `scripts/cc-clip-notify.swift` | New | Swift notification helper (attempted, not used in v1) |
+
+## Implementation Order
+
+```
+Phase 1: Core state layer (pure logic, no dependencies)
+  (1) internal/session/session.go + session_test.go
+
+Phase 2: Notification interface + async pipeline
+  (2) internal/daemon/notifier.go
+  (3) internal/daemon/server.go modifications
+  (4) internal/daemon/notify_test.go
+
+Phase 3: Platform notification implementations
+  (5) notify_darwin.go (terminal-notifier + osascript fallback)
+  (6) notify_other.go (no-op)
+
+Phase 4: Protocol integration
+  (7) internal/shim/template.go + install_test.go
+  (8) internal/shim/ssh.go (GenerateSessionID + WriteRemoteSessionID)
+  (9) internal/x11bridge/bridge.go (session header on both requests)
+  (10) cmd/cc-clip/main.go + main_test.go
+
+Phase 5: End-to-end verification
+  (11) Local serve -> connect -> remote paste -> receive notification with text + click-to-preview
+```
+
+## Test Strategy
+
+| Level | Coverage | Method |
+|-------|----------|--------|
+| Unit | Ring buffer, seq increment, dedup, TTL expiry | Pure Go tests |
+| Unit | AnalyzeAndRecord concurrency safety | `go test -race` |
+| Unit | Async delivery: channel full drops without blocking | Mock Notifier + timing assertions |
+| Unit | Shim template contains session header | String matching |
+| Integration | Daemon + session header -> mock notifier triggered | httptest + mock |
+| Manual | macOS native notification with thumbnail + seq + duplicate | Local `cc-clip serve` + curl |
+| Manual | Fallback: `CGO_ENABLED=0 go build` -> osascript notification | Build verification |
+| E2E | Full connect -> remote paste -> local notification | SSH to test server |
+
+## Future Extensions (Not in Scope)
+
+- **v1.1: Native thumbnail notifications** — Revisit `UNNotificationAttachment` via signed .app helper or macOS Shortcuts integration
+- `cc-clip history` — list recent transfers with thumbnails
+- `cc-clip watch` — real-time monitoring in separate terminal pane (terminal image protocols work here since no TUI blocking)
+- Windows toast notification support
+- Web dashboard for transfer visualization
+- Configurable dedup window size

--- a/docs/plans/2026-04-01-notification-bridge-design.md
+++ b/docs/plans/2026-04-01-notification-bridge-design.md
@@ -518,6 +518,43 @@ Phase 8: End-to-end verification
 | E2E | Chain fallthrough: kill cmux → macOS fallback fires | Manual |
 | E2E | Codex auto-detect: connect to host with ~/.codex/ → config injected | SSH to test server |
 
+## E2E Verification Notes (2026-04-02)
+
+Verified on venus (Ubuntu, SSH from macOS). Issues found and resolved during testing:
+
+### Issues Found
+
+1. **Hook script had no curl** — Venus had an old placeholder `cc-clip-hook` from a previous install that contained no curl logic. The new hook template must be deployed via `cc-clip connect` or manual install.
+
+2. **curl had no timeout** — The hook template's curl command lacked `--connect-timeout` and `--max-time`. When the tunnel was down, hooks blocked for 2+ minutes, causing Claude Code's "running stop hooks" to stall. Fixed: `--connect-timeout 2 --max-time 5`.
+
+3. **Stale sshd RemoteForward** — Old SSH sessions leave `sshd` child processes holding port 18339 in `CLOSE_WAIT` state. New SSH connections' RemoteForward silently fails because the port is already bound. Fix: `sudo kill $(sudo lsof -ti :18339)` before reconnecting. This is the same pitfall documented in CLAUDE.md "Known Pitfalls". The `cc-clip connect` flow should add a remote port cleanup step.
+
+4. **Nonce not provisioned** — Plain `ssh venus` does not generate or register a notification nonce. Users must either use `cc-clip connect` (which handles this automatically) or manually generate and register a nonce. Consider auto-provisioning nonce during the notification setup step of `cc-clip connect`.
+
+5. **Daemon binary mismatch** — The running daemon was an old binary without the `/notify` route. After rebuilding, the daemon must be restarted. The `/notify` endpoint hung instead of returning 404, which was confusing.
+
+6. **User-Agent required for /register-nonce** — The `authMiddleware` requires `User-Agent: cc-clip/0.1`. Manual curl without this header gets 403, which is not obvious.
+
+### Verified Working
+
+| Test | Result |
+|------|--------|
+| Manual `echo ... \| cc-clip-hook` → local popup | PASS |
+| Claude Code Stop hook → local popup ("Claude stopped") | PASS |
+| Image paste Ctrl+V in Claude Code | PASS |
+| Image paste notification (v0.5.0 path) | PASS |
+| Dedup: 3x identical Stop in 12s → 1 popup | PASS |
+| DeliveryChain: cmux fail → macOS fallback | PASS |
+| Tunnel health: `curl /health` from venus | PASS |
+
+### Not Triggered (By Design)
+
+| Event | Why no notification |
+|-------|-------------------|
+| Claude waiting for user input | Not a hook event — normal interaction loop |
+| Claude using tools (Bash/Edit) | `PreToolUse` hook not installed in V1 |
+
 ## Relationship to Existing Notification System
 
 This design extends, not replaces, the v0.5.0 clipboard notification system:

--- a/docs/plans/2026-04-01-notification-bridge-design.md
+++ b/docs/plans/2026-04-01-notification-bridge-design.md
@@ -1,0 +1,543 @@
+# Notification Bridge Design
+
+**Date:** 2026-04-01
+**Status:** Design Complete, Pending Implementation
+**Version:** v0.6.0 (planned)
+**Prerequisite:** v0.5.0 (clipboard preview notification)
+
+## Problem
+
+When running Claude Code or Codex CLI on a remote server via SSH, all meaningful notification mechanisms are broken:
+
+| Scenario | What works | What breaks |
+|----------|-----------|-------------|
+| Local (no SSH) | Everything | - |
+| Direct SSH (no tmux) | BEL may pass through (no content) | Hook commands (execute on remote, no local notification tools); `TERM_PROGRAM` not forwarded so auto-detection fails; OSC 9/777 unreliable |
+| SSH + tmux | Nothing | All of the above + tmux swallows OSC sequences |
+
+**Root cause:** All existing notification solutions assume the AI tool runs on the same machine as the notification system:
+- **cmux:** Injects Claude Code hooks via wrapper script; hooks communicate via local Unix socket. Neither exists on the remote.
+- **Ghostty/iTerm2/Kitty:** Detect OSC 9/99/777 escape sequences in terminal output. SSH doesn't forward `TERM_PROGRAM`, and tmux swallows escape sequences.
+- **Claude Code hooks:** Execute shell commands on the remote machine. `terminal-notifier`, `osascript`, `cmux notify` don't exist there.
+- **Codex CLI notify:** Same problem as hooks; the configured command runs on the remote.
+
+**Opportunity:** cc-clip already maintains a reverse HTTP tunnel (SSH RemoteForward) from remote to local. Adding a `/notify` endpoint to the daemon creates an application-level notification bridge that naturally traverses SSH.
+
+## Positioning
+
+**cc-clip = Notification Transport Bridge, NOT Notification UI**
+
+cc-clip does not render notifications itself. It transports notification data from the remote through the SSH tunnel and delivers to the local system's native notification mechanisms.
+
+```
+cc-clip's role:
+  Remote hook/notify → [SSH tunnel] → Local daemon → Delivery adapter → Native notification system
+                                                       ↑
+                                            cmux / Ghostty / macOS / ...
+```
+
+Advantage: Users get the notification quality of their chosen terminal/tool, not a separate second-class experience.
+
+## Architecture
+
+```
++---------------- Remote Server ------------------+
+|                                                  |
+|  Claude Code              Codex CLI              |
+|      |                        |                  |
+|  Hook events             notify config           |
+|  (Stop/Notification)     (task complete)          |
+|      |                       |                   |
+|      |                       |                   |
+|      v                       v                   |
+|  cc-clip-hook.sh         cc-clip notify          |
+|  (stdin JSON -> curl)    (CLI -> curl)            |
+|      |                       |                   |
+|      +----------+------------+                   |
+|                 |                                 |
+|     HTTP POST /notify (127.0.0.1:18339)          |
+|         (via SSH RemoteForward tunnel)            |
+|                                                  |
++---------------------|----------------------------+
+                      | SSH tunnel
++---------------------v----------------------------+
+|               Local Mac                           |
+|                                                   |
+|  cc-clip daemon (127.0.0.1:18339)                |
+|      |                                            |
+|  POST /notify handler                             |
+|      +-- Parse payload (hook JSON or generic)     |
+|      +-- Classify notification type               |
+|      +-- Dedup / throttle (10-15s window)         |
+|      +-- Create NotifyEnvelope                    |
+|      +-- Route: critical → criticalCh (blocking)  |
+|      +--         normal → notifyCh (drop on full) |
+|              |                                    |
+|  RunNotifier goroutine                            |
+|      +-- DeliveryChain (try cmux → macOS)         |
+|      +-- Deliver notification                     |
+|                                                   |
+|  Result: native notification in user's tool       |
++---------------------------------------------------+
+```
+
+## V1 Scope
+
+### In scope
+- `POST /notify` endpoint on daemon
+- Dual payload format (Claude hook JSON passthrough + generic schema)
+- Notification classifier (extract type/title/body from hook JSON)
+- Delivery adapters: macOS Notification Center (fallback) + cmux
+- `cc-clip-hook.sh` script for remote Claude Code hook integration
+- `cc-clip notify` subcommand for generic CLI use
+- Auto-configuration of Codex `~/.codex/config.toml` during `connect` (not `--codex`-specific; see Design Note 1)
+- Dedup/throttle per source+type+title+body hash in 10-15s window
+- Priority channel for critical notifications (permission_prompt) — never dropped
+- Hook transport health: failure counter + log + health probe before default-on
+- Notification nonce: per-connect secret for hook auth, separate from clipboard token
+- Multi-host: host alias in notification title (e.g., `[venus] Claude Code`)
+- Default enabled, `--no-notify` to opt-out
+
+### Out of scope (V2+)
+- OSC sequence injection to terminal PTY (PTY discovery is complex)
+- Action buttons (Approve/Deny) with bidirectional communication
+- Web dashboard
+- Windows/Linux local delivery adapters
+- Auto-injection of Claude Code hook settings (V1 generates paste-ready config)
+
+## Notification Envelope Model
+
+The existing `NotifyEvent` is image-transfer specific. Rather than expanding it, introduce a unified envelope with kind-specific payloads:
+
+```go
+// internal/daemon/envelope.go
+
+type NotifyKind string
+
+const (
+    KindImageTransfer NotifyKind = "image_transfer"
+    KindToolAttention NotifyKind = "tool_attention"
+    KindGenericMessage NotifyKind = "generic_message"
+)
+
+type NotifyEnvelope struct {
+    Kind      NotifyKind
+    Source    string     // "clipboard" | "claude_hook" | "codex_notify" | "cli"
+    Host      string     // remote host alias, e.g. "venus"
+    Timestamp time.Time
+
+    // Kind-specific payload (exactly one is non-nil)
+    ImageTransfer  *ImageTransferPayload
+    ToolAttention  *ToolAttentionPayload
+    GenericMessage *GenericMessagePayload
+}
+
+type ImageTransferPayload struct {
+    SessionID   string
+    Seq         int
+    Fingerprint string
+    ImageData   []byte
+    Format      string
+    Width       int
+    Height      int
+    DuplicateOf int
+}
+
+type ToolAttentionPayload struct {
+    SessionID  string
+    HookType   string   // "stop" | "notification"
+    StopReason string   // "stop_at_end_of_turn", etc.
+    NotifType  string   // "permission_prompt" | "idle_prompt" | etc.
+    ToolName   string
+    ToolInput  string   // truncated
+    Message    string   // last_assistant_message (truncated)
+}
+
+type GenericMessagePayload struct {
+    Title   string
+    Body    string
+    Urgency int // 0=low, 1=normal, 2=critical
+}
+```
+
+### Migration path
+
+The existing `NotifyEvent` (image-transfer specific) continues to work for `/clipboard/image`. The new `POST /notify` endpoint produces `ToolAttention` or `GenericMessage` envelopes. Both converge in the `RunNotifier` goroutine, but via **two channels**:
+
+```go
+notifyCh     chan NotifyEnvelope // buffered, cap=8, non-critical events (drop on full)
+criticalCh   chan NotifyEnvelope // buffered, cap=4, critical events (blocking enqueue)
+```
+
+`RunNotifier` selects from both, with `criticalCh` checked first. This ensures `permission_prompt` and other urgency=critical events are never dropped even when non-critical notifications saturate the queue.
+
+## Components
+
+### 1. `POST /notify` Endpoint (`internal/daemon/server.go`)
+
+```
+POST /notify HTTP/1.1
+Authorization: Bearer <notify-nonce>
+Content-Type: application/json OR application/x-claude-hook
+
+{...payload...}
+```
+
+**Authentication:** Uses a dedicated **notification nonce** (not the clipboard bearer token). Generated per `cc-clip connect`, written to `~/.cache/cc-clip/notify.nonce` on remote. This narrows the trust boundary: clipboard token holders cannot forge notifications, and notification nonce holders cannot read clipboard data. The nonce is a separate 32-byte random hex string with the same file permissions (chmod 600).
+
+**Dual format detection:**
+
+| Content-Type | Behavior |
+|-------------|----------|
+| `application/x-claude-hook` | Parse as Claude Code hook JSON. Daemon classifies internally (extracts type, title, body from hook fields). |
+| `application/json` (default) | Parse as generic schema: `{"title": "...", "body": "...", "urgency": 0-2, "host": "..."}` |
+
+**Response:** `204 No Content` on success, `400` on parse error, `401` on bad nonce.
+
+**Visual distinction:** Notifications from `application/x-claude-hook` (verified hook source) show tool name and session context. Notifications from `application/json` (generic) are prefixed with `[unverified]` in the subtitle to distinguish them from authenticated Claude hook events. This prevents spoofing of "Tool approval needed" via generic endpoint.
+
+### 2. Notification Classifier (`internal/daemon/classifier.go`)
+
+Translates Claude Code hook JSON into structured notification data. Similar to cmux's `classifyClaudeNotification()`.
+
+```go
+func ClassifyHookPayload(hookType string, raw map[string]any) *ToolAttentionPayload
+```
+
+**Classification rules:**
+
+| Hook type | Input field | Notification title | Urgency |
+|-----------|------------|-------------------|---------|
+| `notification` + `permission_prompt` | `title`, `body` | "Tool approval needed" | critical |
+| `notification` + `idle_prompt` | `title`, `body` | "Claude is idle" | normal |
+| `stop` + `stop_at_end_of_turn` | `last_assistant_message` | "Claude finished" | low |
+| `stop` + other | `last_assistant_message` | "Claude stopped" | normal |
+
+**Removed:** `pre_tool_use` was previously listed as a dedup-clear trigger, but V1 hook configuration only installs `Stop` and `Notification` hooks. Dedup logic must not depend on events that aren't wired. If PreToolUse is added in V2, dedup-clear can be revisited.
+
+**`permission_prompt` is never suppressed by dedup/throttle AND routes to `criticalCh`** (blocking enqueue, never dropped).
+
+### 3. Delivery Adapters (`internal/daemon/deliver_*.go`)
+
+```go
+// internal/daemon/deliver.go
+type Deliverer interface {
+    Deliver(ctx context.Context, env NotifyEnvelope) error
+    Name() string
+}
+
+// DeliveryChain tries adapters in order; falls through on error.
+type DeliveryChain struct {
+    adapters []Deliverer
+}
+
+func (c *DeliveryChain) Deliver(ctx context.Context, env NotifyEnvelope) error {
+    for _, a := range c.adapters {
+        if err := a.Deliver(ctx, env); err == nil {
+            return nil // first success wins
+        }
+        // log failure, try next adapter
+    }
+    return fmt.Errorf("all delivery adapters failed")
+}
+
+func BuildDeliveryChain() *DeliveryChain
+```
+
+**Chain delivery (not single-select):** Each adapter is tried in priority order. If cmux is detected but fails at runtime (e.g., no active surface, app not running), delivery falls through to macOS. This prevents "cmux binary exists but can't deliver" from swallowing the fallback.
+
+| Priority | Adapter | Detection | Delivery mechanism | Fallthrough on |
+|----------|---------|-----------|-------------------|----------------|
+| 1 | cmux | `exec.LookPath("cmux")` at startup | `cmux notify --title ... --body ...` | non-zero exit or timeout |
+| 2 | macOS | always available on darwin | terminal-notifier / osascript fallback | (terminal, never fails) |
+
+**V2 planned:**
+
+| Priority | Adapter | Detection | Delivery mechanism |
+|----------|---------|-----------|-------------------|
+| 0 (highest) | Terminal OSC | Find current terminal PTY | Write OSC 9/777 to PTY fd |
+
+### 4. Dedup / Throttle (`internal/daemon/dedup.go`)
+
+```go
+type DedupKey struct {
+    Source string
+    Type   string
+    Title  string
+    BodyHash [16]byte // MD5 of body, for fast comparison
+}
+
+type DedupEntry struct {
+    Key       DedupKey
+    FirstSeen time.Time
+    Count     int
+}
+```
+
+**Rules:**
+- Window: 10-15 seconds
+- Same `DedupKey` within window: suppress, increment count
+- Exception: `permission_prompt` notifications are **never** deduplicated
+- Merged notification shows count: "Claude finished (x3)"
+
+### 5. Remote: `cc-clip-hook.sh` (`internal/shim/hook_template.go`)
+
+Bash script installed to `~/.local/bin/cc-clip-hook` on the remote. Claude Code hooks pipe JSON to stdin.
+
+```bash
+#!/usr/bin/env bash
+# cc-clip-hook — Claude Code hook bridge
+# Reads hook JSON from stdin, forwards to cc-clip daemon via tunnel
+
+set -euo pipefail
+
+_CC_CLIP_PORT="${CC_CLIP_PORT:-18339}"
+_CC_CLIP_NONCE_FILE="${HOME}/.cache/cc-clip/notify.nonce"
+_CC_CLIP_HOST_ALIAS="${CC_CLIP_HOST_ALIAS:-$(hostname -s)}"
+_CC_CLIP_HEALTH_FILE="${HOME}/.cache/cc-clip/notify-health.log"
+
+# Read notification nonce (dedicated, not clipboard token)
+_nonce=""
+if [ -f "$_CC_CLIP_NONCE_FILE" ]; then
+    _nonce=$(head -1 "$_CC_CLIP_NONCE_FILE")
+fi
+
+# Read stdin (hook JSON)
+_payload=$(cat)
+
+# Inject host alias
+_payload=$(echo "$_payload" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
+json.dump(d, sys.stdout)
+" 2>/dev/null || echo "$_payload")
+
+# Forward to daemon (with health tracking)
+_http_code=$(curl -sf -o /dev/null -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $_nonce" \
+    -H "Content-Type: application/x-claude-hook" \
+    -H "User-Agent: cc-clip-hook/0.1" \
+    -d "$_payload" \
+    "http://127.0.0.1:${_CC_CLIP_PORT}/notify" \
+    2>/dev/null) || _http_code="000"
+
+# Health tracking: log failures (visible via cc-clip status)
+if [ "$_http_code" != "204" ] && [ "$_http_code" != "200" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) FAIL http=$_http_code" >> "$_CC_CLIP_HEALTH_FILE" 2>/dev/null || true
+fi
+
+# Always exit 0 — hook failures must not block Claude Code
+exit 0
+```
+
+**Health signal:** Failed deliveries are appended to `~/.cache/cc-clip/notify-health.log` on the remote. `cc-clip connect` can check this file and warn the user if recent failures are detected. This prevents the "silent disappearance" problem identified in adversarial review.
+
+### 6. Remote: `cc-clip notify` Subcommand (`cmd/cc-clip/main.go`)
+
+```bash
+# Generic notification (explicit body)
+cc-clip notify --title "Build complete" --body "All tests passed" --urgency 1
+
+# Codex integration (reads JSON from first positional argument)
+cc-clip notify --from-codex "$1"
+```
+
+**`--from-codex` mode:** Codex passes a JSON string as `$1` containing `{"last-assistant-message": "..."}`. The `--from-codex` flag parses this JSON, extracts `last-assistant-message` as body, sets title to "Codex", and POSTs to `/notify`. This is the single, documented Codex contract.
+
+Reads notification nonce from `~/.cache/cc-clip/notify.nonce`, POSTs to `/notify` with generic JSON schema.
+
+### 7. Claude Code Hook Configuration
+
+`cc-clip connect` generates a paste-ready configuration snippet and prints it:
+
+```
+=== Claude Code Hook Setup ===
+Add the following to your Claude Code settings on the remote:
+
+claude config set --global hooks.Stop '[{"type":"command","command":"cc-clip-hook"}]'
+claude config set --global hooks.Notification '[{"type":"command","command":"cc-clip-hook"}]'
+
+Or add to ~/.claude/settings.json:
+{
+  "hooks": {
+    "Stop": [{"type": "command", "command": "cc-clip-hook"}],
+    "Notification": [{"type": "command", "command": "cc-clip-hook"}]
+  }
+}
+```
+
+V1 does NOT auto-modify Claude Code settings (user-controlled config, should not be silently changed).
+
+### 8. Codex Auto-Configuration
+
+**Design Note 1:** Codex notify injection is part of the regular `connect` flow, NOT exclusive to `--codex`. The `--codex` flag has existing semantics: it enables Xvfb/x11-bridge for clipboard support. A user who doesn't need X11 clipboard bridging but does use Codex should still get notifications. Codex config injection triggers when: (a) `~/.codex/` directory exists on remote AND (b) `--no-notify` is not set.
+
+`cc-clip connect <host>` automatically writes to remote `~/.codex/config.toml` (if Codex is detected):
+
+```toml
+# cc-clip-managed — do not edit this line
+notify = ["cc-clip", "notify", "--from-codex", "$1"]
+```
+
+Uses `# cc-clip-managed` guard (same pattern as PATH/DISPLAY markers). Detection: `test -d ~/.codex` on remote.
+
+### 9. Connect Flow Changes
+
+`cc-clip connect <host>` gains:
+- **Step N: Generate notification nonce** — Create dedicated 32-byte random hex, write to remote `~/.cache/cc-clip/notify.nonce` (chmod 600), register on local daemon
+- **Step N+1: Install hook script** — Upload `cc-clip-hook` to `~/.local/bin/`, chmod +x
+- **Step N+2: Print Claude Code hook config** — Generate and display paste-ready snippet
+- **Step N+3: Auto-configure Codex** — If `~/.codex/` exists on remote, inject notify setting
+- **Step N+4: Health probe** — Send a test `POST /notify` with `{"title":"cc-clip","body":"notification bridge connected"}` to verify end-to-end delivery before declaring success
+- **`--no-notify` flag** — Skip all notification-related steps (N through N+4)
+
+Default: notification setup is enabled.
+
+## Notification Examples
+
+### Claude Code: Permission prompt
+```
++-------------------------------------------+
+| [venus] Claude Code            now        |
+| Tool approval needed                      |
+| Claude wants to Edit cmd/main.go          |
++-------------------------------------------+
+```
+
+### Claude Code: Task complete
+```
++-------------------------------------------+
+| [venus] Claude Code            now        |
+| Claude finished                           |
+| I've implemented the notification bridge  |
++-------------------------------------------+
+```
+
+### Codex: Task complete
+```
++-------------------------------------------+
+| [venus] Codex                  now        |
+| Task complete                             |
+| Added error handling to fetch module      |
++-------------------------------------------+
+```
+
+### Image transfer (existing, migrated)
+```
++-------------------------------------------+
+| cc-clip #3                     now        |
+| a1b2c3d4 . 1920x1080 . PNG               |
+| Image transferred                    [img]|
++-------------------------------------------+
+```
+
+## File Change List
+
+| File | Type | Description |
+|------|------|-------------|
+| `internal/daemon/envelope.go` | New | NotifyEnvelope, NotifyKind, payload types |
+| `internal/daemon/classifier.go` | New | ClassifyHookPayload — hook JSON to structured data |
+| `internal/daemon/classifier_test.go` | New | Classification rules tests |
+| `internal/daemon/dedup.go` | New | DedupKey, DedupEntry, window-based dedup |
+| `internal/daemon/dedup_test.go` | New | Dedup window, permission_prompt exception |
+| `internal/daemon/deliver.go` | New | Deliverer interface, DeliveryChain, BuildDeliveryChain |
+| `internal/daemon/deliver_darwin.go` | New | macOS adapter (reuses terminal-notifier/osascript) |
+| `internal/daemon/deliver_cmux.go` | New | cmux adapter (`cmux notify` command) |
+| `internal/daemon/deliver_other.go` | New | No-op for non-darwin |
+| `internal/daemon/deliver_test.go` | New | Adapter selection, delivery tests |
+| `internal/daemon/server.go` | Modify | Add POST /notify handler, migrate notifyCh to NotifyEnvelope |
+| `internal/daemon/notifier.go` | Modify | Adapt NotifyEvent → ImageTransferPayload bridge |
+| `internal/daemon/notify_darwin.go` | Modify | Implement Deliverer for image_transfer kind |
+| `internal/shim/hook_template.go` | New | cc-clip-hook bash script template |
+| `internal/shim/hook_template_test.go` | New | Template rendering tests |
+| `internal/token/nonce.go` | New | Notification nonce generation, validation, file I/O |
+| `internal/token/nonce_test.go` | New | Nonce lifecycle tests |
+| `cmd/cc-clip/main.go` | Modify | Add `notify` subcommand (with `--from-codex`), connect nonce + hook install + health probe, `--no-notify` flag |
+
+## Implementation Order
+
+```
+Phase 1: Envelope model + classifier (pure logic)
+  (1) internal/daemon/envelope.go
+  (2) internal/daemon/classifier.go + classifier_test.go
+
+Phase 2: Dedup engine (pure logic, no PreToolUse dependency)
+  (3) internal/daemon/dedup.go + dedup_test.go
+
+Phase 3: Notification nonce (trust boundary)
+  (4) internal/token/nonce.go + nonce_test.go
+
+Phase 4: Delivery chain
+  (5) internal/daemon/deliver.go (interface + DeliveryChain)
+  (6) internal/daemon/deliver_darwin.go (macOS, reuse existing notify_darwin logic)
+  (7) internal/daemon/deliver_cmux.go (cmux adapter, fallthrough on failure)
+  (8) internal/daemon/deliver_other.go (no-op)
+  (9) internal/daemon/deliver_test.go (chain fallthrough tests)
+
+Phase 5: Server integration (dual channel)
+  (10) internal/daemon/server.go (POST /notify + notifyCh/criticalCh split + nonce auth)
+  (11) internal/daemon/notifier.go (bridge NotifyEvent → NotifyEnvelope)
+
+Phase 6: Remote components
+  (12) internal/shim/hook_template.go + test (nonce-based auth + health logging)
+  (13) cmd/cc-clip/main.go (notify subcommand with --from-codex + connect steps + --no-notify)
+
+Phase 7: Codex auto-config (in regular connect, not --codex only)
+  (14) Codex config.toml writer (detect ~/.codex/, inject with guard)
+
+Phase 8: End-to-end verification
+  (15) Health probe: connect sends test notification, verifies delivery
+  (16) Local serve → connect → remote Claude Code hook → local notification
+  (17) Local serve → connect → remote Codex notify → local notification
+  (18) Chain fallthrough: cmux fails → macOS delivers
+  (19) Critical channel: permission_prompt survives queue saturation
+```
+
+## Test Strategy
+
+| Level | Coverage | Method |
+|-------|----------|--------|
+| Unit | Classifier: all hook types → correct title/urgency | Table-driven Go tests |
+| Unit | Dedup: window merge, permission_prompt exception (no PreToolUse dep) | Time-controlled tests |
+| Unit | DeliveryChain: cmux fail → macOS fallthrough | Mock adapters |
+| Unit | Nonce: generation, validation, file I/O | Temp dir isolation |
+| Unit | Hook template: nonce auth + health logging | String matching |
+| Unit | Dual channel: critical enqueue blocks, non-critical drops | Channel capacity tests |
+| Unit | `--from-codex` JSON parsing | Table-driven with valid/malformed inputs |
+| Integration | POST /notify with nonce auth → notifyCh → mock deliverer | httptest |
+| Integration | POST /notify with clipboard token → 401 rejected | httptest |
+| Integration | Dual format: application/x-claude-hook vs application/json | httptest |
+| Integration | Visual distinction: generic JSON gets [unverified] prefix | httptest + mock deliverer |
+| Integration | Critical permission_prompt survives full notifyCh | Channel saturation test |
+| Manual | cmux adapter: `cmux notify` shows in-app | Local cmux + curl |
+| Manual | macOS adapter: terminal-notifier popup | Local daemon + curl |
+| Manual | Health probe: connect displays test notification on success | Local connect |
+| E2E | Full: SSH connect → remote Claude Code hook → local notification | SSH to test server |
+| E2E | Full: SSH connect → remote Codex notify (--from-codex) → local notification | SSH to test server |
+| E2E | Chain fallthrough: kill cmux → macOS fallback fires | Manual |
+| E2E | Codex auto-detect: connect to host with ~/.codex/ → config injected | SSH to test server |
+
+## Relationship to Existing Notification System
+
+This design extends, not replaces, the v0.5.0 clipboard notification system:
+
+| Aspect | v0.5.0 (clipboard) | v0.6.0 (bridge) |
+|--------|--------------------|--------------------|
+| Trigger | Image transfer via /clipboard/image | Hook event / CLI command via POST /notify |
+| Data source | Daemon observes its own image serving | Remote tool pushes event to daemon |
+| Direction | Local observation | Remote → local transport |
+| Envelope kind | `image_transfer` | `tool_attention`, `generic_message` |
+| Shared infra | notifyCh, RunNotifier, DarwinNotifier | Same channel, same goroutine, new adapters |
+
+The `NotifyEnvelope` unifies both paths. `RunNotifier` consumes envelopes and dispatches to the appropriate `Deliverer` based on kind and available adapters.
+
+## Future Roadmap
+
+| Version | Feature | Notes |
+|---------|---------|-------|
+| v0.6.0 | Notification bridge V1 (this design) | macOS + cmux delivery, display-only |
+| v0.6.1 | OSC delivery adapter | Write OSC 9/777 to detected terminal PTY |
+| v0.7.0 | Action buttons | Bidirectional: Approve/Deny from notification → remote Claude Code |
+| v0.7.1 | Web dashboard | Local web UI for notification history and action management |
+| v0.8.0 | Windows/Linux local delivery | Toast notifications (Windows), libnotify (Linux) |

--- a/internal/daemon/classifier.go
+++ b/internal/daemon/classifier.go
@@ -1,0 +1,94 @@
+package daemon
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ClassifyHookPayload translates a Claude Code hook JSON payload into a
+// structured NotifyEnvelope. hookType is the hook category ("notification",
+// "stop", etc.) and raw is the decoded JSON body.
+func ClassifyHookPayload(hookType string, raw map[string]any) *NotifyEnvelope {
+	host, _ := raw["_cc_clip_host"].(string)
+	env := &NotifyEnvelope{
+		Kind:      KindToolAttention,
+		Source:    "claude_hook",
+		Host:      host,
+		Timestamp: time.Now().UTC(),
+		ToolAttention: &ToolAttentionPayload{
+			HookType: hookType,
+			Verified: true,
+		},
+		GenericMessage: &GenericMessagePayload{Verified: true},
+	}
+
+	switch hookType {
+	case "notification":
+		notifType, _ := raw["type"].(string)
+		title, _ := raw["title"].(string)
+		body, _ := raw["body"].(string)
+		env.ToolAttention.NotifType = notifType
+		env.GenericMessage.Body = body
+		switch notifType {
+		case "permission_prompt":
+			env.GenericMessage.Title = "Tool approval needed"
+			env.GenericMessage.Urgency = 2
+		case "idle_prompt":
+			env.GenericMessage.Title = "Claude is idle"
+			env.GenericMessage.Urgency = 1
+		default:
+			env.GenericMessage.Title = title
+			env.GenericMessage.Urgency = 1
+		}
+	case "stop":
+		reason, _ := raw["stop_hook_reason"].(string)
+		msg, _ := raw["last_assistant_message"].(string)
+		env.ToolAttention.StopReason = reason
+		env.ToolAttention.Message = truncate(msg, 280)
+		env.GenericMessage.Body = truncate(msg, 280)
+		if reason == "stop_at_end_of_turn" {
+			env.GenericMessage.Title = "Claude finished"
+			env.GenericMessage.Urgency = 0
+		} else {
+			env.GenericMessage.Title = "Claude stopped"
+			env.GenericMessage.Urgency = 1
+		}
+	default:
+		env.Kind = KindGenericMessage
+		env.Source = "claude_hook"
+		env.GenericMessage.Title = fmt.Sprintf("Claude hook: %s", hookType)
+		env.GenericMessage.Body = truncate(stringifyMap(raw), 280)
+		env.GenericMessage.Urgency = 1
+		env.ToolAttention = nil
+	}
+
+	return env
+}
+
+// truncate trims whitespace and limits s to at most limit bytes,
+// appending an ellipsis if truncation occurs.
+func truncate(s string, limit int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= limit {
+		return s
+	}
+	return s[:limit-1] + "\u2026"
+}
+
+// stringifyMap produces a deterministic "key=value, key=value" string from
+// a map, sorted by key. Used for the default classifier case.
+func stringifyMap(m map[string]any) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(m))
+	for _, k := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", k, m[k]))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/daemon/classifier_test.go
+++ b/internal/daemon/classifier_test.go
@@ -1,0 +1,269 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestClassifyHookPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		hookType  string
+		raw       map[string]any
+		wantTitle string
+		wantUrg   int
+		wantType  string
+	}{
+		{
+			name:     "permission prompt is critical",
+			hookType: "notification",
+			raw: map[string]any{
+				"type":  "permission_prompt",
+				"title": "Approve tool",
+				"body":  "Claude wants to Edit cmd/main.go",
+			},
+			wantTitle: "Tool approval needed",
+			wantUrg:   2,
+			wantType:  "permission_prompt",
+		},
+		{
+			name:     "stop at end of turn is low urgency",
+			hookType: "stop",
+			raw: map[string]any{
+				"stop_hook_reason":       "stop_at_end_of_turn",
+				"last_assistant_message": "Done implementing bridge",
+			},
+			wantTitle: "Claude finished",
+			wantUrg:   0,
+			wantType:  "stop_at_end_of_turn",
+		},
+		{
+			name:     "idle prompt is medium urgency",
+			hookType: "notification",
+			raw: map[string]any{
+				"type":  "idle_prompt",
+				"title": "Waiting for input",
+				"body":  "Claude is waiting",
+			},
+			wantTitle: "Claude is idle",
+			wantUrg:   1,
+			wantType:  "idle_prompt",
+		},
+		{
+			name:     "stop with non-end-of-turn reason",
+			hookType: "stop",
+			raw: map[string]any{
+				"stop_hook_reason":       "interrupted",
+				"last_assistant_message": "Was working on...",
+			},
+			wantTitle: "Claude stopped",
+			wantUrg:   1,
+			wantType:  "interrupted",
+		},
+		{
+			name:     "unknown hook type falls through to default",
+			hookType: "custom_event",
+			raw: map[string]any{
+				"foo": "bar",
+				"baz": "qux",
+			},
+			wantTitle: "Claude hook: custom_event",
+			wantUrg:   1,
+			wantType:  "custom_event",
+		},
+		{
+			name:     "notification with unknown type gets title from raw",
+			hookType: "notification",
+			raw: map[string]any{
+				"type":  "progress_update",
+				"title": "Step 3 of 5",
+				"body":  "Running tests...",
+			},
+			wantTitle: "Step 3 of 5",
+			wantUrg:   1,
+			wantType:  "progress_update",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := ClassifyHookPayload(tt.hookType, tt.raw)
+			if env == nil || env.GenericMessage == nil {
+				t.Fatalf("expected generic message envelope, got %#v", env)
+			}
+			if env.GenericMessage.Title != tt.wantTitle {
+				t.Fatalf("expected title %q, got %q", tt.wantTitle, env.GenericMessage.Title)
+			}
+			if env.GenericMessage.Urgency != tt.wantUrg {
+				t.Fatalf("expected urgency %d, got %d", tt.wantUrg, env.GenericMessage.Urgency)
+			}
+		})
+	}
+}
+
+func TestClassifyHookPayloadKindAndSource(t *testing.T) {
+	t.Run("notification sets KindToolAttention", func(t *testing.T) {
+		env := ClassifyHookPayload("notification", map[string]any{
+			"type": "permission_prompt",
+			"body": "approve edit",
+		})
+		if env.Kind != KindToolAttention {
+			t.Fatalf("expected kind %q, got %q", KindToolAttention, env.Kind)
+		}
+		if env.Source != "claude_hook" {
+			t.Fatalf("expected source claude_hook, got %q", env.Source)
+		}
+		if env.ToolAttention == nil {
+			t.Fatal("expected non-nil ToolAttention for notification hook")
+		}
+		if !env.ToolAttention.Verified {
+			t.Fatal("expected Verified=true")
+		}
+	})
+
+	t.Run("stop sets KindToolAttention", func(t *testing.T) {
+		env := ClassifyHookPayload("stop", map[string]any{
+			"stop_hook_reason": "stop_at_end_of_turn",
+		})
+		if env.Kind != KindToolAttention {
+			t.Fatalf("expected kind %q, got %q", KindToolAttention, env.Kind)
+		}
+		if env.ToolAttention == nil || env.ToolAttention.StopReason != "stop_at_end_of_turn" {
+			t.Fatalf("expected stop reason, got %#v", env.ToolAttention)
+		}
+	})
+
+	t.Run("unknown hookType sets KindGenericMessage and nil ToolAttention", func(t *testing.T) {
+		env := ClassifyHookPayload("something_else", map[string]any{
+			"key": "value",
+		})
+		if env.Kind != KindGenericMessage {
+			t.Fatalf("expected kind %q, got %q", KindGenericMessage, env.Kind)
+		}
+		if env.ToolAttention != nil {
+			t.Fatal("expected nil ToolAttention for unknown hookType")
+		}
+	})
+}
+
+func TestClassifyHookPayloadHostExtraction(t *testing.T) {
+	env := ClassifyHookPayload("notification", map[string]any{
+		"type":            "permission_prompt",
+		"body":            "approve",
+		"_cc_clip_host":   "devbox-01",
+	})
+	if env.Host != "devbox-01" {
+		t.Fatalf("expected host devbox-01, got %q", env.Host)
+	}
+}
+
+func TestClassifyHookPayloadTruncatesLongMessages(t *testing.T) {
+	longMsg := ""
+	for i := 0; i < 300; i++ {
+		longMsg += "x"
+	}
+	env := ClassifyHookPayload("stop", map[string]any{
+		"stop_hook_reason":       "stop_at_end_of_turn",
+		"last_assistant_message": longMsg,
+	})
+	// truncate(s, 280) yields at most 279 ASCII bytes + multi-byte ellipsis.
+	// The result must be strictly shorter than the 300-byte input.
+	if len(env.GenericMessage.Body) >= 300 {
+		t.Fatalf("expected body truncated below 300 bytes, got len=%d", len(env.GenericMessage.Body))
+	}
+	if len(env.GenericMessage.Body) == 0 {
+		t.Fatal("expected non-empty body after truncation")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		limit int
+		want  string
+	}{
+		{"short string", "hello", 10, "hello"},
+		{"exact limit", "hello", 5, "hello"},
+		{"over limit", "hello world", 6, "hello\u2026"},
+		{"empty string", "", 10, ""},
+		{"whitespace trimmed", "  hello  ", 10, "hello"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncate(tt.input, tt.limit)
+			if got != tt.want {
+				t.Fatalf("truncate(%q, %d) = %q, want %q", tt.input, tt.limit, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringifyMap(t *testing.T) {
+	tests := []struct {
+		name string
+		m    map[string]any
+		want string
+	}{
+		{
+			name: "single key",
+			m:    map[string]any{"foo": "bar"},
+			want: "foo=bar",
+		},
+		{
+			name: "empty map",
+			m:    map[string]any{},
+			want: "",
+		},
+		{
+			name: "non-string value",
+			m:    map[string]any{"count": 42},
+			want: "count=42",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringifyMap(tt.m)
+			if tt.name == "single key" || tt.name == "empty map" || tt.name == "non-string value" {
+				// For single-key maps, exact match is deterministic
+				if got != tt.want {
+					t.Fatalf("stringifyMap(%v) = %q, want %q", tt.m, got, tt.want)
+				}
+			}
+		})
+	}
+
+	// Multi-key: just check all pairs are present (map iteration order is non-deterministic)
+	t.Run("multi key contains all pairs", func(t *testing.T) {
+		m := map[string]any{"a": "1", "b": "2"}
+		got := stringifyMap(m)
+		if len(got) == 0 {
+			t.Fatal("expected non-empty result")
+		}
+		for _, pair := range []string{"a=1", "b=2"} {
+			found := false
+			for _, seg := range splitOnCommaSpace(got) {
+				if seg == pair {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("expected %q in %q", pair, got)
+			}
+		}
+	})
+}
+
+// splitOnCommaSpace splits on ", " to check stringifyMap output pairs.
+func splitOnCommaSpace(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == ',' && s[i+1] == ' ' {
+			parts = append(parts, s[start:i])
+			start = i + 2
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}

--- a/internal/daemon/dedup.go
+++ b/internal/daemon/dedup.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"crypto/md5"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// DedupKey identifies a notification for deduplication purposes.
+type DedupKey struct {
+	Source   string
+	Type     string
+	Title    string
+	BodyHash [16]byte
+}
+
+// DedupEntry tracks when a notification was last seen and how many
+// times it has repeated within the dedup window.
+type DedupEntry struct {
+	SeenAt time.Time
+	Count  int
+}
+
+// Deduper suppresses repeated notifications within a configurable time
+// window. Critical notifications (Urgency == 2) are never suppressed.
+type Deduper struct {
+	mu     sync.Mutex
+	window time.Duration
+	items  map[DedupKey]DedupEntry
+}
+
+// NewDeduper creates a Deduper with the given suppression window.
+func NewDeduper(window time.Duration) *Deduper {
+	return &Deduper{window: window, items: make(map[DedupKey]DedupEntry)}
+}
+
+// AllowAt checks whether env should be delivered at the given time.
+// Returns (true, nil) if the notification is allowed through.
+// Returns (false, &merged) if the notification is suppressed, where
+// merged carries the updated DedupCount.
+func (d *Deduper) AllowAt(env NotifyEnvelope, now time.Time) (bool, *NotifyEnvelope) {
+	if isAlwaysCritical(env) {
+		return true, nil
+	}
+	msg := env.GenericMessage
+	if msg == nil {
+		return true, nil
+	}
+
+	key := DedupKey{
+		Source:   env.Source,
+		Type:     dedupType(env),
+		Title:    msg.Title,
+		BodyHash: md5.Sum([]byte(msg.Body)),
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	entry, ok := d.items[key]
+	if !ok || now.Sub(entry.SeenAt) > d.window {
+		d.items[key] = DedupEntry{SeenAt: now, Count: 1}
+		return true, nil
+	}
+
+	entry.Count++
+	entry.SeenAt = now
+	d.items[key] = entry
+
+	merged := env
+	clone := *msg
+	clone.DedupCount = entry.Count
+	merged.GenericMessage = &clone
+	return false, &merged
+}
+
+// isAlwaysCritical returns true for notifications that must never be
+// suppressed by dedup (e.g., permission prompts).
+func isAlwaysCritical(env NotifyEnvelope) bool {
+	return env.GenericMessage != nil && env.GenericMessage.Urgency == 2
+}
+
+// dedupType extracts a notification subtype string used as part of the
+// dedup key. For tool attention events it combines hookType and the
+// relevant subtype; otherwise it falls back to the envelope Kind.
+func dedupType(env NotifyEnvelope) string {
+	if env.ToolAttention != nil {
+		switch env.ToolAttention.HookType {
+		case "notification":
+			return fmt.Sprintf("notification:%s", env.ToolAttention.NotifType)
+		case "stop":
+			return fmt.Sprintf("stop:%s", env.ToolAttention.StopReason)
+		}
+	}
+	return string(env.Kind)
+}

--- a/internal/daemon/dedup_test.go
+++ b/internal/daemon/dedup_test.go
@@ -1,0 +1,272 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeduperSuppressesRepeatedMessagesWithinWindow(t *testing.T) {
+	now := time.Unix(1000, 0)
+	d := NewDeduper(15 * time.Second)
+
+	env := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Claude finished",
+			Body:    "Done",
+			Urgency: 0,
+		},
+	}
+
+	allowed, merged := d.AllowAt(env, now)
+	if !allowed || merged != nil {
+		t.Fatalf("first event should pass")
+	}
+
+	allowed, merged = d.AllowAt(env, now.Add(5*time.Second))
+	if allowed || merged == nil || merged.GenericMessage.DedupCount != 2 {
+		t.Fatalf("second event should merge, got allowed=%v merged=%#v", allowed, merged)
+	}
+}
+
+func TestDeduperNeverSuppressesCriticalPermissionPrompt(t *testing.T) {
+	now := time.Unix(1000, 0)
+	d := NewDeduper(15 * time.Second)
+	env := NotifyEnvelope{
+		Kind:   KindToolAttention,
+		Source: "claude_hook",
+		ToolAttention: &ToolAttentionPayload{
+			HookType:  "notification",
+			NotifType: "permission_prompt",
+			Verified:  true,
+		},
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Tool approval needed",
+			Body:    "Claude wants to Edit file",
+			Urgency: 2,
+		},
+	}
+
+	if allowed, _ := d.AllowAt(env, now); !allowed {
+		t.Fatal("critical prompt should pass")
+	}
+	if allowed, _ := d.AllowAt(env, now.Add(2*time.Second)); !allowed {
+		t.Fatal("critical prompt should not be deduped")
+	}
+}
+
+func TestDeduperAllowsAfterWindowExpires(t *testing.T) {
+	d := NewDeduper(10 * time.Second)
+	now := time.Unix(1000, 0)
+
+	env := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Claude finished",
+			Body:    "Done",
+			Urgency: 0,
+		},
+	}
+
+	allowed, _ := d.AllowAt(env, now)
+	if !allowed {
+		t.Fatal("first event should pass")
+	}
+
+	// Within window: should suppress
+	allowed, merged := d.AllowAt(env, now.Add(5*time.Second))
+	if allowed {
+		t.Fatal("within window should suppress")
+	}
+	if merged == nil || merged.GenericMessage.DedupCount != 2 {
+		t.Fatalf("expected dedup count 2, got %#v", merged)
+	}
+
+	// After window: should allow again (must exceed last-seen + window;
+	// last-seen was at now+5s, window is 10s, so now+16s is past the boundary)
+	allowed, merged = d.AllowAt(env, now.Add(16*time.Second))
+	if !allowed || merged != nil {
+		t.Fatal("after window expires, event should pass as new")
+	}
+}
+
+func TestDeduperDifferentMessagesNotMerged(t *testing.T) {
+	d := NewDeduper(15 * time.Second)
+	now := time.Unix(1000, 0)
+
+	env1 := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Claude finished",
+			Body:    "Task A done",
+			Urgency: 0,
+		},
+	}
+	env2 := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Claude finished",
+			Body:    "Task B done",
+			Urgency: 0,
+		},
+	}
+
+	allowed1, _ := d.AllowAt(env1, now)
+	allowed2, _ := d.AllowAt(env2, now.Add(1*time.Second))
+	if !allowed1 || !allowed2 {
+		t.Fatal("different bodies should not be deduped against each other")
+	}
+}
+
+func TestDeduperNilGenericMessagePassesThrough(t *testing.T) {
+	d := NewDeduper(15 * time.Second)
+	now := time.Unix(1000, 0)
+
+	env := NotifyEnvelope{
+		Kind:   KindImageTransfer,
+		Source: "clipboard",
+		ImageTransfer: &ImageTransferPayload{
+			SessionID: "abc",
+			Seq:       1,
+			Format:    "png",
+		},
+	}
+
+	allowed, merged := d.AllowAt(env, now)
+	if !allowed || merged != nil {
+		t.Fatal("envelope without GenericMessage should always pass")
+	}
+
+	// Second identical should also pass (no GenericMessage to dedup on)
+	allowed, merged = d.AllowAt(env, now.Add(1*time.Second))
+	if !allowed || merged != nil {
+		t.Fatal("envelope without GenericMessage should always pass, even repeated")
+	}
+}
+
+func TestDeduperCountIncrementsCorrectly(t *testing.T) {
+	d := NewDeduper(30 * time.Second)
+	now := time.Unix(1000, 0)
+
+	env := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Claude finished",
+			Body:    "Done",
+			Urgency: 0,
+		},
+	}
+
+	d.AllowAt(env, now) // count=1, allowed
+
+	_, merged := d.AllowAt(env, now.Add(1*time.Second)) // count=2, suppressed
+	if merged == nil || merged.GenericMessage.DedupCount != 2 {
+		t.Fatalf("expected dedup count 2, got %v", merged)
+	}
+
+	_, merged = d.AllowAt(env, now.Add(2*time.Second)) // count=3, suppressed
+	if merged == nil || merged.GenericMessage.DedupCount != 3 {
+		t.Fatalf("expected dedup count 3, got %v", merged)
+	}
+
+	_, merged = d.AllowAt(env, now.Add(3*time.Second)) // count=4, suppressed
+	if merged == nil || merged.GenericMessage.DedupCount != 4 {
+		t.Fatalf("expected dedup count 4, got %v", merged)
+	}
+}
+
+func TestDedupType(t *testing.T) {
+	tests := []struct {
+		name string
+		env  NotifyEnvelope
+		want string
+	}{
+		{
+			name: "notification with notif type",
+			env: NotifyEnvelope{
+				Kind: KindToolAttention,
+				ToolAttention: &ToolAttentionPayload{
+					HookType:  "notification",
+					NotifType: "permission_prompt",
+				},
+			},
+			want: "notification:permission_prompt",
+		},
+		{
+			name: "stop with reason",
+			env: NotifyEnvelope{
+				Kind: KindToolAttention,
+				ToolAttention: &ToolAttentionPayload{
+					HookType:   "stop",
+					StopReason: "stop_at_end_of_turn",
+				},
+			},
+			want: "stop:stop_at_end_of_turn",
+		},
+		{
+			name: "generic message without tool attention",
+			env: NotifyEnvelope{
+				Kind: KindGenericMessage,
+			},
+			want: "generic_message",
+		},
+		{
+			name: "image transfer",
+			env: NotifyEnvelope{
+				Kind: KindImageTransfer,
+			},
+			want: "image_transfer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dedupType(tt.env)
+			if got != tt.want {
+				t.Fatalf("dedupType() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAlwaysCritical(t *testing.T) {
+	tests := []struct {
+		name string
+		env  NotifyEnvelope
+		want bool
+	}{
+		{
+			name: "urgency 2 is critical",
+			env: NotifyEnvelope{
+				GenericMessage: &GenericMessagePayload{Urgency: 2},
+			},
+			want: true,
+		},
+		{
+			name: "urgency 1 is not critical",
+			env: NotifyEnvelope{
+				GenericMessage: &GenericMessagePayload{Urgency: 1},
+			},
+			want: false,
+		},
+		{
+			name: "nil GenericMessage is not critical",
+			env:  NotifyEnvelope{},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAlwaysCritical(tt.env)
+			if got != tt.want {
+				t.Fatalf("isAlwaysCritical() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/deliver.go
+++ b/internal/daemon/deliver.go
@@ -1,0 +1,104 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+)
+
+// Deliverer sends a notification envelope through a specific transport.
+// Implementations must be safe for concurrent use.
+type Deliverer interface {
+	Deliver(ctx context.Context, env NotifyEnvelope) error
+	Name() string
+}
+
+// DeliveryChain tries adapters in priority order, falling through on failure.
+// The first successful delivery stops the chain.
+type DeliveryChain struct {
+	adapters []Deliverer
+}
+
+// Deliver iterates through adapters in order. Returns nil on the first
+// success. If all adapters fail, returns the last error. If no adapters
+// are configured, returns an error.
+func (c *DeliveryChain) Deliver(ctx context.Context, env NotifyEnvelope) error {
+	var lastErr error
+	for _, adapter := range c.adapters {
+		if err := adapter.Deliver(ctx, env); err != nil {
+			lastErr = err
+			log.Printf("delivery adapter %s failed: %v", adapter.Name(), err)
+			continue
+		}
+		return nil
+	}
+	if lastErr == nil {
+		return fmt.Errorf("no delivery adapters configured")
+	}
+	return lastErr
+}
+
+// Notify satisfies the Notifier interface by bridging NotifyEvent into
+// NotifyEnvelope via newImageTransferEnvelope, then delegating to Deliver.
+// This allows DeliveryChain to be used as a drop-in Notifier replacement.
+func (c *DeliveryChain) Notify(ctx context.Context, evt NotifyEvent) error {
+	env := newImageTransferEnvelope("clipboard", ImageTransferPayload{
+		SessionID:   evt.SessionID,
+		Seq:         evt.Seq,
+		Fingerprint: evt.Fingerprint,
+		ImageData:   evt.ImageData,
+		Format:      evt.Format,
+		Width:       evt.Width,
+		Height:      evt.Height,
+		DuplicateOf: evt.DuplicateOf,
+	})
+	return c.Deliver(ctx, env)
+}
+
+// BuildDeliveryChain constructs the default chain with available adapters.
+// cmux is tried first (cross-platform tmux notification), then the
+// platform-specific deliverer (macOS terminal-notifier / osascript).
+// platformDeliverer() is defined per-platform in deliver_other.go / notify_darwin.go.
+func BuildDeliveryChain() *DeliveryChain {
+	adapters := make([]Deliverer, 0, 2)
+	if cmux := NewCmuxDeliverer(); cmux != nil {
+		adapters = append(adapters, cmux)
+	}
+	if d := platformDeliverer(); d != nil {
+		adapters = append(adapters, d)
+	}
+	return &DeliveryChain{adapters: adapters}
+}
+
+// formatNotification extracts display-ready title and body text from any
+// envelope kind. Used by both cmux and darwin adapters.
+func formatNotification(env NotifyEnvelope) (title, body string) {
+	switch env.Kind {
+	case KindImageTransfer:
+		if env.ImageTransfer != nil {
+			title = fmt.Sprintf("cc-clip #%d", env.ImageTransfer.Seq)
+			if env.ImageTransfer.DuplicateOf > 0 {
+				body = fmt.Sprintf("Duplicate of #%d", env.ImageTransfer.DuplicateOf)
+			} else {
+				body = fmt.Sprintf("%s %dx%d %s",
+					env.ImageTransfer.Fingerprint,
+					env.ImageTransfer.Width,
+					env.ImageTransfer.Height,
+					env.ImageTransfer.Format,
+				)
+			}
+		}
+	case KindToolAttention, KindGenericMessage:
+		if env.GenericMessage != nil {
+			title = env.GenericMessage.Title
+			body = env.GenericMessage.Body
+			if env.Kind == KindGenericMessage && !env.GenericMessage.Verified {
+				title = "[unverified] " + title
+			}
+		}
+	default:
+		title = "cc-clip"
+		body = string(env.Kind)
+	}
+	return title, body
+}

--- a/internal/daemon/deliver_cmux.go
+++ b/internal/daemon/deliver_cmux.go
@@ -1,0 +1,35 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// CmuxDeliverer sends notifications via the cmux CLI tool.
+// cmux detection is runtime (exec.LookPath), so no build tag is needed.
+type CmuxDeliverer struct {
+	path string
+}
+
+// NewCmuxDeliverer returns a CmuxDeliverer if the cmux binary is found
+// on PATH, or nil if it is not available.
+func NewCmuxDeliverer() *CmuxDeliverer {
+	path, err := exec.LookPath("cmux")
+	if err != nil {
+		return nil
+	}
+	return &CmuxDeliverer{path: path}
+}
+
+func (d *CmuxDeliverer) Name() string { return "cmux" }
+
+// Deliver formats the envelope and shells out to `cmux notify`.
+func (d *CmuxDeliverer) Deliver(_ context.Context, env NotifyEnvelope) error {
+	title, body := formatNotification(env)
+	cmd := exec.Command(d.path, "notify", "--title", title, "--body", body)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("cmux notify failed: %s: %w", string(out), err)
+	}
+	return nil
+}

--- a/internal/daemon/deliver_other.go
+++ b/internal/daemon/deliver_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package daemon
+
+// platformDeliverer returns nil on non-darwin platforms.
+// No platform-specific notification adapter is available.
+func platformDeliverer() Deliverer {
+	return nil
+}

--- a/internal/daemon/deliver_test.go
+++ b/internal/daemon/deliver_test.go
@@ -1,0 +1,230 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeDeliverer is a test double for the Deliverer interface.
+type fakeDeliverer struct {
+	name  string
+	err   error
+	calls int
+}
+
+func (f *fakeDeliverer) Deliver(_ context.Context, _ NotifyEnvelope) error {
+	f.calls++
+	return f.err
+}
+
+func (f *fakeDeliverer) Name() string { return f.name }
+
+func TestDeliveryChainFallsBackToSecondAdapter(t *testing.T) {
+	first := &fakeDeliverer{name: "cmux", err: errors.New("cmux unavailable")}
+	second := &fakeDeliverer{name: "darwin"}
+	chain := &DeliveryChain{adapters: []Deliverer{first, second}}
+
+	err := chain.Deliver(context.Background(), NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title: "Build complete",
+			Body:  "ok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected fallback success, got %v", err)
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("expected both adapters to run, got first=%d second=%d", first.calls, second.calls)
+	}
+}
+
+func TestDeliveryChainStopsOnFirstSuccess(t *testing.T) {
+	first := &fakeDeliverer{name: "cmux"}
+	second := &fakeDeliverer{name: "darwin"}
+	chain := &DeliveryChain{adapters: []Deliverer{first, second}}
+
+	err := chain.Deliver(context.Background(), NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title: "Test",
+			Body:  "ok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if first.calls != 1 {
+		t.Fatalf("expected first adapter called once, got %d", first.calls)
+	}
+	if second.calls != 0 {
+		t.Fatalf("expected second adapter not called, got %d", second.calls)
+	}
+}
+
+func TestDeliveryChainAllFail(t *testing.T) {
+	first := &fakeDeliverer{name: "cmux", err: errors.New("cmux down")}
+	second := &fakeDeliverer{name: "darwin", err: errors.New("darwin down")}
+	chain := &DeliveryChain{adapters: []Deliverer{first, second}}
+
+	err := chain.Deliver(context.Background(), NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title: "Fail",
+			Body:  "all",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when all adapters fail")
+	}
+	if first.calls != 1 || second.calls != 1 {
+		t.Fatalf("expected both adapters called, got first=%d second=%d", first.calls, second.calls)
+	}
+}
+
+func TestDeliveryChainNoAdapters(t *testing.T) {
+	chain := &DeliveryChain{adapters: []Deliverer{}}
+
+	err := chain.Deliver(context.Background(), NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title: "Empty",
+			Body:  "chain",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error with no adapters")
+	}
+}
+
+func TestFormatNotificationImageTransfer(t *testing.T) {
+	env := NotifyEnvelope{
+		Kind:   KindImageTransfer,
+		Source: "clipboard",
+		ImageTransfer: &ImageTransferPayload{
+			Seq:         3,
+			Fingerprint: "abc12345",
+			Width:       800,
+			Height:      600,
+			Format:      "png",
+			DuplicateOf: 0,
+		},
+	}
+	title, body := formatNotification(env)
+	if title != "cc-clip #3" {
+		t.Fatalf("expected title 'cc-clip #3', got %q", title)
+	}
+	if body != "abc12345 800x600 png" {
+		t.Fatalf("expected body 'abc12345 800x600 png', got %q", body)
+	}
+}
+
+func TestFormatNotificationImageTransferDuplicate(t *testing.T) {
+	env := NotifyEnvelope{
+		Kind:   KindImageTransfer,
+		Source: "clipboard",
+		ImageTransfer: &ImageTransferPayload{
+			Seq:         5,
+			Fingerprint: "def67890",
+			Width:       1920,
+			Height:      1080,
+			Format:      "jpeg",
+			DuplicateOf: 2,
+		},
+	}
+	title, body := formatNotification(env)
+	if title != "cc-clip #5" {
+		t.Fatalf("expected title 'cc-clip #5', got %q", title)
+	}
+	if body != "Duplicate of #2" {
+		t.Fatalf("expected body 'Duplicate of #2', got %q", body)
+	}
+}
+
+func TestFormatNotificationGenericMessage(t *testing.T) {
+	env := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title:    "Build complete",
+			Body:     "All tests passed",
+			Verified: true,
+		},
+	}
+	title, body := formatNotification(env)
+	if title != "Build complete" {
+		t.Fatalf("expected title 'Build complete', got %q", title)
+	}
+	if body != "All tests passed" {
+		t.Fatalf("expected body 'All tests passed', got %q", body)
+	}
+}
+
+func TestFormatNotificationGenericMessageUnverified(t *testing.T) {
+	env := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "cli",
+		GenericMessage: &GenericMessagePayload{
+			Title: "Build complete",
+			Body:  "All tests passed",
+		},
+	}
+	title, body := formatNotification(env)
+	if title != "[unverified] Build complete" {
+		t.Fatalf("expected unverified title, got %q", title)
+	}
+	if body != "All tests passed" {
+		t.Fatalf("expected body 'All tests passed', got %q", body)
+	}
+}
+
+func TestFormatNotificationToolAttention(t *testing.T) {
+	env := NotifyEnvelope{
+		Kind:   KindToolAttention,
+		Source: "claude_hook",
+		ToolAttention: &ToolAttentionPayload{
+			HookType:   "notification",
+			NotifType:  "permission_prompt",
+			ToolName:   "Bash",
+			ToolInput:  "rm -rf /",
+			StopReason: "",
+		},
+		GenericMessage: &GenericMessagePayload{
+			Title: "Tool approval needed",
+			Body:  "Bash wants to run",
+		},
+	}
+	title, body := formatNotification(env)
+	if title != "Tool approval needed" {
+		t.Fatalf("expected title 'Tool approval needed', got %q", title)
+	}
+	if body != "Bash wants to run" {
+		t.Fatalf("expected body 'Bash wants to run', got %q", body)
+	}
+}
+
+func TestDeliveryChainNotifyBridgesEvent(t *testing.T) {
+	recorder := &fakeDeliverer{name: "test"}
+	chain := &DeliveryChain{adapters: []Deliverer{recorder}}
+
+	evt := NotifyEvent{
+		SessionID:   "sess-123",
+		Seq:         7,
+		Fingerprint: "aabbccdd",
+		Format:      "png",
+		Width:       640,
+		Height:      480,
+	}
+	err := chain.Notify(context.Background(), evt)
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if recorder.calls != 1 {
+		t.Fatalf("expected 1 call, got %d", recorder.calls)
+	}
+}

--- a/internal/daemon/envelope.go
+++ b/internal/daemon/envelope.go
@@ -11,8 +11,10 @@ const (
 	KindGenericMessage NotifyKind = "generic_message"
 )
 
-// NotifyEnvelope is the unified notification model. Exactly one payload
-// field is non-nil, matching Kind.
+// NotifyEnvelope is the unified notification model. For KindToolAttention,
+// both ToolAttention and GenericMessage may be set (GenericMessage carries
+// display-ready text derived by the classifier). For other kinds, exactly
+// one payload field is non-nil, matching Kind.
 type NotifyEnvelope struct {
 	Kind      NotifyKind
 	Source    string

--- a/internal/daemon/envelope.go
+++ b/internal/daemon/envelope.go
@@ -1,0 +1,59 @@
+package daemon
+
+import "time"
+
+// NotifyKind discriminates the payload carried by a NotifyEnvelope.
+type NotifyKind string
+
+const (
+	KindImageTransfer  NotifyKind = "image_transfer"
+	KindToolAttention  NotifyKind = "tool_attention"
+	KindGenericMessage NotifyKind = "generic_message"
+)
+
+// NotifyEnvelope is the unified notification model. Exactly one payload
+// field is non-nil, matching Kind.
+type NotifyEnvelope struct {
+	Kind      NotifyKind
+	Source    string
+	Host      string
+	Timestamp time.Time
+
+	ImageTransfer  *ImageTransferPayload
+	ToolAttention  *ToolAttentionPayload
+	GenericMessage *GenericMessagePayload
+}
+
+// ImageTransferPayload carries clipboard image transfer metadata.
+type ImageTransferPayload struct {
+	SessionID   string
+	Seq         int
+	Fingerprint string
+	ImageData   []byte
+	Format      string
+	Width       int
+	Height      int
+	DuplicateOf int
+}
+
+// ToolAttentionPayload carries hook/tool attention metadata (future use).
+type ToolAttentionPayload struct {
+	SessionID  string
+	HookType   string
+	StopReason string
+	NotifType  string
+	ToolName   string
+	ToolInput  string
+	Message    string
+	Verified   bool
+}
+
+// GenericMessagePayload carries a freeform notification (future use).
+type GenericMessagePayload struct {
+	Title      string
+	Body       string
+	Urgency    int
+	Verified   bool
+	Subtitle   string
+	DedupCount int
+}

--- a/internal/daemon/notifier.go
+++ b/internal/daemon/notifier.go
@@ -1,0 +1,25 @@
+package daemon
+
+import "context"
+
+// NotifyEvent carries image transfer metadata for notification delivery.
+type NotifyEvent struct {
+	SessionID   string
+	Seq         int
+	Fingerprint string
+	ImageData   []byte
+	Format      string
+	Width       int
+	Height      int
+	DuplicateOf int // 0 = unique, N = matches seq N
+}
+
+// Notifier delivers transfer notifications to the user.
+type Notifier interface {
+	Notify(ctx context.Context, event NotifyEvent) error
+}
+
+// NopNotifier is a no-op implementation for platforms without notification support.
+type NopNotifier struct{}
+
+func (NopNotifier) Notify(context.Context, NotifyEvent) error { return nil }

--- a/internal/daemon/notifier.go
+++ b/internal/daemon/notifier.go
@@ -1,6 +1,9 @@
 package daemon
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // NotifyEvent carries image transfer metadata for notification delivery.
 type NotifyEvent struct {
@@ -23,3 +26,24 @@ type Notifier interface {
 type NopNotifier struct{}
 
 func (NopNotifier) Notify(context.Context, NotifyEvent) error { return nil }
+
+// newImageTransferEnvelope converts clipboard transfer metadata into
+// a NotifyEnvelope. This bridges the legacy NotifyEvent path into the
+// unified envelope model.
+func newImageTransferEnvelope(source string, payload ImageTransferPayload) NotifyEnvelope {
+	return NotifyEnvelope{
+		Kind:      KindImageTransfer,
+		Source:    source,
+		Timestamp: time.Now().UTC(),
+		ImageTransfer: &ImageTransferPayload{
+			SessionID:   payload.SessionID,
+			Seq:         payload.Seq,
+			Fingerprint: payload.Fingerprint,
+			ImageData:   payload.ImageData,
+			Format:      payload.Format,
+			Width:       payload.Width,
+			Height:      payload.Height,
+			DuplicateOf: payload.DuplicateOf,
+		},
+	}
+}

--- a/internal/daemon/notify_darwin.go
+++ b/internal/daemon/notify_darwin.go
@@ -1,0 +1,81 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// DarwinNotifier delivers macOS notifications with image thumbnails
+// via terminal-notifier, falling back to osascript (text-only) if unavailable.
+type DarwinNotifier struct {
+	previewDir         string
+	terminalNotifier   string // path to terminal-notifier binary, empty if not found
+}
+
+func NewDarwinNotifier() *DarwinNotifier {
+	home, _ := os.UserHomeDir()
+	dir := filepath.Join(home, ".cache", "cc-clip", "previews")
+	os.MkdirAll(dir, 0700)
+
+	tn, _ := exec.LookPath("terminal-notifier")
+	return &DarwinNotifier{previewDir: dir, terminalNotifier: tn}
+}
+
+func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
+	// Save preview image to disk
+	var previewPath string
+	if len(evt.ImageData) > 0 {
+		ext := ".png"
+		if evt.Format == "jpeg" {
+			ext = ".jpeg"
+		}
+		sid := evt.SessionID
+		if len(sid) > 8 {
+			sid = sid[:8]
+		}
+		previewPath = filepath.Join(n.previewDir, fmt.Sprintf("preview-%s-%d%s", sid, evt.Seq, ext))
+		if err := os.WriteFile(previewPath, evt.ImageData, 0600); err != nil {
+			previewPath = ""
+		}
+	}
+
+	title := fmt.Sprintf("cc-clip #%d", evt.Seq)
+	subtitle := fmt.Sprintf("%s · %dx%d · %s", evt.Fingerprint, evt.Width, evt.Height, evt.Format)
+
+	body := "Image transferred"
+	if evt.DuplicateOf > 0 {
+		body = fmt.Sprintf("Duplicate of #%d", evt.DuplicateOf)
+	}
+
+	if n.terminalNotifier != "" {
+		return n.sendViaTerminalNotifier(title, subtitle, body, previewPath)
+	}
+	return n.sendViaOsascript(title, subtitle, body)
+}
+
+func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePath string) error {
+	args := []string{
+		"-title", title,
+		"-subtitle", subtitle,
+		"-message", body,
+		"-group", "cc-clip",
+	}
+	if imagePath != "" {
+		args = append(args, "-contentImage", imagePath)
+		args = append(args, "-open", "file://"+imagePath)
+	}
+	return exec.Command(n.terminalNotifier, args...).Run()
+}
+
+func (n *DarwinNotifier) sendViaOsascript(title, subtitle, body string) error {
+	script := fmt.Sprintf(
+		`display notification %q with title %q subtitle %q`,
+		body, title, subtitle,
+	)
+	return exec.Command("osascript", "-e", script).Run()
+}

--- a/internal/daemon/notify_darwin.go
+++ b/internal/daemon/notify_darwin.go
@@ -26,6 +26,54 @@ func NewDarwinNotifier() *DarwinNotifier {
 	return &DarwinNotifier{previewDir: dir, terminalNotifier: tn}
 }
 
+// platformDeliverer returns the darwin-specific notification adapter.
+// Called by BuildDeliveryChain to add the macOS fallback.
+func platformDeliverer() Deliverer {
+	return NewDarwinNotifier()
+}
+
+// Name returns the adapter name for logging in the delivery chain.
+func (n *DarwinNotifier) Name() string { return "darwin" }
+
+// Deliver handles any envelope kind by rendering display text and sending
+// via terminal-notifier (with image preview for image_transfer) or osascript.
+func (n *DarwinNotifier) Deliver(_ context.Context, env NotifyEnvelope) error {
+	title, body := formatNotification(env)
+	subtitle := ""
+	imagePath := ""
+
+	// For image transfers, write a preview thumbnail and build a subtitle
+	if env.Kind == KindImageTransfer && env.ImageTransfer != nil {
+		p := env.ImageTransfer
+		subtitle = fmt.Sprintf("%s \u00b7 %dx%d \u00b7 %s", p.Fingerprint, p.Width, p.Height, p.Format)
+
+		if len(p.ImageData) > 0 {
+			ext := ".png"
+			if p.Format == "jpeg" {
+				ext = ".jpeg"
+			}
+			sid := p.SessionID
+			if len(sid) > 8 {
+				sid = sid[:8]
+			}
+			path := filepath.Join(n.previewDir, fmt.Sprintf("preview-%s-%d%s", sid, p.Seq, ext))
+			if err := os.WriteFile(path, p.ImageData, 0600); err == nil {
+				imagePath = path
+			}
+		}
+	}
+
+	// For generic / tool_attention envelopes, use subtitle from payload
+	if env.GenericMessage != nil && env.GenericMessage.Subtitle != "" {
+		subtitle = env.GenericMessage.Subtitle
+	}
+
+	if n.terminalNotifier != "" {
+		return n.sendViaTerminalNotifier(title, subtitle, body, imagePath)
+	}
+	return n.sendViaOsascript(title, subtitle, body)
+}
+
 func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
 	// Save preview image to disk
 	var previewPath string

--- a/internal/daemon/notify_other.go
+++ b/internal/daemon/notify_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package daemon
+
+// DarwinNotifier is a no-op on non-darwin platforms.
+type DarwinNotifier = NopNotifier
+
+func NewDarwinNotifier() *DarwinNotifier {
+	return &DarwinNotifier{}
+}

--- a/internal/daemon/notify_test.go
+++ b/internal/daemon/notify_test.go
@@ -1,0 +1,167 @@
+package daemon
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/session"
+	"github.com/shunmei/cc-clip/internal/token"
+)
+
+type countingNotifier struct {
+	count atomic.Int64
+	last  atomic.Value // stores NotifyEvent
+}
+
+func (n *countingNotifier) Notify(_ context.Context, evt NotifyEvent) error {
+	n.count.Add(1)
+	n.last.Store(evt)
+	return nil
+}
+
+func newTestServerWithNotifier(clip ClipboardReader) (*Server, string, *countingNotifier) {
+	tm := token.NewManager(1 * time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	notifier := &countingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	go srv.RunNotifier(ctx, notifier)
+	_ = cancel // caller is responsible; tests are short-lived
+	return srv, s.Token, notifier
+}
+
+func TestNotificationTriggeredOnImageFetch(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A} // PNG header
+	clip := &mockClipboard{
+		clipType:  ClipboardInfo{Type: ClipboardImage, Format: "png"},
+		imageData: fakeImage,
+	}
+	srv, tok, notifier := newTestServerWithNotifier(clip)
+
+	req := httptest.NewRequest("GET", "/clipboard/image", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("User-Agent", "cc-clip/0.1")
+	req.Header.Set("X-CC-Clip-Session", "test-session-abc")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Wait for async notification delivery
+	deadline := time.Now().Add(2 * time.Second)
+	for notifier.count.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if notifier.count.Load() != 1 {
+		t.Fatalf("expected 1 notification, got %d", notifier.count.Load())
+	}
+
+	evt := notifier.last.Load().(NotifyEvent)
+	if evt.SessionID != "test-session-abc" {
+		t.Errorf("expected session test-session-abc, got %s", evt.SessionID)
+	}
+	if evt.Seq != 1 {
+		t.Errorf("expected seq 1, got %d", evt.Seq)
+	}
+	if evt.Format != "png" {
+		t.Errorf("expected format png, got %s", evt.Format)
+	}
+}
+
+func TestNoNotificationWithoutSessionHeader(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47}
+	clip := &mockClipboard{
+		clipType:  ClipboardInfo{Type: ClipboardImage, Format: "png"},
+		imageData: fakeImage,
+	}
+	srv, tok, notifier := newTestServerWithNotifier(clip)
+
+	req := httptest.NewRequest("GET", "/clipboard/image", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("User-Agent", "cc-clip/0.1")
+	// No X-CC-Clip-Session header
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	if notifier.count.Load() != 0 {
+		t.Fatalf("expected 0 notifications without session header, got %d", notifier.count.Load())
+	}
+}
+
+func TestNotificationChannelFullDoesNotBlock(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47}
+	clip := &mockClipboard{
+		clipType:  ClipboardInfo{Type: ClipboardImage, Format: "png"},
+		imageData: fakeImage,
+	}
+
+	tm := token.NewManager(1 * time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	// Do NOT start RunNotifier — channel will fill up
+
+	// Fill the channel
+	for i := 0; i < notifyChCap+5; i++ {
+		req := httptest.NewRequest("GET", "/clipboard/image", nil)
+		req.Header.Set("Authorization", "Bearer "+s.Token)
+		req.Header.Set("User-Agent", "cc-clip/0.1")
+		req.Header.Set("X-CC-Clip-Session", "fill-test")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: expected 200, got %d", i, w.Code)
+		}
+	}
+	// If we get here, no deadlock — channel full was handled gracefully
+}
+
+func TestDuplicateDetectionViaNotification(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	clip := &mockClipboard{
+		clipType:  ClipboardInfo{Type: ClipboardImage, Format: "png"},
+		imageData: fakeImage,
+	}
+	srv, tok, notifier := newTestServerWithNotifier(clip)
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest("GET", "/clipboard/image", nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("User-Agent", "cc-clip/0.1")
+		req.Header.Set("X-CC-Clip-Session", "dup-test")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for notifier.count.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if notifier.count.Load() != 2 {
+		t.Fatalf("expected 2 notifications, got %d", notifier.count.Load())
+	}
+
+	evt := notifier.last.Load().(NotifyEvent)
+	if evt.Seq != 2 {
+		t.Errorf("expected seq 2, got %d", evt.Seq)
+	}
+	if evt.DuplicateOf != 1 {
+		t.Errorf("expected duplicate of seq 1, got %d", evt.DuplicateOf)
+	}
+}

--- a/internal/daemon/notify_test.go
+++ b/internal/daemon/notify_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -129,6 +130,297 @@ func TestNotificationChannelFullDoesNotBlock(t *testing.T) {
 		}
 	}
 	// If we get here, no deadlock — channel full was handled gracefully
+}
+
+func TestImageFetchProducesImageTransferEnvelope(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47}
+	clip := &mockClipboard{
+		clipType:  ClipboardInfo{Type: ClipboardImage, Format: "png"},
+		imageData: fakeImage,
+	}
+
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	deliverer := &recordingDeliverer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.RunNotifier(ctx, deliverer)
+
+	req := httptest.NewRequest("GET", "/clipboard/image", nil)
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("User-Agent", "cc-clip/0.1")
+	req.Header.Set("X-CC-Clip-Session", "session-a")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for deliverer.Count() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if deliverer.Count() != 1 {
+		t.Fatalf("expected 1 delivery, got %d", deliverer.Count())
+	}
+	env := deliverer.Last()
+	if env.Kind != KindImageTransfer {
+		t.Fatalf("expected kind %q, got %q", KindImageTransfer, env.Kind)
+	}
+	if env.ImageTransfer == nil {
+		t.Fatal("expected non-nil ImageTransfer payload")
+	}
+	if env.ImageTransfer.Format != "png" {
+		t.Fatalf("expected format png, got %s", env.ImageTransfer.Format)
+	}
+	if env.ImageTransfer.SessionID != "session-a" {
+		t.Fatalf("expected session-a, got %s", env.ImageTransfer.SessionID)
+	}
+	if env.ImageTransfer.Seq != 1 {
+		t.Fatalf("expected seq 1, got %d", env.ImageTransfer.Seq)
+	}
+	if env.Source != "clipboard" {
+		t.Fatalf("expected source clipboard, got %s", env.Source)
+	}
+	if env.Timestamp.IsZero() {
+		t.Fatal("expected non-zero timestamp")
+	}
+}
+
+// recordingDeliverer is a test helper that bridges NotifyEvent into
+// NotifyEnvelope using newImageTransferEnvelope, then records the result.
+// It satisfies the Notifier interface (accepts NotifyEvent) and proves that
+// the bridge function produces correct envelopes.
+type recordingDeliverer struct {
+	count atomic.Int64
+	last  atomic.Value // stores NotifyEnvelope
+}
+
+func (d *recordingDeliverer) Notify(_ context.Context, evt NotifyEvent) error {
+	env := newImageTransferEnvelope("clipboard", ImageTransferPayload{
+		SessionID:   evt.SessionID,
+		Seq:         evt.Seq,
+		Fingerprint: evt.Fingerprint,
+		ImageData:   evt.ImageData,
+		Format:      evt.Format,
+		Width:       evt.Width,
+		Height:      evt.Height,
+		DuplicateOf: evt.DuplicateOf,
+	})
+	d.count.Add(1)
+	d.last.Store(env)
+	return nil
+}
+
+func (d *recordingDeliverer) Count() int64 {
+	return d.count.Load()
+}
+
+func (d *recordingDeliverer) Last() NotifyEnvelope {
+	v := d.last.Load()
+	if v == nil {
+		return NotifyEnvelope{}
+	}
+	return v.(NotifyEnvelope)
+}
+
+type hybridNotifier struct {
+	deliverCount atomic.Int64
+	notifyCount  atomic.Int64
+	lastEnvelope atomic.Value // stores NotifyEnvelope
+	lastEvent    atomic.Value // stores NotifyEvent
+}
+
+func (n *hybridNotifier) Deliver(_ context.Context, env NotifyEnvelope) error {
+	n.deliverCount.Add(1)
+	n.lastEnvelope.Store(env)
+	return nil
+}
+
+func (n *hybridNotifier) Notify(_ context.Context, evt NotifyEvent) error {
+	n.notifyCount.Add(1)
+	n.lastEvent.Store(evt)
+	return nil
+}
+
+func TestCriticalEnvelopeRoutedToCriticalChannel(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-crit")
+
+	// Send a permission_prompt (urgency=2 => critical)
+	body := `{"hook_event_name":"Notification","type":"permission_prompt","title":"Approve tool","body":"Edit file","_cc_clip_host":"mars"}`
+	req := httptest.NewRequest("POST", "/notify", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer nonce-crit")
+	req.Header.Set("Content-Type", "application/x-claude-hook")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	// Critical envelope should be in criticalCh
+	select {
+	case env := <-srv.criticalCh:
+		if env.GenericMessage == nil || env.GenericMessage.Urgency != 2 {
+			t.Fatalf("expected urgency 2, got %+v", env.GenericMessage)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected critical envelope in criticalCh, timed out")
+	}
+}
+
+func TestNonCriticalEnvelopeRoutedToNotifyChannel(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-norm")
+
+	// Send a generic (non-critical) notification
+	body := `{"title":"Info","body":"Build passed","urgency":0}`
+	req := httptest.NewRequest("POST", "/notify", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer nonce-norm")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	// Non-critical should be in notifyCh
+	select {
+	case env := <-srv.notifyCh:
+		if env.Kind != KindGenericMessage {
+			t.Fatalf("expected kind %q, got %q", KindGenericMessage, env.Kind)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected envelope in notifyCh, timed out")
+	}
+}
+
+func TestNotifyNonCriticalChannelFullDoesNotBlock(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-full")
+
+	// Fill the notifyCh entirely (no RunNotifier consuming)
+	for i := 0; i < notifyChCap+10; i++ {
+		body := `{"title":"Flood","body":"msg","urgency":0}`
+		req := httptest.NewRequest("POST", "/notify", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer nonce-full")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("request %d: expected 204, got %d", i, w.Code)
+		}
+	}
+	// If we get here, no deadlock — non-critical full channel was handled
+}
+
+func TestRunNotifierDrainsBothChannels(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	notifier := &countingNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.RunNotifier(ctx, notifier)
+
+	// Enqueue one via notifyCh (image transfer style)
+	srv.enqueueEnvelope(newImageTransferEnvelope("clipboard", ImageTransferPayload{
+		SessionID: "s1",
+		Seq:       1,
+		Format:    "png",
+	}))
+
+	// Enqueue one via criticalCh (permission_prompt)
+	critEnv := NotifyEnvelope{
+		Kind:   KindGenericMessage,
+		Source: "claude_hook",
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Tool approval needed",
+			Body:    "Edit file",
+			Urgency: 2,
+		},
+	}
+	srv.enqueueEnvelope(critEnv)
+
+	// Wait for both to be consumed
+	deadline := time.Now().Add(2 * time.Second)
+	for notifier.count.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if notifier.count.Load() != 2 {
+		t.Fatalf("expected 2 notifications, got %d", notifier.count.Load())
+	}
+}
+
+func TestRunNotifierUsesEnvelopeDeliveryWhenAvailable(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	notifier := &hybridNotifier{}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.RunNotifier(ctx, notifier)
+
+	srv.enqueueEnvelope(NotifyEnvelope{
+		Kind:      KindGenericMessage,
+		Source:    "cli",
+		Timestamp: time.Now().UTC(),
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Build complete",
+			Body:    "All tests passed",
+			Urgency: 1,
+		},
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for notifier.deliverCount.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if notifier.deliverCount.Load() != 1 {
+		t.Fatalf("expected Deliver to be used once, got %d", notifier.deliverCount.Load())
+	}
+	if notifier.notifyCount.Load() != 0 {
+		t.Fatalf("expected legacy Notify path to be skipped, got %d", notifier.notifyCount.Load())
+	}
+
+	got := notifier.lastEnvelope.Load()
+	if got == nil {
+		t.Fatal("expected delivered envelope")
+	}
+	env := got.(NotifyEnvelope)
+	if env.GenericMessage == nil {
+		t.Fatal("expected GenericMessage payload")
+	}
+	if env.GenericMessage.Title != "Build complete" {
+		t.Fatalf("expected title preserved, got %q", env.GenericMessage.Title)
+	}
+	if env.GenericMessage.Body != "All tests passed" {
+		t.Fatalf("expected body preserved, got %q", env.GenericMessage.Body)
+	}
 }
 
 func TestDuplicateDetectionViaNotification(t *testing.T) {

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,13 +1,21 @@
 package daemon
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"bytes"
 	"log"
 	"net"
 	"net/http"
 	"strings"
 
+	"github.com/shunmei/cc-clip/internal/session"
 	"github.com/shunmei/cc-clip/internal/token"
 )
 
@@ -16,17 +24,23 @@ const (
 	userAgent    = "cc-clip"
 )
 
+const notifyChCap = 8
+
 type Server struct {
 	clipboard ClipboardReader
 	tokens    *token.Manager
+	sessions  *session.Store
+	notifyCh  chan NotifyEvent
 	addr      string
 	mux       *http.ServeMux
 }
 
-func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager) *Server {
+func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, sessions *session.Store) *Server {
 	s := &Server{
 		clipboard: clipboard,
 		tokens:    tokens,
+		sessions:  sessions,
+		notifyCh:  make(chan NotifyEvent, notifyChCap),
 		addr:      addr,
 		mux:       http.NewServeMux(),
 	}
@@ -34,6 +48,29 @@ func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager) *S
 	s.mux.HandleFunc("GET /clipboard/type", s.authMiddleware(s.handleClipboardType))
 	s.mux.HandleFunc("GET /clipboard/image", s.authMiddleware(s.handleClipboardImage))
 	return s
+}
+
+// RunNotifier consumes transfer events and delivers notifications.
+// It blocks until ctx is cancelled. Panics in Notify are recovered
+// to prevent notification failures from crashing the daemon.
+func (s *Server) RunNotifier(ctx context.Context, n Notifier) {
+	for {
+		select {
+		case evt := <-s.notifyCh:
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("notification panic recovered: %v", r)
+					}
+				}()
+				if err := n.Notify(ctx, evt); err != nil {
+					log.Printf("notification failed: %v", err)
+				}
+			}()
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (s *Server) ListenAndServe() error {
@@ -126,5 +163,47 @@ func (s *Server) handleClipboardImage(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", contentType)
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(data)))
-	w.Write(data)
+	_, writeErr := w.Write(data)
+
+	// Only notify if the image was successfully written to the client.
+	// If the client disconnected mid-transfer, skip notification to avoid
+	// false-positive "image transferred" confirmations.
+	if writeErr != nil {
+		return
+	}
+
+	sessionID := r.Header.Get("X-CC-Clip-Session")
+	if sessionID != "" && s.sessions != nil {
+		hash := sha256.Sum256(data)
+		fingerprint := hex.EncodeToString(hash[:8])
+
+		width, height := decodeImageDimensions(data)
+
+		evt := s.sessions.AnalyzeAndRecord(sessionID, fingerprint, width, height, info.Format)
+		notify := NotifyEvent{
+			SessionID:   evt.SessionID,
+			Seq:         evt.Seq,
+			Fingerprint: evt.Fingerprint,
+			ImageData:   data,
+			Format:      info.Format,
+			Width:       width,
+			Height:      height,
+			DuplicateOf: evt.DuplicateOf,
+		}
+		select {
+		case s.notifyCh <- notify:
+		default:
+			// channel full: drop notification
+		}
+	}
+}
+
+// decodeImageDimensions reads width and height from image data.
+// Returns 0, 0 if decoding fails.
+func decodeImageDimensions(data []byte) (int, int) {
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+	if err != nil {
+		return 0, 0
+	}
+	return cfg.Width, cfg.Height
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -9,68 +10,187 @@ import (
 	"image"
 	_ "image/jpeg"
 	_ "image/png"
-	"bytes"
+	"io"
 	"log"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/shunmei/cc-clip/internal/session"
 	"github.com/shunmei/cc-clip/internal/token"
 )
 
 const (
-	maxImageSize = 20 * 1024 * 1024 // 20MB
-	userAgent    = "cc-clip"
+	maxImageSize    = 20 * 1024 * 1024 // 20MB
+	maxNotifyBody   = 64 * 1024        // 64KB
+	userAgent       = "cc-clip"
+	criticalChCap   = 4
+	claudeHookCType = "application/x-claude-hook"
 )
 
 const notifyChCap = 8
 
 type Server struct {
-	clipboard ClipboardReader
-	tokens    *token.Manager
-	sessions  *session.Store
-	notifyCh  chan NotifyEvent
-	addr      string
-	mux       *http.ServeMux
+	clipboard    ClipboardReader
+	tokens       *token.Manager
+	sessions     *session.Store
+	notifyCh     chan NotifyEnvelope
+	criticalCh   chan NotifyEnvelope
+	notifyNonces map[string]struct{}
+	noncesMu     sync.RWMutex
+	addr         string
+	mux          *http.ServeMux
 }
 
 func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, sessions *session.Store) *Server {
 	s := &Server{
-		clipboard: clipboard,
-		tokens:    tokens,
-		sessions:  sessions,
-		notifyCh:  make(chan NotifyEvent, notifyChCap),
-		addr:      addr,
-		mux:       http.NewServeMux(),
+		clipboard:    clipboard,
+		tokens:       tokens,
+		sessions:     sessions,
+		notifyCh:     make(chan NotifyEnvelope, notifyChCap),
+		criticalCh:   make(chan NotifyEnvelope, criticalChCap),
+		notifyNonces: make(map[string]struct{}),
+		addr:         addr,
+		mux:          http.NewServeMux(),
 	}
 	s.mux.HandleFunc("GET /health", s.handleHealth)
 	s.mux.HandleFunc("GET /clipboard/type", s.authMiddleware(s.handleClipboardType))
 	s.mux.HandleFunc("GET /clipboard/image", s.authMiddleware(s.handleClipboardImage))
+	s.mux.HandleFunc("POST /notify", s.handleNotify)
+	s.mux.HandleFunc("POST /register-nonce", s.authMiddleware(s.handleRegisterNonce))
 	return s
 }
 
-// RunNotifier consumes transfer events and delivers notifications.
-// It blocks until ctx is cancelled. Panics in Notify are recovered
+// RegisterNotificationNonce adds a nonce to the dedicated notification
+// auth registry. Notification nonces are separate from clipboard bearer
+// tokens to enforce distinct auth domains. Returns an error if the nonce
+// is empty or collides with a valid clipboard token.
+func (s *Server) RegisterNotificationNonce(nonce string) error {
+	if nonce == "" {
+		return fmt.Errorf("empty nonce is not allowed")
+	}
+	if s.tokens.Validate(nonce) == nil {
+		return fmt.Errorf("refusing to register clipboard token as notification nonce")
+	}
+	s.noncesMu.Lock()
+	defer s.noncesMu.Unlock()
+	s.notifyNonces[nonce] = struct{}{}
+	return nil
+}
+
+// validNotificationNonce checks whether the given nonce is registered.
+func (s *Server) validNotificationNonce(nonce string) bool {
+	s.noncesMu.RLock()
+	defer s.noncesMu.RUnlock()
+	_, ok := s.notifyNonces[nonce]
+	return ok
+}
+
+// enqueueEnvelope routes a notification envelope to the appropriate
+// channel. Critical envelopes (e.g. permission_prompt with Urgency=2)
+// attempt a send to criticalCh with a 500ms timeout to prevent
+// deadlocking the HTTP handler. Non-critical envelopes use a
+// select-default send to notifyCh, dropping on full.
+func (s *Server) enqueueEnvelope(env NotifyEnvelope) {
+	if isAlwaysCritical(env) {
+		select {
+		case s.criticalCh <- env:
+		case <-time.After(500 * time.Millisecond):
+			log.Printf("WARN: criticalCh full, dropping critical envelope kind=%s", env.Kind)
+		}
+		return
+	}
+	select {
+	case s.notifyCh <- env:
+	default:
+		// channel full: drop non-critical notification
+	}
+}
+
+// RunNotifier consumes transfer events from both criticalCh (priority)
+// and notifyCh, then delivers notifications via the Notifier interface.
+// It blocks until ctx is cancelled. Panics in Notify/Deliver are recovered
 // to prevent notification failures from crashing the daemon.
+//
+// If the supplied notifier also supports envelope delivery, envelopes are
+// delivered directly so generic/tool notifications keep their structured
+// payload. Legacy notifiers continue to receive bridged NotifyEvent values.
 func (s *Server) RunNotifier(ctx context.Context, n Notifier) {
 	for {
+		var env NotifyEnvelope
+
+		// Give critical notifications strict priority when both queues are ready.
 		select {
-		case evt := <-s.notifyCh:
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						log.Printf("notification panic recovered: %v", r)
-					}
-				}()
-				if err := n.Notify(ctx, evt); err != nil {
-					log.Printf("notification failed: %v", err)
-				}
-			}()
 		case <-ctx.Done():
 			return
+		case env = <-s.criticalCh:
+		default:
+			select {
+			case env = <-s.criticalCh:
+			case env = <-s.notifyCh:
+			case <-ctx.Done():
+				return
+			}
+		}
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("notification panic recovered: %v", r)
+				}
+			}()
+
+			if deliverer, ok := n.(interface {
+				Deliver(context.Context, NotifyEnvelope) error
+			}); ok {
+				if err := deliverer.Deliver(ctx, env); err != nil {
+					log.Printf("notification failed: %v", err)
+				}
+				return
+			}
+
+			evt := envelopeToEvent(env)
+			if err := n.Notify(ctx, evt); err != nil {
+				log.Printf("notification failed: %v", err)
+			}
+		}()
+	}
+}
+
+// envelopeToEvent bridges a NotifyEnvelope back to a NotifyEvent for
+// backward compatibility with the Notifier interface.
+func envelopeToEvent(env NotifyEnvelope) NotifyEvent {
+	if env.ImageTransfer != nil {
+		return NotifyEvent{
+			SessionID:   env.ImageTransfer.SessionID,
+			Seq:         env.ImageTransfer.Seq,
+			Fingerprint: env.ImageTransfer.Fingerprint,
+			ImageData:   env.ImageTransfer.ImageData,
+			Format:      env.ImageTransfer.Format,
+			Width:       env.ImageTransfer.Width,
+			Height:      env.ImageTransfer.Height,
+			DuplicateOf: env.ImageTransfer.DuplicateOf,
 		}
 	}
+	// For non-image envelopes, construct a synthetic event with
+	// available metadata so existing Notifier implementations can
+	// display something useful.
+	return NotifyEvent{
+		Format: string(env.Kind),
+	}
+}
+
+// Handler returns the HTTP handler for this server.
+// Useful for testing with httptest.NewServer.
+func (s *Server) Handler() http.Handler {
+	return s.mux
+}
+
+// Serve accepts connections on the given listener and serves HTTP.
+func (s *Server) Serve(ln net.Listener) error {
+	return http.Serve(ln, s.mux)
 }
 
 func (s *Server) ListenAndServe() error {
@@ -117,6 +237,24 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// handleRegisterNonce accepts a notification nonce from an authenticated
+// connect session. The request body is a JSON object with a "nonce" field.
+// Protected by authMiddleware (requires clipboard bearer token).
+func (s *Server) handleRegisterNonce(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Nonce string `json:"nonce"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := s.RegisterNotificationNonce(req.Nonce); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleClipboardType(w http.ResponseWriter, r *http.Request) {
@@ -180,7 +318,7 @@ func (s *Server) handleClipboardImage(w http.ResponseWriter, r *http.Request) {
 		width, height := decodeImageDimensions(data)
 
 		evt := s.sessions.AnalyzeAndRecord(sessionID, fingerprint, width, height, info.Format)
-		notify := NotifyEvent{
+		env := newImageTransferEnvelope("clipboard", ImageTransferPayload{
 			SessionID:   evt.SessionID,
 			Seq:         evt.Seq,
 			Fingerprint: evt.Fingerprint,
@@ -189,13 +327,94 @@ func (s *Server) handleClipboardImage(w http.ResponseWriter, r *http.Request) {
 			Width:       width,
 			Height:      height,
 			DuplicateOf: evt.DuplicateOf,
-		}
-		select {
-		case s.notifyCh <- notify:
-		default:
-			// channel full: drop notification
-		}
+		})
+		s.enqueueEnvelope(env)
 	}
+}
+
+// handleNotify accepts notification payloads from remote hook scripts
+// or generic senders. Auth is via notification nonce (separate from
+// clipboard bearer token).
+func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
+	nonce := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if nonce == "" || !s.validNotificationNonce(nonce) {
+		http.Error(w, "invalid notification nonce", http.StatusUnauthorized)
+		return
+	}
+
+	env, err := s.parseNotifyRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	s.enqueueEnvelope(env)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseNotifyRequest decodes the request body into a NotifyEnvelope.
+// Two content types are supported:
+//   - application/x-claude-hook: Claude hook JSON, processed via ClassifyHookPayload
+//   - anything else (typically application/json): generic JSON notification
+func (s *Server) parseNotifyRequest(r *http.Request) (NotifyEnvelope, error) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxNotifyBody))
+	if err != nil {
+		return NotifyEnvelope{}, fmt.Errorf("failed to read body: %w", err)
+	}
+	if len(body) == 0 {
+		return NotifyEnvelope{}, fmt.Errorf("empty request body")
+	}
+
+	ct := r.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, claudeHookCType) {
+		return s.parseClaudeHookPayload(body)
+	}
+	return s.parseGenericJSON(body)
+}
+
+// parseClaudeHookPayload decodes Claude hook JSON and classifies it.
+func (s *Server) parseClaudeHookPayload(body []byte) (NotifyEnvelope, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return NotifyEnvelope{}, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	hookType := "notification"
+	if ht, ok := raw["hook_event_name"].(string); ok {
+		hookType = strings.ToLower(ht)
+	}
+
+	env := ClassifyHookPayload(hookType, raw)
+	if env == nil {
+		return NotifyEnvelope{}, fmt.Errorf("classifier returned nil")
+	}
+	return *env, nil
+}
+
+// parseGenericJSON decodes a freeform JSON notification payload.
+func (s *Server) parseGenericJSON(body []byte) (NotifyEnvelope, error) {
+	var payload struct {
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+		Urgency int    `json:"urgency"`
+		Host    string `json:"host"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return NotifyEnvelope{}, fmt.Errorf("invalid JSON: %w", err)
+	}
+
+	return NotifyEnvelope{
+		Kind:      KindGenericMessage,
+		Source:    "generic",
+		Host:      payload.Host,
+		Timestamp: time.Now().UTC(),
+		GenericMessage: &GenericMessagePayload{
+			Title:    payload.Title,
+			Body:     payload.Body,
+			Urgency:  payload.Urgency,
+			Verified: false,
+		},
+	}, nil
 }
 
 // decodeImageDimensions reads width and height from image data.
@@ -206,4 +425,9 @@ func decodeImageDimensions(data []byte) (int, int) {
 		return 0, 0
 	}
 	return cfg.Width, cfg.Height
+}
+
+// NotifyChannel exposes the non-critical notification queue to tests.
+func (s *Server) NotifyChannel() <-chan NotifyEnvelope {
+	return s.notifyCh
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	clipboard    ClipboardReader
 	tokens       *token.Manager
 	sessions     *session.Store
+	dedup        *Deduper
 	notifyCh     chan NotifyEnvelope
 	criticalCh   chan NotifyEnvelope
 	notifyNonces map[string]struct{}
@@ -49,6 +50,7 @@ func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, se
 		clipboard:    clipboard,
 		tokens:       tokens,
 		sessions:     sessions,
+		dedup:        NewDeduper(12 * time.Second),
 		notifyCh:     make(chan NotifyEnvelope, notifyChCap),
 		criticalCh:   make(chan NotifyEnvelope, criticalChCap),
 		notifyNonces: make(map[string]struct{}),
@@ -88,12 +90,15 @@ func (s *Server) validNotificationNonce(nonce string) bool {
 	return ok
 }
 
-// enqueueEnvelope routes a notification envelope to the appropriate
-// channel. Critical envelopes (e.g. permission_prompt with Urgency=2)
-// attempt a send to criticalCh with a 500ms timeout to prevent
-// deadlocking the HTTP handler. Non-critical envelopes use a
-// select-default send to notifyCh, dropping on full.
+// enqueueEnvelope deduplicates then routes a notification envelope to
+// the appropriate channel. Repeated non-critical notifications within
+// the dedup window are suppressed. Critical envelopes (permission_prompt)
+// bypass dedup and use criticalCh with a 500ms timeout. Non-critical
+// envelopes use a select-default send to notifyCh, dropping on full.
 func (s *Server) enqueueEnvelope(env NotifyEnvelope) {
+	if allowed, _ := s.dedup.AllowAt(env, time.Now()); !allowed {
+		return
+	}
 	if isAlwaysCritical(env) {
 		select {
 		case s.criticalCh <- env:

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shunmei/cc-clip/internal/session"
 	"github.com/shunmei/cc-clip/internal/token"
 )
 
@@ -29,7 +30,8 @@ func (m *mockClipboard) ImageBytes() ([]byte, error) {
 func newTestServer(clip ClipboardReader) (*Server, string) {
 	tm := token.NewManager(1 * time.Hour)
 	s, _ := tm.Generate()
-	srv := NewServer("127.0.0.1:0", clip, tm)
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
 	return srv, s.Token
 }
 

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -182,5 +183,226 @@ func TestWrongTokenRejected(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+// --- /notify endpoint tests ---
+
+func TestNotifyEndpointAcceptsClaudeHookPayload(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-123")
+
+	body := strings.NewReader(`{"hook_event_name":"Notification","type":"permission_prompt","title":"Approve tool","body":"Claude wants to Edit file","_cc_clip_host":"venus"}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Authorization", "Bearer nonce-123")
+	req.Header.Set("Content-Type", "application/x-claude-hook")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestNotifyEndpointRejectsInvalidNonce(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	// No nonce registered
+
+	body := strings.NewReader(`{"title":"test","body":"hello"}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Authorization", "Bearer bad-nonce")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for bad nonce, got %d", w.Code)
+	}
+}
+
+func TestNotifyEndpointRejectsMissingAuth(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	body := strings.NewReader(`{"title":"test","body":"hello"}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing auth, got %d", w.Code)
+	}
+}
+
+func TestNotifyEndpointAcceptsGenericJSON(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-abc")
+
+	body := strings.NewReader(`{"title":"Build done","body":"All tests passed","urgency":1}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Authorization", "Bearer nonce-abc")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestNotifyEndpointRejectsClipboardToken(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	// Do NOT register clipboard token as nonce
+
+	body := strings.NewReader(`{"title":"test","body":"hello"}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (clipboard token should not work for /notify), got %d", w.Code)
+	}
+}
+
+func TestNotifyEndpointRejectsEmptyBody(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-xyz")
+
+	req := httptest.NewRequest("POST", "/notify", strings.NewReader(""))
+	req.Header.Set("Authorization", "Bearer nonce-xyz")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty body, got %d", w.Code)
+	}
+}
+
+// --- /register-nonce endpoint tests ---
+
+func TestRegisterNonceEndpointRegistersNonce(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	// Register a nonce via the endpoint
+	body := strings.NewReader(`{"nonce":"test-nonce-abc123"}`)
+	req := httptest.NewRequest("POST", "/register-nonce", body)
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the nonce is now usable for /notify
+	notifyBody := strings.NewReader(`{"title":"test","body":"hello"}`)
+	notifyReq := httptest.NewRequest("POST", "/notify", notifyBody)
+	notifyReq.Header.Set("Authorization", "Bearer test-nonce-abc123")
+	notifyReq.Header.Set("Content-Type", "application/json")
+	notifyW := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(notifyW, notifyReq)
+
+	if notifyW.Code != http.StatusNoContent {
+		t.Fatalf("expected 204 after nonce registration, got %d", notifyW.Code)
+	}
+}
+
+func TestRegisterNonceEndpointRequiresAuth(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	body := strings.NewReader(`{"nonce":"some-nonce"}`)
+	req := httptest.NewRequest("POST", "/register-nonce", body)
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without auth, got %d", w.Code)
+	}
+}
+
+func TestRegisterNonceEndpointRejectsEmptyNonce(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	body := strings.NewReader(`{"nonce":""}`)
+	req := httptest.NewRequest("POST", "/register-nonce", body)
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty nonce, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegisterNonceEndpointRejectsInvalidJSON(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+
+	body := strings.NewReader(`{invalid json`)
+	req := httptest.NewRequest("POST", "/register-nonce", body)
+	req.Header.Set("Authorization", "Bearer "+s.Token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
 	}
 }

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -406,3 +406,87 @@ func TestRegisterNonceEndpointRejectsInvalidJSON(t *testing.T) {
 		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
 	}
 }
+
+func TestDedupSuppressesRepeatedNotifyAtRuntime(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-dedup")
+
+	postNotify := func() int {
+		body := strings.NewReader(`{"title":"Claude finished","body":"Done","urgency":0}`)
+		req := httptest.NewRequest("POST", "/notify", body)
+		req.Header.Set("Authorization", "Bearer nonce-dedup")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// First request: accepted (204)
+	if code := postNotify(); code != http.StatusNoContent {
+		t.Fatalf("first notify: expected 204, got %d", code)
+	}
+
+	// Second identical request within dedup window: still 204 from handler
+	// (dedup happens at enqueue, not at HTTP level) but the envelope
+	// should NOT reach the channel.
+	if code := postNotify(); code != http.StatusNoContent {
+		t.Fatalf("second notify: expected 204, got %d", code)
+	}
+
+	// Only one envelope should have been enqueued
+	select {
+	case <-srv.notifyCh:
+		// good, first one is there
+	default:
+		t.Fatal("expected first envelope in notifyCh")
+	}
+	select {
+	case <-srv.notifyCh:
+		t.Fatal("dedup should have suppressed the second envelope")
+	default:
+		// good, channel is empty
+	}
+}
+
+func TestDedupDoesNotSuppressCriticalPermissionPrompt(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	srv.RegisterNotificationNonce("nonce-crit-dedup")
+
+	postCritical := func() int {
+		body := strings.NewReader(`{"hook_event_name":"Notification","type":"permission_prompt","title":"Approve","body":"Edit main.go","_cc_clip_host":"venus"}`)
+		req := httptest.NewRequest("POST", "/notify", body)
+		req.Header.Set("Authorization", "Bearer nonce-crit-dedup")
+		req.Header.Set("Content-Type", "application/x-claude-hook")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Send two identical permission_prompt notifications
+	if code := postCritical(); code != http.StatusNoContent {
+		t.Fatalf("first critical: expected 204, got %d", code)
+	}
+	if code := postCritical(); code != http.StatusNoContent {
+		t.Fatalf("second critical: expected 204, got %d", code)
+	}
+
+	// Both should be in criticalCh (not deduped)
+	count := 0
+	for range 2 {
+		select {
+		case <-srv.criticalCh:
+			count++
+		case <-time.After(200 * time.Millisecond):
+			// timeout
+		}
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 critical envelopes, got %d", count)
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1,0 +1,140 @@
+package session
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+const ringSize = 5
+
+// TransferEvent is emitted when an image is analyzed and recorded.
+type TransferEvent struct {
+	SessionID   string
+	Seq         int
+	Fingerprint string
+	Width       int
+	Height      int
+	Format      string
+	DuplicateOf int // 0 = unique, N = matches seq N
+}
+
+// ImageRecord stores metadata for a single transferred image.
+type ImageRecord struct {
+	Seq         int
+	Fingerprint string
+	Width       int
+	Height      int
+	Format      string
+	At          time.Time
+}
+
+// Session tracks transfer state for a single connect session.
+type Session struct {
+	ID         string
+	Recent     [ringSize]ImageRecord
+	Cursor     int // next write position in ring buffer
+	Count      int // valid entries (0..ringSize)
+	SeqNext    int // next sequence number (starts at 1)
+	LastAccess time.Time
+}
+
+// Store manages sessions with TTL-based cleanup.
+type Store struct {
+	mu       sync.Mutex
+	sessions map[string]*Session
+	ttl      time.Duration
+}
+
+// NewStore creates a session store with the given TTL for idle session expiry.
+func NewStore(ttl time.Duration) *Store {
+	return &Store{
+		sessions: make(map[string]*Session),
+		ttl:      ttl,
+	}
+}
+
+// AnalyzeAndRecord atomically assigns a sequence number, checks for duplicates
+// in the ring buffer, records the image, and returns a TransferEvent.
+func (s *Store) AnalyzeAndRecord(sessionID, fingerprint string, width, height int, format string) TransferEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[sessionID]
+	if !ok {
+		sess = &Session{
+			ID:      sessionID,
+			SeqNext: 1,
+		}
+		s.sessions[sessionID] = sess
+	}
+
+	now := time.Now()
+	sess.LastAccess = now
+
+	// Check for duplicate in ring buffer
+	duplicateOf := 0
+	limit := sess.Count
+	for i := 0; i < limit; i++ {
+		if sess.Recent[i].Fingerprint == fingerprint {
+			duplicateOf = sess.Recent[i].Seq
+			break
+		}
+	}
+
+	// Assign sequence number
+	seq := sess.SeqNext
+	sess.SeqNext++
+
+	// Write to ring buffer
+	record := ImageRecord{
+		Seq:         seq,
+		Fingerprint: fingerprint,
+		Width:       width,
+		Height:      height,
+		Format:      format,
+		At:          now,
+	}
+	sess.Recent[sess.Cursor] = record
+	sess.Cursor = (sess.Cursor + 1) % ringSize
+	if sess.Count < ringSize {
+		sess.Count++
+	}
+
+	return TransferEvent{
+		SessionID:   sessionID,
+		Seq:         seq,
+		Fingerprint: fingerprint,
+		Width:       width,
+		Height:      height,
+		Format:      format,
+		DuplicateOf: duplicateOf,
+	}
+}
+
+// Cleanup removes sessions that have been idle longer than the TTL.
+func (s *Store) Cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	for id, sess := range s.sessions {
+		if now.Sub(sess.LastAccess) > s.ttl {
+			delete(s.sessions, id)
+		}
+	}
+}
+
+// RunCleanup periodically removes expired sessions until ctx is cancelled.
+func (s *Store) RunCleanup(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			s.Cleanup()
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,0 +1,181 @@
+package session
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAnalyzeAndRecord_AssignsSequentialSeq(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	sid := "test-session-1"
+
+	e1 := s.AnalyzeAndRecord(sid, "aabbccdd", 1920, 1080, "png")
+	e2 := s.AnalyzeAndRecord(sid, "11223344", 800, 600, "jpeg")
+	e3 := s.AnalyzeAndRecord(sid, "55667788", 1024, 768, "png")
+
+	if e1.Seq != 1 {
+		t.Errorf("expected seq 1, got %d", e1.Seq)
+	}
+	if e2.Seq != 2 {
+		t.Errorf("expected seq 2, got %d", e2.Seq)
+	}
+	if e3.Seq != 3 {
+		t.Errorf("expected seq 3, got %d", e3.Seq)
+	}
+}
+
+func TestAnalyzeAndRecord_DetectsDuplicate(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	sid := "test-session-dup"
+
+	s.AnalyzeAndRecord(sid, "aabbccdd", 1920, 1080, "png")
+	s.AnalyzeAndRecord(sid, "11223344", 800, 600, "jpeg")
+	e3 := s.AnalyzeAndRecord(sid, "aabbccdd", 1920, 1080, "png")
+
+	if e3.DuplicateOf != 1 {
+		t.Errorf("expected duplicate of seq 1, got %d", e3.DuplicateOf)
+	}
+}
+
+func TestAnalyzeAndRecord_NoDuplicateForUnique(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	sid := "test-session-uniq"
+
+	s.AnalyzeAndRecord(sid, "aabbccdd", 1920, 1080, "png")
+	e2 := s.AnalyzeAndRecord(sid, "11223344", 800, 600, "jpeg")
+
+	if e2.DuplicateOf != 0 {
+		t.Errorf("expected no duplicate (0), got %d", e2.DuplicateOf)
+	}
+}
+
+func TestAnalyzeAndRecord_RingBufferEvicts(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	sid := "test-session-ring"
+
+	// Fill ring buffer with 5 unique images (slots 0-4)
+	s.AnalyzeAndRecord(sid, "fp-1", 100, 100, "png") // seq 1, slot 0
+	s.AnalyzeAndRecord(sid, "fp-2", 100, 100, "png") // seq 2, slot 1
+	s.AnalyzeAndRecord(sid, "fp-3", 100, 100, "png") // seq 3, slot 2
+	s.AnalyzeAndRecord(sid, "fp-4", 100, 100, "png") // seq 4, slot 3
+	s.AnalyzeAndRecord(sid, "fp-5", 100, 100, "png") // seq 5, slot 4
+
+	// fp-1 is still in buffer at slot 0
+	e6 := s.AnalyzeAndRecord(sid, "fp-1", 100, 100, "png")
+	if e6.DuplicateOf != 1 {
+		t.Errorf("expected duplicate of seq 1 (still in buffer), got %d", e6.DuplicateOf)
+	}
+
+	// Now add 5 more unique images to fully cycle the ring buffer
+	// This evicts all original entries including fp-1 re-entry at slot 0
+	s.AnalyzeAndRecord(sid, "fp-a", 100, 100, "png") // seq 7, overwrites slot 1
+	s.AnalyzeAndRecord(sid, "fp-b", 100, 100, "png") // seq 8, overwrites slot 2
+	s.AnalyzeAndRecord(sid, "fp-c", 100, 100, "png") // seq 9, overwrites slot 3
+	s.AnalyzeAndRecord(sid, "fp-d", 100, 100, "png") // seq 10, overwrites slot 4
+	s.AnalyzeAndRecord(sid, "fp-e", 100, 100, "png") // seq 11, overwrites slot 0 (evicts fp-1)
+
+	// fp-1 is now fully evicted from ring buffer
+	e12 := s.AnalyzeAndRecord(sid, "fp-1", 100, 100, "png")
+	if e12.DuplicateOf != 0 {
+		t.Errorf("expected no duplicate after full eviction, got %d", e12.DuplicateOf)
+	}
+}
+
+func TestAnalyzeAndRecord_SeparateSessions(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+
+	e1 := s.AnalyzeAndRecord("session-a", "fp-1", 100, 100, "png")
+	e2 := s.AnalyzeAndRecord("session-b", "fp-1", 100, 100, "png")
+
+	if e1.Seq != 1 {
+		t.Errorf("session-a: expected seq 1, got %d", e1.Seq)
+	}
+	if e2.Seq != 1 {
+		t.Errorf("session-b: expected seq 1, got %d", e2.Seq)
+	}
+	if e2.DuplicateOf != 0 {
+		t.Errorf("session-b: should not detect duplicate from session-a, got %d", e2.DuplicateOf)
+	}
+}
+
+func TestAnalyzeAndRecord_EventFields(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	e := s.AnalyzeAndRecord("sess-1", "abcd1234", 1920, 1080, "png")
+
+	if e.SessionID != "sess-1" {
+		t.Errorf("expected session ID sess-1, got %s", e.SessionID)
+	}
+	if e.Fingerprint != "abcd1234" {
+		t.Errorf("expected fingerprint abcd1234, got %s", e.Fingerprint)
+	}
+	if e.Width != 1920 || e.Height != 1080 {
+		t.Errorf("expected 1920x1080, got %dx%d", e.Width, e.Height)
+	}
+	if e.Format != "png" {
+		t.Errorf("expected format png, got %s", e.Format)
+	}
+}
+
+func TestCleanup_RemovesExpiredSessions(t *testing.T) {
+	s := NewStore(50 * time.Millisecond)
+
+	s.AnalyzeAndRecord("old-session", "fp-1", 100, 100, "png")
+	time.Sleep(100 * time.Millisecond)
+
+	s.AnalyzeAndRecord("new-session", "fp-2", 100, 100, "png")
+
+	s.Cleanup()
+
+	// old-session should be gone, new-session should remain
+	s.mu.Lock()
+	_, oldExists := s.sessions["old-session"]
+	_, newExists := s.sessions["new-session"]
+	s.mu.Unlock()
+
+	if oldExists {
+		t.Error("expected old-session to be cleaned up")
+	}
+	if !newExists {
+		t.Error("expected new-session to still exist")
+	}
+}
+
+func TestCleanup_KeepsActiveSessions(t *testing.T) {
+	s := NewStore(1 * time.Hour)
+
+	s.AnalyzeAndRecord("active-session", "fp-1", 100, 100, "png")
+	s.Cleanup()
+
+	s.mu.Lock()
+	_, exists := s.sessions["active-session"]
+	s.mu.Unlock()
+
+	if !exists {
+		t.Error("expected active session to survive cleanup")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	s := NewStore(12 * time.Hour)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			sid := "concurrent-session"
+			s.AnalyzeAndRecord(sid, "fp-"+string(rune('a'+n%26)), 100, 100, "png")
+		}(i)
+	}
+
+	wg.Wait()
+
+	s.mu.Lock()
+	sess := s.sessions["concurrent-session"]
+	s.mu.Unlock()
+
+	if sess.SeqNext != 101 {
+		t.Errorf("expected SeqNext 101 after 100 concurrent records, got %d", sess.SeqNext)
+	}
+}

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -18,15 +18,24 @@ type CodexDeployState struct {
 	DisplayFixed bool   `json:"display_fixed"`
 }
 
+// NotifyDeployState represents the notification bridge deployment state.
+type NotifyDeployState struct {
+	Enabled        bool `json:"enabled"`
+	HookInstalled  bool `json:"hook_installed"`
+	CodexInjected  bool `json:"codex_injected"`
+	HealthVerified bool `json:"health_verified"`
+}
+
 // DeployState represents the state of a cc-clip deployment on a remote host.
 // It is stored as ~/.cache/cc-clip/deploy.json on the remote.
 type DeployState struct {
-	BinaryHash    string           `json:"binary_hash"`
-	BinaryVersion string           `json:"binary_version"`
-	ShimInstalled bool             `json:"shim_installed"`
-	ShimTarget    string           `json:"shim_target"`
-	PathFixed     bool             `json:"path_fixed"`
-	Codex         *CodexDeployState `json:"codex,omitempty"`
+	BinaryHash    string             `json:"binary_hash"`
+	BinaryVersion string             `json:"binary_version"`
+	ShimInstalled bool               `json:"shim_installed"`
+	ShimTarget    string             `json:"shim_target"`
+	PathFixed     bool               `json:"path_fixed"`
+	Notify        *NotifyDeployState `json:"notify,omitempty"`
+	Codex         *CodexDeployState  `json:"codex,omitempty"`
 }
 
 const remoteDeployPath = "~/.cache/cc-clip/deploy.json"
@@ -111,6 +120,14 @@ func NeedsShimInstall(remote *DeployState) bool {
 		return true
 	}
 	return !remote.ShimInstalled
+}
+
+// NeedsNotifySetup checks whether notification bridge setup is needed on the remote.
+func NeedsNotifySetup(remote *DeployState) bool {
+	if remote == nil || remote.Notify == nil {
+		return true
+	}
+	return !remote.Notify.Enabled
 }
 
 // NeedsCodexSetup checks whether Codex setup is needed on the remote.

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -338,6 +338,134 @@ func TestDeployStateJSONUnmarshalOldFormat(t *testing.T) {
 	}
 }
 
+func TestDeployStatePersistsNotificationSetup(t *testing.T) {
+	state := &DeployState{
+		BinaryHash: "sha256:abc",
+		Notify: &NotifyDeployState{
+			Enabled:        true,
+			HookInstalled:  true,
+			CodexInjected:  true,
+			HealthVerified: true,
+		},
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(raw), `"notify"`) {
+		t.Fatalf("expected notify block, got %s", raw)
+	}
+
+	// Round-trip unmarshal
+	var decoded DeployState
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.Notify == nil {
+		t.Fatal("decoded Notify should not be nil")
+	}
+	if !decoded.Notify.Enabled {
+		t.Error("decoded Notify.Enabled should be true")
+	}
+	if !decoded.Notify.HookInstalled {
+		t.Error("decoded Notify.HookInstalled should be true")
+	}
+	if !decoded.Notify.CodexInjected {
+		t.Error("decoded Notify.CodexInjected should be true")
+	}
+	if !decoded.Notify.HealthVerified {
+		t.Error("decoded Notify.HealthVerified should be true")
+	}
+}
+
+func TestDeployStateJSONNotifyNil(t *testing.T) {
+	// Marshal with Notify: nil -> no "notify" key in JSON
+	state := DeployState{
+		BinaryHash:    "sha256:abc",
+		BinaryVersion: "v0.1.0",
+		ShimInstalled: true,
+		Notify:        nil,
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	raw := string(data)
+	if strings.Contains(raw, `"notify"`) {
+		t.Fatalf("JSON should not contain 'notify' key when Notify is nil, got: %s", raw)
+	}
+}
+
+func TestDeployStateJSONUnmarshalOldFormatNoNotify(t *testing.T) {
+	// Unmarshal old JSON (no notify field) -> Notify: nil, no error
+	raw := `{
+  "binary_hash": "sha256:deadbeef",
+  "binary_version": "v0.2.0",
+  "shim_installed": true,
+  "shim_target": "wl-paste",
+  "path_fixed": false
+}`
+
+	var state DeployState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		t.Fatalf("failed to unmarshal old format: %v", err)
+	}
+
+	if state.Notify != nil {
+		t.Fatalf("Notify should be nil for old format JSON, got: %+v", state.Notify)
+	}
+}
+
+func TestNeedsNotifySetup(t *testing.T) {
+	tests := []struct {
+		name   string
+		remote *DeployState
+		want   bool
+	}{
+		{
+			name:   "nil remote state",
+			remote: nil,
+			want:   true,
+		},
+		{
+			name:   "nil Notify field",
+			remote: &DeployState{},
+			want:   true,
+		},
+		{
+			name: "Notify not enabled",
+			remote: &DeployState{
+				Notify: &NotifyDeployState{
+					Enabled: false,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Notify enabled",
+			remote: &DeployState{
+				Notify: &NotifyDeployState{
+					Enabled:        true,
+					HookInstalled:  true,
+					HealthVerified: true,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NeedsNotifySetup(tt.remote)
+			if got != tt.want {
+				t.Errorf("NeedsNotifySetup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNeedsCodexSetup(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/shim/hook_template.go
+++ b/internal/shim/hook_template.go
@@ -27,7 +27,7 @@ d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
 json.dump(d, sys.stdout)
 " 2>/dev/null || echo "$_payload")
 
-_http_code=$(curl -sf -o /dev/null -w '%%{http_code}' -X POST \
+_http_code=$(curl -sf --connect-timeout 2 --max-time 5 -o /dev/null -w '%%{http_code}' -X POST \
 	-H "Authorization: Bearer $_nonce" \
 	-H "Content-Type: application/x-claude-hook" \
 	-H "User-Agent: cc-clip-hook/0.1" \

--- a/internal/shim/hook_template.go
+++ b/internal/shim/hook_template.go
@@ -1,0 +1,52 @@
+package shim
+
+import "fmt"
+
+const hookTemplate = `#!/usr/bin/env bash
+# cc-clip-hook — Claude Code hook bridge
+# Reads hook JSON from stdin, forwards to cc-clip daemon via tunnel
+
+set -euo pipefail
+
+_CC_CLIP_PORT="${CC_CLIP_PORT:-%d}"
+_CC_CLIP_NONCE_FILE="${HOME}/.cache/cc-clip/notify.nonce"
+_CC_CLIP_HOST_ALIAS="${CC_CLIP_HOST_ALIAS:-$(hostname -s)}"
+_CC_CLIP_HEALTH_FILE="${HOME}/.cache/cc-clip/notify-health.log"
+
+_nonce=""
+if [ -f "$_CC_CLIP_NONCE_FILE" ]; then
+	_nonce=$(head -1 "$_CC_CLIP_NONCE_FILE")
+fi
+
+_payload=$(cat)
+
+_payload=$(echo "$_payload" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
+json.dump(d, sys.stdout)
+" 2>/dev/null || echo "$_payload")
+
+_http_code=$(curl -sf -o /dev/null -w '%%{http_code}' -X POST \
+	-H "Authorization: Bearer $_nonce" \
+	-H "Content-Type: application/x-claude-hook" \
+	-H "User-Agent: cc-clip-hook/0.1" \
+	-d "$_payload" \
+	"http://127.0.0.1:${_CC_CLIP_PORT}/notify" \
+	2>/dev/null) || _http_code="000"
+
+if [ "$_http_code" != "204" ] && [ "$_http_code" != "200" ]; then
+	echo "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) FAIL http=$_http_code" >> "$_CC_CLIP_HEALTH_FILE" 2>/dev/null || true
+fi
+
+exit 0
+`
+
+// HookScript returns the cc-clip-hook bash script with the given port baked in.
+// This script is installed to ~/.local/bin/cc-clip-hook on the remote. Claude Code
+// hooks pipe JSON to stdin, which the script forwards to the cc-clip daemon via
+// the SSH tunnel. Authentication uses the notification nonce (not the clipboard
+// session token).
+func HookScript(port int) string {
+	return fmt.Sprintf(hookTemplate, port)
+}

--- a/internal/shim/hook_template_test.go
+++ b/internal/shim/hook_template_test.go
@@ -1,0 +1,56 @@
+package shim
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHookTemplateUsesNotificationNonceAndHealthLog(t *testing.T) {
+	got := HookScript(18339)
+	for _, needle := range []string{
+		"notify.nonce",
+		"notify-health.log",
+		"application/x-claude-hook",
+		"Authorization: Bearer $_nonce",
+	} {
+		if !strings.Contains(got, needle) {
+			t.Fatalf("expected template to contain %q", needle)
+		}
+	}
+}
+
+func TestHookScriptSubstitutesPort(t *testing.T) {
+	got := HookScript(19999)
+	if !strings.Contains(got, "19999") {
+		t.Fatal("expected template to contain the substituted port 19999")
+	}
+	// The default port line should have the substituted value, not a format directive.
+	// Note: %d also appears in date formats (%Y-%m-%dT) which is expected.
+	if strings.Contains(got, "${CC_CLIP_PORT:-%"+"d}") {
+		t.Fatal("template still contains unsubstituted port format directive")
+	}
+}
+
+func TestHookScriptDoesNotUseSessionToken(t *testing.T) {
+	got := HookScript(18339)
+	if strings.Contains(got, "session.token") {
+		t.Fatal("hook template must use notify.nonce, not session.token")
+	}
+}
+
+func TestHookScriptAlwaysExitsZero(t *testing.T) {
+	got := HookScript(18339)
+	if !strings.Contains(got, "exit 0") {
+		t.Fatal("hook script must always exit 0 to avoid blocking Claude Code")
+	}
+}
+
+func TestHookScriptIsValidBash(t *testing.T) {
+	got := HookScript(18339)
+	if !strings.HasPrefix(got, "#!/usr/bin/env bash") {
+		t.Fatal("hook script must start with bash shebang")
+	}
+	if !strings.Contains(got, "set -euo pipefail") {
+		t.Fatal("hook script must use strict mode")
+	}
+}

--- a/internal/shim/install_test.go
+++ b/internal/shim/install_test.go
@@ -128,6 +128,9 @@ func TestXclipShimContent(t *testing.T) {
 		"TARGETS",
 		"image/",
 		"_cc_clip_fallback",
+		"CC_CLIP_SESSION_FILE",
+		"X-CC-Clip-Session",
+		"_cc_clip_session_header",
 	}
 	for _, check := range checks {
 		if !strings.Contains(content, check) {

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -1,6 +1,8 @@
 package shim
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -198,6 +200,27 @@ func WriteRemoteTokenViaSession(session *SSHSession, tok string) error {
 	cmd.Stdin = strings.NewReader(tok + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote token: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// GenerateSessionID creates a random session identifier for transfer tracking.
+func GenerateSessionID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate session ID: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// WriteRemoteSessionID writes a session ID to ~/.cache/cc-clip/session.id on the remote.
+func WriteRemoteSessionID(session *SSHSession, sessionID string) error {
+	args := append(session.connArgs(), session.host,
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.id && chmod 600 ~/.cache/cc-clip/session.id")
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = strings.NewReader(sessionID + "\n")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write remote session ID: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -213,6 +213,92 @@ func GenerateSessionID() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
+// GenerateNotificationNonce creates a random nonce for notification auth.
+// Returns 32 random bytes encoded as a 64-character hex string.
+// This is intentionally longer than GenerateSessionID (16 bytes) to
+// ensure the two cannot be confused or accidentally swapped.
+func GenerateNotificationNonce() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate notification nonce: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// WriteRemoteNotificationNonce writes the notification nonce to
+// ~/.cache/cc-clip/notify.nonce on the remote with chmod 600.
+func WriteRemoteNotificationNonce(session *SSHSession, nonce string) error {
+	args := append(session.connArgs(), session.host,
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/notify.nonce && chmod 600 ~/.cache/cc-clip/notify.nonce")
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = strings.NewReader(nonce + "\n")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to write remote notification nonce: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// InstallRemoteHookScript writes the cc-clip-hook bash script to
+// ~/.local/bin/cc-clip-hook on the remote with chmod +x.
+func InstallRemoteHookScript(session *SSHSession, port int) error {
+	script := HookScript(port)
+	args := append(session.connArgs(), session.host,
+		"mkdir -p ~/.local/bin && cat > ~/.local/bin/cc-clip-hook && chmod +x ~/.local/bin/cc-clip-hook")
+	cmd := exec.Command("ssh", args...)
+	cmd.Stdin = strings.NewReader(script)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to install remote hook script: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+// RemoteHasCodex checks whether ~/.codex directory exists on the remote.
+func RemoteHasCodex(session *SSHSession) bool {
+	_, err := session.Exec("test -d ~/.codex")
+	return err == nil
+}
+
+// EnsureRemoteCodexNotifyConfig injects the cc-clip notification hook
+// block into ~/.codex/config.toml using # cc-clip-managed guard markers.
+// Idempotent: if the managed block already exists, it is replaced.
+func EnsureRemoteCodexNotifyConfig(session *SSHSession) error {
+	const markerStart = "# >>> cc-clip notify (do not edit) >>>"
+	const markerEnd = "# <<< cc-clip notify (do not edit) <<<"
+	const configPath = "~/.codex/config.toml"
+
+	managedBlock := codexNotifyManagedBlock(markerStart, markerEnd)
+
+	// Check if the managed block already exists.
+	out, _ := session.Exec(fmt.Sprintf("grep -F %q %s 2>/dev/null || true", markerStart, configPath))
+	if strings.Contains(out, markerStart) {
+		// Replace existing block using sed.
+		sedCmd := fmt.Sprintf(
+			`sed -i.cc-clip-bak '/%s/,/%s/d' %s 2>/dev/null; rm -f %s.cc-clip-bak`,
+			sedEscape(markerStart), sedEscape(markerEnd), configPath, configPath)
+		session.Exec(sedCmd)
+	}
+
+	// Append the managed block to the config file.
+	appendCmd := fmt.Sprintf(
+		"mkdir -p ~/.codex && cat >> %s << 'CC_CLIP_EOF'\n%s\nCC_CLIP_EOF",
+		configPath, managedBlock)
+	_, err := session.Exec(appendCmd)
+	if err != nil {
+		return fmt.Errorf("failed to inject notify config into %s: %w", configPath, err)
+	}
+
+	return nil
+}
+
+func codexNotifyManagedBlock(markerStart, markerEnd string) string {
+	// Codex notify is configured as a command array in config.toml. The payload
+	// JSON is provided on stdin, so the managed command reads from stdin instead
+	// of relying on shell interpolation.
+	return markerStart + "\n" +
+		`notify = ["cc-clip", "notify", "--from-codex-stdin"]` + "\n" +
+		markerEnd
+}
+
 // WriteRemoteSessionID writes a session ID to ~/.cache/cc-clip/session.id on the remote.
 func WriteRemoteSessionID(session *SSHSession, sessionID string) error {
 	args := append(session.connArgs(), session.host,

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -145,6 +145,62 @@ func TestConnArgsWithoutControlPath(t *testing.T) {
 	}
 }
 
+func TestGenerateNotificationNonce(t *testing.T) {
+	nonce, err := GenerateNotificationNonce()
+	if err != nil {
+		t.Fatalf("GenerateNotificationNonce failed: %v", err)
+	}
+	// 32 random bytes -> 64 hex characters
+	if len(nonce) != 64 {
+		t.Errorf("expected 64 hex chars, got %d: %q", len(nonce), nonce)
+	}
+	// Should be valid hex
+	for _, c := range nonce {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("nonce contains non-hex character: %c", c)
+		}
+	}
+}
+
+func TestGenerateNotificationNonceUniqueness(t *testing.T) {
+	nonce1, err := GenerateNotificationNonce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce2, err := GenerateNotificationNonce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if nonce1 == nonce2 {
+		t.Fatal("two consecutive nonces should not be equal")
+	}
+}
+
+func TestGenerateNotificationNonceDistinctFromSessionID(t *testing.T) {
+	nonce, err := GenerateNotificationNonce()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid, err := GenerateSessionID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Nonce is 64 hex chars (32 bytes), session ID is 32 hex chars (16 bytes)
+	if len(nonce) == len(sid) {
+		t.Errorf("nonce and session ID should have different lengths: nonce=%d, sid=%d", len(nonce), len(sid))
+	}
+}
+
+func TestCodexNotifyManagedBlockUsesConfigArray(t *testing.T) {
+	block := codexNotifyManagedBlock("start", "end")
+	if !strings.Contains(block, `notify = ["cc-clip", "notify", "--from-codex-stdin"]`) {
+		t.Fatalf("expected notify array config, got %q", block)
+	}
+	if strings.Contains(block, "[notify]") {
+		t.Fatalf("unexpected legacy [notify] table in %q", block)
+	}
+}
+
 // parseUnameOutput is a testable extraction of the uname parsing logic.
 // Both DetectRemoteArch and DetectRemoteArchViaSession use equivalent logic.
 func parseUnameOutput(output string) (string, string, error) {

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -12,6 +12,7 @@ set -euo pipefail
 CC_CLIP_PORT="${CC_CLIP_PORT:-%d}"
 CC_CLIP_ADDR="127.0.0.1:${CC_CLIP_PORT}"
 CC_CLIP_TOKEN_FILE="${CC_CLIP_TOKEN_FILE:-${HOME}/.cache/cc-clip/session.token}"
+CC_CLIP_SESSION_FILE="${CC_CLIP_SESSION_FILE:-${HOME}/.cache/cc-clip/session.id}"
 CC_CLIP_PROBE_TIMEOUT_MS="${CC_CLIP_PROBE_TIMEOUT_MS:-500}"
 CC_CLIP_FETCH_TIMEOUT_MS="${CC_CLIP_FETCH_TIMEOUT_MS:-5000}"
 CC_CLIP_TOTAL_TIMEOUT_MS="${CC_CLIP_TOTAL_TIMEOUT_MS:-8000}"
@@ -35,6 +36,12 @@ _cc_clip_read_token() {
     cat "$CC_CLIP_TOKEN_FILE"
 }
 
+_cc_clip_session_header() {
+    if [ -f "$CC_CLIP_SESSION_FILE" ]; then
+        echo "X-CC-Clip-Session: $(cat "$CC_CLIP_SESSION_FILE" 2>/dev/null)"
+    fi
+}
+
 _cc_clip_probe() {
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_PROBE_TIMEOUT_MS}/1000}")
@@ -54,9 +61,12 @@ _cc_clip_fetch_json() {
     token=$(_cc_clip_read_token) || return 12
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
     curl -sf --max-time "$timeout_s" \
         -H "Authorization: Bearer ${token}" \
         -H "User-Agent: cc-clip/0.1" \
+        ${session_hdr:+-H "$session_hdr"} \
         "http://${CC_CLIP_ADDR}${path}"
 }
 
@@ -67,12 +77,15 @@ _cc_clip_fetch_binary() {
     token=$(_cc_clip_read_token) || return 12
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
     local tmpfile
     tmpfile=$(mktemp 2>/dev/null) || return 20
     if curl -sf --max-time "$timeout_s" \
         -o "$tmpfile" \
         -H "Authorization: Bearer ${token}" \
         -H "User-Agent: cc-clip/0.1" \
+        ${session_hdr:+-H "$session_hdr"} \
         "http://${CC_CLIP_ADDR}${path}"; then
         # Guard against empty response (e.g. HTTP 204 No Content)
         if [ ! -s "$tmpfile" ]; then
@@ -151,6 +164,7 @@ set -euo pipefail
 CC_CLIP_PORT="${CC_CLIP_PORT:-%d}"
 CC_CLIP_ADDR="127.0.0.1:${CC_CLIP_PORT}"
 CC_CLIP_TOKEN_FILE="${CC_CLIP_TOKEN_FILE:-${HOME}/.cache/cc-clip/session.token}"
+CC_CLIP_SESSION_FILE="${CC_CLIP_SESSION_FILE:-${HOME}/.cache/cc-clip/session.id}"
 CC_CLIP_PROBE_TIMEOUT_MS="${CC_CLIP_PROBE_TIMEOUT_MS:-500}"
 CC_CLIP_FETCH_TIMEOUT_MS="${CC_CLIP_FETCH_TIMEOUT_MS:-5000}"
 REAL_WL_PASTE="%s"
@@ -173,6 +187,12 @@ _cc_clip_read_token() {
     cat "$CC_CLIP_TOKEN_FILE"
 }
 
+_cc_clip_session_header() {
+    if [ -f "$CC_CLIP_SESSION_FILE" ]; then
+        echo "X-CC-Clip-Session: $(cat "$CC_CLIP_SESSION_FILE" 2>/dev/null)"
+    fi
+}
+
 _cc_clip_probe() {
     if command -v nc >/dev/null 2>&1; then
         nc -z -w 1 "${CC_CLIP_ADDR%%%%:*}" "${CC_CLIP_ADDR##*:}" 2>/dev/null
@@ -187,9 +207,12 @@ _cc_clip_fetch_json() {
     token=$(cat "$CC_CLIP_TOKEN_FILE" 2>/dev/null) || return 12
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
     curl -sf --max-time "$timeout_s" \
         -H "Authorization: Bearer ${token}" \
         -H "User-Agent: cc-clip/0.1" \
+        ${session_hdr:+-H "$session_hdr"} \
         "http://${CC_CLIP_ADDR}${path}"
 }
 
@@ -199,12 +222,15 @@ _cc_clip_fetch_binary() {
     token=$(cat "$CC_CLIP_TOKEN_FILE" 2>/dev/null) || return 12
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
     local tmpfile
     tmpfile=$(mktemp 2>/dev/null) || return 20
     if curl -sf --max-time "$timeout_s" \
         -o "$tmpfile" \
         -H "Authorization: Bearer ${token}" \
         -H "User-Agent: cc-clip/0.1" \
+        ${session_hdr:+-H "$session_hdr"} \
         "http://${CC_CLIP_ADDR}${path}"; then
         # Guard against empty response (e.g. HTTP 204 No Content)
         if [ ! -s "$tmpfile" ]; then

--- a/internal/x11bridge/bridge.go
+++ b/internal/x11bridge/bridge.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -327,6 +328,17 @@ func (b *Bridge) readToken() (string, error) {
 	return tok, nil
 }
 
+// readSessionID reads the session ID from the session.id file next to the token file.
+// Returns empty string (not error) if file doesn't exist, since session tracking is optional.
+func (b *Bridge) readSessionID() string {
+	dir := filepath.Dir(b.tokenFile)
+	data, err := os.ReadFile(filepath.Join(dir, "session.id"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // fetchClipboardType queries the cc-clip daemon for clipboard content type.
 func (b *Bridge) fetchClipboardType() (*clipboardTypeResponse, error) {
 	tok, err := b.readToken()
@@ -341,6 +353,9 @@ func (b *Bridge) fetchClipboardType() (*clipboardTypeResponse, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+tok)
 	req.Header.Set("User-Agent", "cc-clip/0.1")
+	if sid := b.readSessionID(); sid != "" {
+		req.Header.Set("X-CC-Clip-Session", sid)
+	}
 
 	resp, err := b.httpClient.Do(req)
 	if err != nil {
@@ -377,6 +392,9 @@ func (b *Bridge) fetchClipboardImage() ([]byte, error) {
 	}
 	req.Header.Set("Authorization", "Bearer "+tok)
 	req.Header.Set("User-Agent", "cc-clip/0.1")
+	if sid := b.readSessionID(); sid != "" {
+		req.Header.Set("X-CC-Clip-Session", sid)
+	}
 
 	resp, err := b.httpClient.Do(req)
 	if err != nil {

--- a/scripts/cc-clip-notify.swift
+++ b/scripts/cc-clip-notify.swift
@@ -1,0 +1,96 @@
+import Foundation
+import AppKit
+import UserNotifications
+
+// cc-clip-notify: Minimal notification helper with image attachment support.
+// Must run from within a .app bundle to provide CFBundleIdentifier.
+//
+// Usage: cc-clip-notify --title T --subtitle S [--body B] [--image /path/to/img]
+//        cc-clip-notify --register  (request permission and wait for user response)
+
+func parseArgs() -> (title: String, subtitle: String, body: String?, imagePath: String?, register: Bool) {
+    let args = CommandLine.arguments
+    var title = "cc-clip"
+    var subtitle = ""
+    var body: String? = nil
+    var imagePath: String? = nil
+    var register = false
+
+    var i = 1
+    while i < args.count {
+        switch args[i] {
+        case "--title" where i + 1 < args.count:
+            i += 1; title = args[i]
+        case "--subtitle" where i + 1 < args.count:
+            i += 1; subtitle = args[i]
+        case "--body" where i + 1 < args.count:
+            i += 1; body = args[i]
+        case "--image" where i + 1 < args.count:
+            i += 1; imagePath = args[i]
+        case "--register":
+            register = true
+        default:
+            break
+        }
+        i += 1
+    }
+    return (title, subtitle, body, imagePath, register)
+}
+
+let params = parseArgs()
+
+// NSApplication is needed for the notification permission dialog to appear
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+
+let center = UNUserNotificationCenter.current()
+
+func sendNotification() {
+    center.requestAuthorization(options: [.alert]) { granted, error in
+        guard granted else {
+            if let e = error { fputs("auth error: \(e)\n", stderr) }
+            else { fputs("notifications denied\n", stderr) }
+            exit(1)
+        }
+
+        if params.register {
+            fputs("notifications authorized\n", stderr)
+            exit(0)
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = params.title
+        content.subtitle = params.subtitle
+        if let body = params.body, !body.isEmpty {
+            content.body = body
+        }
+
+        if let imgPath = params.imagePath {
+            let url = URL(fileURLWithPath: imgPath)
+            if let attachment = try? UNNotificationAttachment(
+                identifier: "image",
+                url: url,
+                options: nil
+            ) {
+                content.attachments = [attachment]
+            }
+        }
+
+        let id = "cc-clip-\(ProcessInfo.processInfo.globallyUniqueString)"
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+        center.add(request) { error in
+            if let e = error { fputs("deliver error: \(e)\n", stderr) }
+            // Give notification center time to process
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                exit(0)
+            }
+        }
+    }
+}
+
+DispatchQueue.main.async {
+    sendNotification()
+}
+
+// Run the app event loop (needed for permission dialog)
+app.run()


### PR DESCRIPTION
## Summary

- **v0.5.0: Clipboard preview notification** — Local macOS notifications on image transfer with session tracking, duplicate detection, and click-to-preview via terminal-notifier
- **v0.6.0: SSH notification bridge** — Transport bridge carrying Claude Code hook events, Codex notify payloads, and generic CLI notifications from remote servers through the existing SSH tunnel to local macOS/cmux notification systems
- **Dedup runtime integration** — 12s window dedup wired into the notification pipeline; permission_prompt bypasses dedup

### Notification Bridge Architecture

```
Remote (Claude Code hook / Codex notify / cc-clip notify CLI)
    → HTTP POST /notify (via SSH RemoteForward tunnel)
    → Local daemon: nonce auth → classify → dedup → DeliveryChain
    → cmux (fallback) → macOS terminal-notifier/osascript
```

### Key Design Decisions

- **Transport bridge, not notification UI** — delivers to user's existing tools (cmux, macOS)
- **Dedicated notification nonce** — separate from clipboard token, prevents spoofing
- **DeliveryChain** — cmux first with fallthrough to macOS on failure
- **Dual channels** — criticalCh (500ms timeout) for permission_prompt, notifyCh (drop on full) for normal
- **`[unverified]` prefix** — generic JSON notifications visually distinguished from authenticated Claude hooks
- **Codex auto-detection** — `connect` detects `~/.codex/` and injects notify config automatically
- **Health logging** — hook failures logged to `~/.cache/cc-clip/notify-health.log`

### New Components

| Component | Description |
|-----------|-------------|
| `POST /notify` endpoint | Dual-format (Claude hook JSON + generic schema) with nonce auth |
| `NotifyEnvelope` model | Unified: image_transfer / tool_attention / generic_message |
| Hook classifier | Translates Claude Code hook JSON → structured notifications |
| Dedup engine | 12s window, permission_prompt exempt |
| `DeliveryChain` | cmux → macOS fallback chain |
| `cc-clip-hook.sh` template | Remote Claude Code hook script with health logging |
| `cc-clip notify` subcommand | Generic CLI + `--from-codex-stdin` for Codex |
| Connect automation | Nonce gen, hook install, Codex config injection, health probe |

## Test plan

- [x] `go test ./... -count=1` — all 13 packages pass
- [x] `go vet ./...` — clean
- [x] ~70+ new tests covering classifier, dedup, delivery chain, /notify endpoint, nonce auth, hook template, Codex parsing
- [x] Code review: 2 CRITICALs fixed (criticalCh deadlock, nonce/token cross-contamination)
- [x] Design review: 7 issues fixed (Codex contract, chain fallback, PreToolUse dedup, etc.)
- [ ] Manual: SSH connect → remote Claude Code hook → local notification
- [ ] Manual: SSH connect → remote Codex notify → local notification
- [ ] Manual: cmux adapter verification (if cmux available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)