### PR TITLE
fix: harden Windows clipboard persistence (#27 part 2)

### DIFF
--- a/cmd/cc-clip/send_windows.go
+++ b/cmd/cc-clip/send_windows.go
@@ -50,8 +50,32 @@ func pasteRemotePath(remotePath, imagePath string, delay time.Duration, restoreC
 	return nil
 }
 
+// clipboardPersistenceSnippet is prepended to every clipboard-setting
+// PowerShell script. Set-Clipboard and WinForms Clipboard.SetText ultimately
+// give ownership to a window owned by the short-lived PowerShell process; when
+// that process exits, Windows destroys the window and the clipboard data goes
+// with it. SetDataObject with $true asks WinForms to leave the data on the
+// clipboard after the app exits, and OleFlushClipboard forces the OLE
+// rendering path to actually commit it. Using both is belt-and-braces because
+// the exact persistence behavior depends on the data format and Windows
+// version.
+const clipboardPersistenceSnippet = `$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+if (-not ('CcClipOle' -as [type])) {
+  Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+public static class CcClipOle {
+    [DllImport("ole32.dll")]
+    public static extern int OleFlushClipboard();
+}
+"@
+}
+`
+
 func windowsSetClipboardText(text string) error {
-	script := `Set-Clipboard -Value $env:CC_CLIP_TEXT`
+	script := clipboardPersistenceSnippet + `
+[System.Windows.Forms.Clipboard]::SetDataObject($env:CC_CLIP_TEXT, $true)
+[void][CcClipOle]::OleFlushClipboard()`
 	cmd := hiddenExec("powershell", "-STA", "-NoProfile", "-Command", script)
 	cmd.Env = append(os.Environ(), "CC_CLIP_TEXT="+text)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -61,12 +85,14 @@ func windowsSetClipboardText(text string) error {
 }
 
 func windowsSetClipboardImage(imagePath string) error {
-	script := `$ErrorActionPreference = 'Stop'
-Add-Type -AssemblyName System.Windows.Forms
+	script := clipboardPersistenceSnippet + `
 Add-Type -AssemblyName System.Drawing
 $img = [System.Drawing.Image]::FromFile($env:CC_CLIP_IMAGE_PATH)
 try {
-  [System.Windows.Forms.Clipboard]::SetImage($img)
+  $data = New-Object System.Windows.Forms.DataObject
+  $data.SetData([System.Windows.Forms.DataFormats]::Bitmap, $true, $img)
+  [System.Windows.Forms.Clipboard]::SetDataObject($data, $true)
+  [void][CcClipOle]::OleFlushClipboard()
 } finally {
   $img.Dispose()
 }`


### PR DESCRIPTION
Part 2 of 2 for #27. Part 1 (hotkey conflict validation) landed as #29.

This PR supersedes #28, which combined both portions and is being closed to keep the diff and description focused.

## Summary

Clipboard data vanished between `windowsSetClipboardText` and `windowsSendCtrlShiftV`:

- `Set-Clipboard` / `Clipboard.SetText` ultimately give clipboard ownership to an internal window inside the short-lived PowerShell process.
- When the process exits, Windows destroys the window and empties the clipboard before the paste keystroke can fire.
- Result: paste delivers an empty clipboard to the terminal.

This PR adopts explicit persistence semantics rather than asserting a single root cause:

1. Use `Clipboard.SetDataObject(data, $true)` — WinForms' documented "leave the data on the clipboard after this app exits" contract.
2. Call `OleFlushClipboard()` (via a small P/Invoke shim) as a belt-and-braces commit, because the exact persistence path for delayed-render formats (notably Bitmap) depends on Windows version and format. Using both keeps the fix robust without relying on any single API.

The same treatment is applied to `windowsSetClipboardImage` (used for the optional `--restore-clipboard` flow).

## Why this PR is draft

This is a PowerShell/WinForms behavioral change on Windows. The project has no Windows CI, so Go-level green tests cannot prove runtime correctness. Held as draft until the reporter or a Windows host confirms the smoke checks below.

## Verification performed locally

- [x] `make test` — full suite passes on darwin
- [x] `make vet` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=arm64 go build ./cmd/cc-clip` — passes
- [x] `GOOS=windows GOARCH=amd64 go test -c ./cmd/cc-clip` — Windows-tagged tests compile cleanly

## Verification still needed (Windows host)

Requested smoke checks — full instructions posted in the issue comment thread (#27):

- [ ] `cc-clip send --paste <image>` on Windows 11: remote path actually pastes into the focused terminal
- [ ] `cc-clip hotkey --run-loop` with default `alt+shift+v`: copy image → hotkey → path pasted
- [ ] With `--restore-clipboard`, the original image is back on the clipboard after paste
- [ ] `Get-Clipboard` after a failed paste (if any) to distinguish "data lost" from "keystroke not delivered"

## Files touched

- `cmd/cc-clip/send_windows.go` (+30/-4) — `SetDataObject(..., $true)` + `OleFlushClipboard` wrapper, applied to both text and image setters

Refs #27. Supersedes #28.