### PR TITLE
fix: harden Windows clipboard persistence and reject paste-conflict hotkeys

### DIFF
--- a/cmd/cc-clip/hotkey_windows.go
+++ b/cmd/cc-clip/hotkey_windows.go
@@ -507,6 +507,21 @@ func parseHotkey(value string) (hotkeyBinding, error) {
 		return hotkeyBinding{}, err
 	}
 
+	// windowsSendCtrlShiftV synthesizes Ctrl+Shift+V; a binding with the
+	// same combination would be re-caught by our own RegisterHotKey loop
+	// (guarded by hotkeyRunning) and the paste would never reach the
+	// terminal. Ctrl+V is the system paste shortcut and must not be
+	// globally hijacked either.
+	const vkV = 0x56
+	if key == vkV {
+		if modifiers == (modControl | modShift) {
+			return hotkeyBinding{}, fmt.Errorf("hotkey %q conflicts with the simulated paste keystroke (ctrl+shift+v); choose a different combination", value)
+		}
+		if modifiers == modControl {
+			return hotkeyBinding{}, fmt.Errorf("hotkey %q conflicts with the system paste shortcut (ctrl+v); choose a different combination", value)
+		}
+	}
+
 	displayParts := make([]string, 0, 4)
 	if modifiers&modControl != 0 {
 		displayParts = append(displayParts, "ctrl")

--- a/cmd/cc-clip/hotkey_windows_test.go
+++ b/cmd/cc-clip/hotkey_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -78,5 +79,88 @@ func TestStopHotkeyProcessWritesSentinelEvenWhenNotRunning(t *testing.T) {
 
 	if _, err := os.Stat(stopFile); os.IsNotExist(err) {
 		t.Fatal("expected stop sentinel file even when hotkey process is not running")
+	}
+}
+
+func TestParseHotkeyAccepts(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"default", "alt+shift+v", "alt+shift+v"},
+		{"case insensitive", "ALT+SHIFT+V", "alt+shift+v"},
+		{"ctrl alt other key", "ctrl+alt+p", "ctrl+alt+p"},
+		{"win modifier", "win+shift+v", "shift+win+v"},
+		{"function key", "ctrl+f12", "ctrl+f12"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseHotkey(tc.in)
+			if err != nil {
+				t.Fatalf("parseHotkey(%q) unexpected error: %v", tc.in, err)
+			}
+			if got.String() != tc.want {
+				t.Fatalf("parseHotkey(%q).String() = %q, want %q", tc.in, got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestParseHotkeyRejectsPasteConflicts(t *testing.T) {
+	// These combinations are rejected because they would prevent pastes
+	// from reaching the terminal:
+	//   - ctrl+v is the system paste shortcut; registering it as a global
+	//     hotkey would hijack every paste.
+	//   - ctrl+shift+v is what windowsSendCtrlShiftV synthesizes; an
+	//     identical binding would be re-caught by our own RegisterHotKey
+	//     loop (hotkeyRunning guard) and the simulated keystroke would be
+	//     silently swallowed.
+	cases := []struct {
+		name     string
+		in       string
+		wantFrag string
+	}{
+		{"ctrl+v", "ctrl+v", "system paste shortcut"},
+		{"ctrl+shift+v", "ctrl+shift+v", "simulated paste keystroke"},
+		{"shift+ctrl+v normalized", "shift+ctrl+v", "simulated paste keystroke"},
+		{"uppercase ctrl+V", "Ctrl+V", "system paste shortcut"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseHotkey(tc.in)
+			if err == nil {
+				t.Fatalf("parseHotkey(%q) returned no error, want rejection", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.wantFrag) {
+				t.Fatalf("parseHotkey(%q) error = %q, want to contain %q", tc.in, err.Error(), tc.wantFrag)
+			}
+		})
+	}
+}
+
+func TestParseHotkeyNonVKeyNotRejected(t *testing.T) {
+	// Sanity check: the conflict rule only targets the V key. Ctrl+Shift+B
+	// looks structurally similar to ctrl+shift+v but must remain valid.
+	if _, err := parseHotkey("ctrl+shift+b"); err != nil {
+		t.Fatalf("parseHotkey(ctrl+shift+b) unexpected error: %v", err)
+	}
+}
+
+func TestSaveHotkeyConfigRejectsPasteConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	hotkeyConfigPathOverride = filepath.Join(tmpDir, "hotkey.json")
+	t.Cleanup(func() { hotkeyConfigPathOverride = "" })
+
+	cfg := hotkeyConfig{Host: "example", Hotkey: "ctrl+shift+v"}
+	if err := saveHotkeyConfig(cfg); err == nil {
+		t.Fatal("saveHotkeyConfig accepted ctrl+shift+v, want rejection")
+	} else if !strings.Contains(err.Error(), "simulated paste keystroke") {
+		t.Fatalf("saveHotkeyConfig error = %q, want to mention conflict reason", err.Error())
+	}
+
+	cfg.Hotkey = "ctrl+v"
+	if err := saveHotkeyConfig(cfg); err == nil {
+		t.Fatal("saveHotkeyConfig accepted ctrl+v, want rejection")
 	}
 }

--- a/cmd/cc-clip/send_windows.go
+++ b/cmd/cc-clip/send_windows.go
@@ -50,8 +50,32 @@ func pasteRemotePath(remotePath, imagePath string, delay time.Duration, restoreC
 	return nil
 }
 
+// clipboardPersistenceSnippet is prepended to every clipboard-setting
+// PowerShell script. Set-Clipboard and WinForms Clipboard.SetText ultimately
+// give ownership to a window owned by the short-lived PowerShell process; when
+// that process exits, Windows destroys the window and the clipboard data goes
+// with it. SetDataObject with $true asks WinForms to leave the data on the
+// clipboard after the app exits, and OleFlushClipboard forces the OLE
+// rendering path to actually commit it. Using both is belt-and-braces because
+// the exact persistence behavior depends on the data format and Windows
+// version.
+const clipboardPersistenceSnippet = `$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+if (-not ('CcClipOle' -as [type])) {
+  Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+public static class CcClipOle {
+    [DllImport("ole32.dll")]
+    public static extern int OleFlushClipboard();
+}
+"@
+}
+`
+
 func windowsSetClipboardText(text string) error {
-	script := `Set-Clipboard -Value $env:CC_CLIP_TEXT`
+	script := clipboardPersistenceSnippet + `
+[System.Windows.Forms.Clipboard]::SetDataObject($env:CC_CLIP_TEXT, $true)
+[void][CcClipOle]::OleFlushClipboard()`
 	cmd := hiddenExec("powershell", "-STA", "-NoProfile", "-Command", script)
 	cmd.Env = append(os.Environ(), "CC_CLIP_TEXT="+text)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -61,12 +85,14 @@ func windowsSetClipboardText(text string) error {
 }
 
 func windowsSetClipboardImage(imagePath string) error {
-	script := `$ErrorActionPreference = 'Stop'
-Add-Type -AssemblyName System.Windows.Forms
+	script := clipboardPersistenceSnippet + `
 Add-Type -AssemblyName System.Drawing
 $img = [System.Drawing.Image]::FromFile($env:CC_CLIP_IMAGE_PATH)
 try {
-  [System.Windows.Forms.Clipboard]::SetImage($img)
+  $data = New-Object System.Windows.Forms.DataObject
+  $data.SetData([System.Windows.Forms.DataFormats]::Bitmap, $true, $img)
+  [System.Windows.Forms.Clipboard]::SetDataObject($data, $true)
+  [void][CcClipOle]::OleFlushClipboard()
 } finally {
   $img.Dispose()
 }`


### PR DESCRIPTION
Closes #27 once verified on a Windows host.

## Summary

Two bugs on Windows prevented the hotkey paste flow from working. This PR addresses both.

### Bug 2 (confirmed deterministic fix)

Configuring the hotkey to `ctrl+shift+v` made paste silently fail:
- `windowsSendCtrlShiftV` synthesizes `Ctrl+Shift+V` via `SendKeys`.
- That synthesized keystroke is intercepted again by our own `RegisterHotKey` loop, and the `hotkeyRunning` re-entry guard swallows it.
- Plain `ctrl+v` would also hijack the system paste shortcut.

`parseHotkey` now rejects `ctrl+v` and `ctrl+shift+v` with explanatory error messages (regardless of casing or modifier order), and `saveHotkeyConfig` inherits the validation. The default `alt+shift+v` is unaffected.

### Bug 1 (persistence hardening, needs Windows smoke verification)

Clipboard data vanished between `windowsSetClipboardText` and `windowsSendCtrlShiftV`:
- `Set-Clipboard` / `Clipboard.SetText` give clipboard ownership to an internal window inside the short-lived PowerShell process.
- When the process exits, Windows destroys the window and empties the clipboard.

The fix adopts explicit persistence semantics rather than asserting a single root cause:
1. Use `Clipboard.SetDataObject(data, $true)` — WinForms' documented "leave the data on the clipboard after this app exits" contract.
2. Call `OleFlushClipboard()` as a belt-and-braces commit, because the exact persistence path for delayed-render formats (notably `Bitmap`) depends on Windows version and format. Using both keeps the fix robust without relying on any single API.

The same treatment is applied to `windowsSetClipboardImage` (used for the optional `--restore-clipboard` flow).

## Tests

Added table-driven tests in `cmd/cc-clip/hotkey_windows_test.go`:
- `TestParseHotkeyAccepts` — default, casing, extra modifiers, function keys
- `TestParseHotkeyRejectsPasteConflicts` — ctrl+v / ctrl+shift+v across casings and modifier orderings
- `TestParseHotkeyNonVKeyNotRejected` — scope check: the rule must only target the V key
- `TestSaveHotkeyConfigRejectsPasteConflicts` — end-to-end rejection at the config layer

## Verification performed locally

- [x] `make test` — full suite passes on darwin
- [x] `make vet` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=arm64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=386 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=amd64 go vet ./cmd/cc-clip` — clean
- [x] `GOOS=windows GOARCH=amd64 go test -c ./cmd/cc-clip` — Windows-tagged tests compile cleanly

## Verification still needed (Windows host)

I do not have a Windows host, so the runtime behavior of the clipboard persistence change must be confirmed by someone who does. Requested smoke checks:

- [ ] `cc-clip send --paste` on Windows 11 with Git Bash / Windows Terminal: image uploads and remote path is actually pasted into the terminal
- [ ] `cc-clip hotkey --run-loop` with default `alt+shift+v`: copy image → hotkey → path pasted
- [ ] Configure hotkey to `ctrl+shift+v` via the config path: rejected with a clear error message
- [ ] Configure hotkey to `ctrl+v`: rejected with a clear error message
- [ ] With `--restore-clipboard`, the original image is back on the clipboard after paste

@nucleoid — would you be willing to test this branch on your Windows 11 setup? Binaries can be built from this branch, or I can attach prebuilt `.exe` artifacts if you prefer.

## Files touched

- `cmd/cc-clip/hotkey_windows.go` — conflict validation in `parseHotkey`
- `cmd/cc-clip/hotkey_windows_test.go` — new tests
- `cmd/cc-clip/send_windows.go` — `SetDataObject(..., $true)` + `OleFlushClipboard` wrapper, applied to both text and image setters

Refs #27.