### PR TITLE
docs: update CLAUDE.md and optimize README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Does
 
-cc-clip bridges your local Mac clipboard to a remote Linux server over SSH, so `Ctrl+V` image paste works in remote Claude Code and Codex CLI sessions. It uses an xclip/wl-paste shim that transparently intercepts only Claude Code's clipboard calls, and an X11 selection owner bridge for Codex CLI which reads the clipboard via X11 directly.
+cc-clip bridges your local Mac/Windows clipboard to a remote Linux server over SSH, so `Ctrl+V` image paste works in remote Claude Code and Codex CLI sessions. It uses an xclip/wl-paste shim that transparently intercepts only Claude Code's clipboard calls, an X11 selection owner bridge for Codex CLI which reads the clipboard via X11 directly, and an SSH notification bridge that forwards Claude Code hook events (stop, permission prompt, idle) back to the local machine as native notifications.
 
 ```
 Claude Code path:
@@ -12,6 +12,9 @@ Claude Code path:
 
 Codex CLI path (--codex):
   Local Mac clipboard → pngpaste → HTTP daemon (127.0.0.1:18339) → SSH RemoteForward → x11-bridge → Xvfb CLIPBOARD → arboard → Codex CLI
+
+Notification path:
+  Claude Code hook → cc-clip-hook (stdin JSON) → POST /notify via tunnel → classifier → dedup → DeliveryChain → native notification
 ```
 
 ## Build & Test Commands
@@ -41,6 +44,18 @@ Version is injected via `-X main.version=$(VERSION)` ldflags. The `version` vari
 9. **xvfb** (`internal/xvfb/`) — Manages Xvfb virtual X server on remote. `StartRemote()` auto-detects display via `-displayfd`, reuses healthy instances, writes PID/display to `~/.cache/cc-clip/codex/`. `StopRemote()` verifies PID+command before killing.
 10. **x11bridge** (`internal/x11bridge/`) — Go X11 selection owner using `github.com/jezek/xgb` (pure Go, no CGo). Claims CLIPBOARD ownership on Xvfb, responds to SelectionRequest events by fetching image data on-demand from the cc-clip HTTP daemon via SSH tunnel. Supports TARGETS negotiation, direct transfer, and INCR protocol for images >256KB.
 
+### Notification Bridge
+
+11. **session** (`internal/session/`) — Ring-buffer session store tracking last 5 image transfers per session ID. `AnalyzeAndRecord()` atomically assigns sequence numbers and detects duplicates by fingerprint. TTL-based cleanup via `RunCleanup()`.
+12. **classifier** (`internal/daemon/classifier.go`) — `ClassifyHookPayload()` translates Claude Code hook JSON (notification, stop, etc.) into a unified `NotifyEnvelope`. Maps hook types to urgency levels: `permission_prompt`=2, `idle_prompt`=1, `stop_at_end_of_turn`=0.
+13. **envelope** (`internal/daemon/envelope.go`) — Unified notification model. Three kinds: `KindImageTransfer`, `KindToolAttention`, `KindGenericMessage`. Each carries kind-specific payload structs.
+14. **dedup** (`internal/daemon/dedup.go`) — Deduplicates notifications by fingerprint within a session using the session store's ring buffer.
+15. **deliver** (`internal/daemon/deliver.go`) — `DeliveryChain` tries adapters in priority order (cmux → platform-native). First success stops the chain. `BuildDeliveryChain()` constructs the default chain. Also implements `Notifier` interface for backward compat.
+16. **deliver_cmux** (`internal/daemon/deliver_cmux.go`) — Cross-platform tmux `display-message` adapter. Falls through if not in tmux.
+17. **notify_darwin** (`internal/daemon/notify_darwin.go`) — macOS-specific: terminal-notifier or osascript fallback.
+18. **claude wrapper** (`internal/shim/claude_wrapper.go`) — Bash script installed to `~/.local/bin/claude` on remote. Auto-injects `--settings` with Stop and Notification hooks when tunnel is alive. Falls through to real claude binary when tunnel is down.
+19. **cc-clip-hook** (`internal/shim/hook_template.go`) — Bash script installed to `~/.local/bin/cc-clip-hook` on remote. Reads hook JSON from stdin, injects hostname, POSTs to `/notify` endpoint with nonce auth. Logs failures to `~/.cache/cc-clip/notify-health.log`.
+
 ### Key Design Decisions
 
 - **Shim is a bash script, not a binary** — installed to `~/.local/bin/` with PATH priority over `/usr/bin/xclip`. Uses `which -a` to find the real binary, skipping its own directory.
@@ -48,11 +63,15 @@ Version is injected via `-X main.version=$(VERSION)` ldflags. The `version` vari
 - **Binary-safe image transfer** in shim — `_cc_clip_fetch_binary()` uses `mktemp` + `curl -o tmpfile` + `cat tmpfile`, not shell variables (which strip NUL bytes) or `exec curl` (which prevents fallback). After curl succeeds, `[ ! -s "$tmpfile" ]` guards against empty responses (e.g., HTTP 204), returning exit code 10 to trigger fallback instead of outputting empty data.
 - **Server-side empty guard** — `handleClipboardImage` checks `len(data) == 0` after `ImageBytes()` and returns 204, preventing 200 with empty body even if the clipboard reader returns empty data without error.
 - **Exit codes are segmented** (`internal/exitcode/`) — 0 success, 10-13 business errors (no image, tunnel down, bad token, download failed), 20+ internal. Business codes trigger transparent fallback in the shim.
-- **Platform clipboard** — `clipboard_darwin.go` (pngpaste), `clipboard_linux.go` (xclip/wl-paste), `clipboard_windows.go` (PowerShell, not shipped in releases yet).
+- **Platform clipboard** — `clipboard_darwin.go` (pngpaste), `clipboard_linux.go` (xclip/wl-paste), `clipboard_windows.go` (PowerShell). Windows uses SCP upload workflow with system tray icon and global hotkey (`Ctrl+Alt+V`).
 - **Codex uses X11, not shims** — Codex CLI uses `arboard` (Rust crate) which accesses X11 CLIPBOARD directly in-process. Cannot be shimmed. Solution: Xvfb + Go X11 selection owner that claims CLIPBOARD and serves images on-demand.
 - **On-demand fetch in x11-bridge** — No polling or caching. Image data is fetched from the cc-clip daemon only when a SelectionRequest arrives. Always fresh.
 - **Token per-request in x11-bridge** — Token is read from file on every HTTP request, enabling `--token-only` rotation without restarting the bridge.
 - **DISPLAY injection is file-driven** — The DISPLAY marker block in shell rc reads from `~/.cache/cc-clip/codex/display` at shell startup, not a hardcoded value. This supports `-displayfd` dynamic allocation.
+- **Notification uses nonce auth, not session token** — `/notify` endpoint authenticates with a separate nonce (stored at `~/.cache/cc-clip/notify.nonce`), not the clipboard Bearer token. This allows independent rotation.
+- **Claude wrapper is conditional** — Only injects `--settings` hooks when the cc-clip tunnel is reachable (health check). When the tunnel is down, passes through transparently so Claude Code still works normally.
+- **DeliveryChain fallthrough** — Notification adapters are tried in priority order (cmux → platform-native). First success stops the chain. If all fail, the last error is returned but the hook script always exits 0 (non-blocking).
+- **Hook script is fire-and-forget** — `cc-clip-hook` always exits 0 to avoid blocking Claude Code. Failures are logged to a health file, not propagated.
 
 ### Token Lifecycle
 
@@ -65,6 +84,12 @@ Version is injected via `-X main.version=$(VERSION)` ldflags. The `version` vari
 - `internal/shim/install_test.go` uses temp directories to test shim installation without touching real PATH.
 - `internal/xvfb/xvfb_test.go` uses `requireXvfb` skip guard — integration tests skip on macOS (no Xvfb available).
 - `internal/x11bridge/bridge_test.go` uses `requireXvfbAndXclip` skip guard — E2E smoke test runs mock HTTP + Xvfb + x11-bridge + xclip roundtrip.
+- `internal/daemon/classifier_test.go` — Tests hook JSON classification into envelopes for each hook type (notification, stop, unknown).
+- `internal/daemon/dedup_test.go` — Tests duplicate detection in the ring buffer across sessions.
+- `internal/daemon/deliver_test.go` — Tests DeliveryChain fallthrough behavior with mock adapters.
+- `internal/shim/claude_wrapper_test.go` — Validates wrapper script port substitution.
+- `internal/shim/hook_template_test.go` — Validates hook script port substitution.
+- `internal/session/session_test.go` — Tests ring-buffer wrap-around and TTL cleanup.
 
 ### Shim Interception Patterns
 
@@ -98,3 +123,6 @@ When `connect` detects a different remote arch (e.g., Mac arm64 → Linux amd64)
 - Changing token format: `token/token.go` + `shim/connect.go:WriteRemoteToken` + shim templates (`_cc_clip_read_token`)
 - Adding a new exit code: `exitcode/exitcode.go` + `cmd/cc-clip/main.go:classifyError` + shim templates (return codes)
 - Changing Codex deploy flow: `cmd/cc-clip/main.go:runConnectCodex` + `xvfb/xvfb.go` + `x11bridge/bridge.go` + `shim/pathfix.go` (DISPLAY marker)
+- Adding a new notification kind: `daemon/envelope.go` (NotifyKind + payload struct) + `daemon/classifier.go` (hook→envelope mapping) + `daemon/deliver.go` (formatNotification display text)
+- Changing hook injection: `shim/claude_wrapper.go` (wrapper template) + `shim/hook_template.go` (hook script) + `shim/connect.go` (deploy steps)
+- Adding a notification adapter: implement `Deliverer` interface + register in `daemon/deliver.go:BuildDeliveryChain()`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center">
   <a href="https://github.com/ShunmeiCho/cc-clip/releases"><img src="https://img.shields.io/github/v/release/ShunmeiCho/cc-clip?color=D97706" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a>
-  <a href="https://go.dev"><img src="https://img.shields.io/badge/Go-1.21+-00ADD8.svg" alt="Go"></a>
+  <a href="https://go.dev"><img src="https://img.shields.io/badge/Go-1.25+-00ADD8.svg" alt="Go"></a>
   <a href="https://github.com/ShunmeiCho/cc-clip/stargazers"><img src="https://img.shields.io/github/stars/ShunmeiCho/cc-clip?style=social" alt="Stars"></a>
 </p>
 
@@ -17,6 +17,33 @@
   <br>
   <em>Install → setup → paste. Clipboard works over SSH.</em>
 </p>
+
+---
+
+<details>
+<summary><b>Table of Contents</b></summary>
+
+- [The Problem](#the-problem)
+- [The Solution](#the-solution)
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Why cc-clip?](#why-cc-clip)
+- [How It Works](#how-it-works)
+- [SSH Notifications](#ssh-notifications)
+- [Security](#security)
+- [Daily Usage](#daily-usage)
+- [Commands](#commands)
+- [Configuration](#configuration)
+- [Platform Support](#platform-support)
+- [Requirements](#requirements)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+- [Related](#related)
+- [License](#license)
+
+</details>
+
+---
 
 ## The Problem
 
@@ -93,17 +120,11 @@ cc-clip --version
 
 ### Step 2: Setup (one command)
 
-macOS:
-
 ```bash
-# For Claude Code only
 cc-clip setup myserver
-
-# For both Claude Code + Codex CLI
-cc-clip setup myserver --codex
 ```
 
-This single command:
+This single command handles everything:
 1. Installs local dependencies (`pngpaste`)
 2. Configures SSH (`RemoteForward`, `ControlMaster no`)
 3. Starts the local daemon (via macOS launchd)
@@ -116,33 +137,37 @@ This single command:
 </p>
 </details>
 
-> **If setup reports an error**, read the error message carefully — it includes specific instructions for how to fix the issue. For example, if `Xvfb` is not found on the remote server and auto-install fails, you will see the exact command to run:
->
-> ```bash
-> # SSH into your server and install manually:
-> ssh myserver
-> sudo apt install xvfb          # Debian/Ubuntu
-> sudo dnf install xorg-x11-server-Xvfb   # RHEL/Fedora
-> ```
->
-> After fixing, re-run `cc-clip setup myserver --codex`.
+<details>
+<summary>Also use Codex CLI? Add <code>--codex</code></summary>
 
-Windows:
+```bash
+cc-clip setup myserver --codex
+```
 
-Use the dedicated guide:
+This additionally installs Xvfb and the x11-bridge on the remote. If `Xvfb` is not found and auto-install fails, you'll see the exact command to run:
+
+```bash
+ssh myserver
+sudo apt install xvfb          # Debian/Ubuntu
+sudo dnf install xorg-x11-server-Xvfb   # RHEL/Fedora
+```
+
+Then re-run `cc-clip setup myserver --codex`.
+
+</details>
+
+<details>
+<summary>Windows? Use the dedicated guide</summary>
 
 - [Windows Quick Start](docs/windows-quickstart.md)
 
-<details>
-<summary>See it in action (Windows)</summary>
 <p align="center">
   <img src="docs/marketing/demo-windows.gif" alt="cc-clip Windows demo" width="720">
 </p>
+
 </details>
 
 ### Step 3: Connect and use
-
-macOS:
 
 Open a **new** SSH session to your server (the tunnel activates on SSH connection):
 
@@ -153,12 +178,6 @@ ssh myserver
 Then use Claude Code or Codex CLI as normal — `Ctrl+V` now pastes images from your Mac clipboard.
 
 > **Important:** The image paste works through the SSH tunnel. You must connect via `ssh myserver` (the host you set up). The tunnel is established on each SSH connection.
-
-Windows:
-
-See:
-
-- [Windows Quick Start](docs/windows-quickstart.md)
 
 ### Verify it works
 
@@ -692,13 +711,19 @@ See [Troubleshooting Guide](docs/troubleshooting.md) for detailed diagnostics, o
 
 ## Contributing
 
-Contributions and bug reports welcome. Please [open an issue](https://github.com/ShunmeiCho/cc-clip/issues) first for major changes.
+Contributions welcome! For bug reports and feature requests, [open an issue](https://github.com/ShunmeiCho/cc-clip/issues).
+
+For code contributions:
 
 ```bash
 git clone https://github.com/ShunmeiCho/cc-clip.git
 cd cc-clip
 make build && make test
 ```
+
+- **Bug fixes:** Open a PR directly with a clear description of the fix
+- **New features:** Open an issue first to discuss the approach
+- **Commit style:** [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.)
 
 ## Related
 


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Add notification bridge subsystem architecture (session, classifier, envelope, dedup, delivery chain, claude wrapper, hook template), update Windows platform note, add coordinated change entries
- **README.md**: Add collapsible TOC, fix Go badge (1.21→1.25), restructure Quick Start with progressive disclosure (Codex/Windows in `<details>`), enhance Contributing section

## Test plan
- [ ] Verify TOC links resolve correctly on GitHub
- [ ] Confirm mermaid diagram still renders
- [ ] Check `<details>` sections expand/collapse properly
- [ ] Verify Go badge shows 1.25+

🤖 Generated with [Claude Code](https://claude.com/claude-code)