### PR TITLE
fix: reject paste-conflict hotkeys on Windows (#27 part 1)

### DIFF
--- a/cmd/cc-clip/hotkey_windows.go
+++ b/cmd/cc-clip/hotkey_windows.go
@@ -507,6 +507,21 @@ func parseHotkey(value string) (hotkeyBinding, error) {
 		return hotkeyBinding{}, err
 	}
 
+	// windowsSendCtrlShiftV synthesizes Ctrl+Shift+V; a binding with the
+	// same combination would be re-caught by our own RegisterHotKey loop
+	// (guarded by hotkeyRunning) and the paste would never reach the
+	// terminal. Ctrl+V is the system paste shortcut and must not be
+	// globally hijacked either.
+	const vkV = 0x56
+	if key == vkV {
+		if modifiers == (modControl | modShift) {
+			return hotkeyBinding{}, fmt.Errorf("hotkey %q conflicts with the simulated paste keystroke (ctrl+shift+v); choose a different combination", value)
+		}
+		if modifiers == modControl {
+			return hotkeyBinding{}, fmt.Errorf("hotkey %q conflicts with the system paste shortcut (ctrl+v); choose a different combination", value)
+		}
+	}
+
 	displayParts := make([]string, 0, 4)
 	if modifiers&modControl != 0 {
 		displayParts = append(displayParts, "ctrl")

--- a/cmd/cc-clip/hotkey_windows_test.go
+++ b/cmd/cc-clip/hotkey_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -78,5 +79,88 @@ func TestStopHotkeyProcessWritesSentinelEvenWhenNotRunning(t *testing.T) {
 
 	if _, err := os.Stat(stopFile); os.IsNotExist(err) {
 		t.Fatal("expected stop sentinel file even when hotkey process is not running")
+	}
+}
+
+func TestParseHotkeyAccepts(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"default", "alt+shift+v", "alt+shift+v"},
+		{"case insensitive", "ALT+SHIFT+V", "alt+shift+v"},
+		{"ctrl alt other key", "ctrl+alt+p", "ctrl+alt+p"},
+		{"win modifier", "win+shift+v", "shift+win+v"},
+		{"function key", "ctrl+f12", "ctrl+f12"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseHotkey(tc.in)
+			if err != nil {
+				t.Fatalf("parseHotkey(%q) unexpected error: %v", tc.in, err)
+			}
+			if got.String() != tc.want {
+				t.Fatalf("parseHotkey(%q).String() = %q, want %q", tc.in, got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestParseHotkeyRejectsPasteConflicts(t *testing.T) {
+	// These combinations are rejected because they would prevent pastes
+	// from reaching the terminal:
+	//   - ctrl+v is the system paste shortcut; registering it as a global
+	//     hotkey would hijack every paste.
+	//   - ctrl+shift+v is what windowsSendCtrlShiftV synthesizes; an
+	//     identical binding would be re-caught by our own RegisterHotKey
+	//     loop (hotkeyRunning guard) and the simulated keystroke would be
+	//     silently swallowed.
+	cases := []struct {
+		name     string
+		in       string
+		wantFrag string
+	}{
+		{"ctrl+v", "ctrl+v", "system paste shortcut"},
+		{"ctrl+shift+v", "ctrl+shift+v", "simulated paste keystroke"},
+		{"shift+ctrl+v normalized", "shift+ctrl+v", "simulated paste keystroke"},
+		{"uppercase ctrl+V", "Ctrl+V", "system paste shortcut"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseHotkey(tc.in)
+			if err == nil {
+				t.Fatalf("parseHotkey(%q) returned no error, want rejection", tc.in)
+			}
+			if !strings.Contains(err.Error(), tc.wantFrag) {
+				t.Fatalf("parseHotkey(%q) error = %q, want to contain %q", tc.in, err.Error(), tc.wantFrag)
+			}
+		})
+	}
+}
+
+func TestParseHotkeyNonVKeyNotRejected(t *testing.T) {
+	// Sanity check: the conflict rule only targets the V key. Ctrl+Shift+B
+	// looks structurally similar to ctrl+shift+v but must remain valid.
+	if _, err := parseHotkey("ctrl+shift+b"); err != nil {
+		t.Fatalf("parseHotkey(ctrl+shift+b) unexpected error: %v", err)
+	}
+}
+
+func TestSaveHotkeyConfigRejectsPasteConflicts(t *testing.T) {
+	tmpDir := t.TempDir()
+	hotkeyConfigPathOverride = filepath.Join(tmpDir, "hotkey.json")
+	t.Cleanup(func() { hotkeyConfigPathOverride = "" })
+
+	cfg := hotkeyConfig{Host: "example", Hotkey: "ctrl+shift+v"}
+	if err := saveHotkeyConfig(cfg); err == nil {
+		t.Fatal("saveHotkeyConfig accepted ctrl+shift+v, want rejection")
+	} else if !strings.Contains(err.Error(), "simulated paste keystroke") {
+		t.Fatalf("saveHotkeyConfig error = %q, want to mention conflict reason", err.Error())
+	}
+
+	cfg.Hotkey = "ctrl+v"
+	if err := saveHotkeyConfig(cfg); err == nil {
+		t.Fatal("saveHotkeyConfig accepted ctrl+v, want rejection")
 	}
 }


### PR DESCRIPTION
Part 1 of 2 for #27.

## Summary

Configuring the hotkey to `ctrl+shift+v` or `ctrl+v` silently broke paste on Windows:

- `windowsSendCtrlShiftV` synthesizes `Ctrl+Shift+V` via SendKeys. That synthesized keystroke is re-intercepted by our own `RegisterHotKey` loop, and the `hotkeyRunning` re-entry guard swallows it. The paste never reaches the terminal.
- Plain `ctrl+v` would also hijack the system paste shortcut globally.

`parseHotkey` now rejects both combinations with explanatory errors. Valid combinations (default `alt+shift+v`, `ctrl+shift+b`, etc.) are untouched.

## Why split from #28

This portion is a deterministic Go-level fix with full test coverage and zero Windows runtime dependency. Splitting it out lets it land on main now, while #28 (Bug 1, clipboard persistence via PowerShell) stays draft until a Windows host confirms runtime behavior.

## Tests

Added table-driven tests in `cmd/cc-clip/hotkey_windows_test.go`:

- `TestParseHotkeyAccepts` — default, casing, extra modifiers, function keys
- `TestParseHotkeyRejectsPasteConflicts` — ctrl+v / ctrl+shift+v across casings and modifier orderings
- `TestParseHotkeyNonVKeyNotRejected` — scope check (only V key triggers the rule)
- `TestSaveHotkeyConfigRejectsPasteConflicts` — end-to-end rejection at the config layer

## Verification performed locally

- [x] `make test` — full suite passes on darwin
- [x] `make vet` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=arm64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=amd64 go test -c ./cmd/cc-clip` — Windows-tagged tests compile cleanly

## Files touched

- `cmd/cc-clip/hotkey_windows.go` (+15)
- `cmd/cc-clip/hotkey_windows_test.go` (+84)

Refs #27.