### PR TITLE
fix: restore goreleaser release pipeline (closes #24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+      - name: Verify release contract
+        run: |
+          # goreleaser must produce cc-clip_{version}_{os}_{arch}.tar.gz
+          grep -qP 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
+          # install.sh must expect the same format with version stripped of v prefix
+          grep -q 'cc-clip_${VERSION#v}_${PLATFORM}.tar.gz' scripts/install.sh
+          # archive format must be tar.gz (not bare binary)
+          grep -q 'format: tar.gz' .goreleaser.yaml
+
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ release:
   github:
     owner: ShunmeiCho
     name: cc-clip
-  draft: true
+  draft: false
   prerelease: auto
 
 changelog:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,24 @@ make build                          # Build binary with version from git tags
 make test                           # Run all tests (go test ./... -count=1)
 make vet                            # Run go vet
 go test ./internal/tunnel/ -v -run TestFetchImageRoundTrip  # Single test
-make release-local                  # Build for all platforms (dist/)
+make release-local                  # Build bare binaries for all platforms (dist/), local testing only
 ```
 
 Version is injected via `-X main.version=$(VERSION)` ldflags. The `version` variable in `cmd/cc-clip/main.go` defaults to `"dev"`.
+
+### Release Process
+
+Production releases use **goreleaser** via GitHub Actions (`.github/workflows/release.yml`). Push a version tag to trigger:
+
+```bash
+git tag v0.6.0
+git push origin v0.6.0
+# CI runs: test → contract check → goreleaser → published release with tar.gz + checksums
+```
+
+**NEVER release manually with `make release-local` + `gh release create`.** The install script (`scripts/install.sh`) expects goreleaser's naming convention (`cc-clip_{version}_{os}_{arch}.tar.gz`). Bare binaries from `make release-local` use a different naming scheme (`cc-clip-{os}-{arch}`) and will cause install script 404s. `make release-local` is for local cross-compilation testing only.
+
+goreleaser config: `.goreleaser.yaml`. Release is published automatically (not draft).
 
 ## Architecture
 
@@ -126,3 +140,4 @@ When `connect` detects a different remote arch (e.g., Mac arm64 → Linux amd64)
 - Adding a new notification kind: `daemon/envelope.go` (NotifyKind + payload struct) + `daemon/classifier.go` (hook→envelope mapping) + `daemon/deliver.go` (formatNotification display text)
 - Changing hook injection: `shim/claude_wrapper.go` (wrapper template) + `shim/hook_template.go` (hook script) + `shim/connect.go` (deploy steps)
 - Adding a notification adapter: implement `Deliverer` interface + register in `daemon/deliver.go:BuildDeliveryChain()`
+- Changing release asset format: `.goreleaser.yaml` (archive naming/format) + `scripts/install.sh` (download URL + extraction logic) — these MUST stay in sync

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,12 @@ make test
 make build          # Build binary
 make test           # Run all tests
 make vet            # Run go vet
-make release-local  # Cross-compile for all platforms
+make release-local  # Cross-compile for local testing only (NOT for GitHub releases)
 ```
+
+> **Warning:** `make release-local` produces bare binaries with different naming than
+> goreleaser. Never upload these to GitHub Releases — the install script will 404.
+> Production releases are automated via GitHub Actions on tag push. See CLAUDE.md.
 
 ## How to Contribute
 

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -243,11 +243,23 @@ func cmdServe() {
 	log.Printf("Token expires at: %s", sess.ExpiresAt.Format(time.RFC3339))
 	log.Printf("Starting daemon on %s", addr)
 
-	// Start notification delivery and session cleanup in background
+	// Start notification delivery, session cleanup, and nonce cleanup in background
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go srv.RunNotifier(ctx, daemon.BuildDeliveryChain())
 	go store.RunCleanup(ctx, 30*time.Minute)
+	go func() {
+		ticker := time.NewTicker(1 * time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				srv.CleanupExpiredNonces()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("server error: %v", err)
@@ -611,6 +623,7 @@ func runConnect(opts connectOpts) {
 			needsShim = true
 		}
 	}
+	var installOut string
 	if needsShim {
 		fmt.Printf("[5/7] Installing shim...\n")
 		installCmd := fmt.Sprintf("%s install --port %d", remoteBin, port)
@@ -623,6 +636,7 @@ func runConnect(opts connectOpts) {
 				log.Fatalf("      remote install failed: %s: %v", out, err)
 			}
 		}
+		installOut = out
 		fmt.Printf("      %s\n", out)
 	} else {
 		fmt.Println("[5/7] Shim already installed, skipping")
@@ -665,15 +679,22 @@ func runConnect(opts connectOpts) {
 
 	// Update remote deploy state
 	localHash, _ := shim.LocalBinaryHash(localBin)
+	// Determine actual shim target from install output or prior state.
+	shimTarget := "xclip"
+	if needsShim {
+		// Parse install output: it prints "Installed shim: <target>"
+		if strings.Contains(installOut, "wl-paste") {
+			shimTarget = "wl-paste"
+		}
+	} else if remoteState != nil && remoteState.ShimTarget != "" {
+		shimTarget = remoteState.ShimTarget
+	}
 	newState := &shim.DeployState{
 		BinaryHash:    localHash,
 		BinaryVersion: version,
 		ShimInstalled: true,
-		ShimTarget:    "xclip",
+		ShimTarget:    shimTarget,
 		PathFixed:     pathFixed,
-	}
-	if remoteState != nil && remoteState.ShimTarget != "" {
-		newState.ShimTarget = remoteState.ShimTarget
 	}
 	// Preserve existing codex state when not using --codex.
 	if remoteState != nil && remoteState.Codex != nil && !opts.codex {

--- a/internal/daemon/clipboard_darwin.go
+++ b/internal/daemon/clipboard_darwin.go
@@ -46,9 +46,12 @@ func (c *darwinClipboard) Type() (ClipboardInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), clipboardTimeout)
 	defer cancel()
 
-	// Try pngpaste first to detect image
+	// Try pngpaste first to detect image.
+	// Discard stdout to prevent binary image data from leaking to the daemon's output.
 	if pngpastePath := findPngpaste(); pngpastePath != "" {
 		cmd := exec.CommandContext(ctx, pngpastePath, "-")
+		cmd.Stdout = nil
+		cmd.Stderr = nil
 		if err := cmd.Run(); err == nil {
 			return ClipboardInfo{Type: ClipboardImage, Format: "png"}, nil
 		}

--- a/internal/daemon/notify_darwin.go
+++ b/internal/daemon/notify_darwin.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 )
 
 // DarwinNotifier delivers macOS notifications with image thumbnails
@@ -17,13 +18,41 @@ type DarwinNotifier struct {
 	terminalNotifier   string // path to terminal-notifier binary, empty if not found
 }
 
+// maxPreviewFiles limits the number of preview images retained on disk.
+const maxPreviewFiles = 50
+
 func NewDarwinNotifier() *DarwinNotifier {
 	home, _ := os.UserHomeDir()
 	dir := filepath.Join(home, ".cache", "cc-clip", "previews")
 	os.MkdirAll(dir, 0700)
+	cleanupPreviews(dir, maxPreviewFiles)
 
 	tn, _ := exec.LookPath("terminal-notifier")
 	return &DarwinNotifier{previewDir: dir, terminalNotifier: tn}
+}
+
+// cleanupPreviews removes the oldest preview files when the count exceeds max.
+// Uses modification time for accurate ordering regardless of filename format.
+func cleanupPreviews(dir string, max int) {
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) <= max {
+		return
+	}
+	type fileWithTime struct {
+		name    string
+		modTime int64
+	}
+	files := make([]fileWithTime, 0, len(entries))
+	for _, e := range entries {
+		if info, err := e.Info(); err == nil {
+			files = append(files, fileWithTime{name: e.Name(), modTime: info.ModTime().UnixNano()})
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].modTime < files[j].modTime })
+	toRemove := len(files) - max
+	for i := 0; i < toRemove; i++ {
+		os.Remove(filepath.Join(dir, files[i].name))
+	}
 }
 
 // platformDeliverer returns the darwin-specific notification adapter.
@@ -59,6 +88,7 @@ func (n *DarwinNotifier) Deliver(_ context.Context, env NotifyEnvelope) error {
 			path := filepath.Join(n.previewDir, fmt.Sprintf("preview-%s-%d%s", sid, p.Seq, ext))
 			if err := os.WriteFile(path, p.ImageData, 0600); err == nil {
 				imagePath = path
+				cleanupPreviews(n.previewDir, maxPreviewFiles)
 			}
 		}
 	}
@@ -89,6 +119,8 @@ func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
 		previewPath = filepath.Join(n.previewDir, fmt.Sprintf("preview-%s-%d%s", sid, evt.Seq, ext))
 		if err := os.WriteFile(previewPath, evt.ImageData, 0600); err != nil {
 			previewPath = ""
+		} else {
+			cleanupPreviews(n.previewDir, maxPreviewFiles)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Restores goreleaser as the sole release mechanism, fixing install script 404s caused by v0.5.0's manual bare-binary release
- Adds GitHub Actions CI for automated releases on tag push
- Fixes 9 additional issues found by two rounds of cross-AI adversarial audit (Codex)

## Root Cause

v0.5.0 was released with `make release-local` + manual upload, producing bare binaries (`cc-clip-darwin-arm64`) instead of goreleaser tarballs (`cc-clip_0.5.0_darwin_arm64.tar.gz`). The install script expects the goreleaser format.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | New CI: tag push -> test -> contract check -> goreleaser |
| `.goreleaser.yaml` | `draft: true` -> `draft: false` (so `/releases/latest` works) |
| `cmd/cc-clip/main.go` | Fix ShimTarget detection + add nonce cleanup goroutine |
| `internal/daemon/clipboard_darwin.go` | Explicit stdout discard in pngpaste type check |
| `internal/daemon/notify_darwin.go` | Preview image cleanup (max 50, mtime-sorted) |
| `CLAUDE.md` | Release Process docs + coordinated changes |
| `CONTRIBUTING.md` | Warning about `make release-local` misuse |

## Test plan

- [x] `make vet` passes
- [x] `make test` passes (all 12 packages)
- [x] `sh -n scripts/install.sh` syntax check passes
- [x] Verified install.sh URL format matches goreleaser name_template
- [x] Verified against all 8 historical releases (v0.1.0-v0.5.0)
- [ ] Tag v0.5.1 after merge to verify CI end-to-end

Closes #24