### PR TITLE
feat: support opencode clipboard invocations out of the box

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,11 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 
 ### Shim Interception Patterns
 
-The shim only intercepts these exact Claude Code invocations:
+The shim intercepts these invocation shapes (covers Claude Code and opencode; other consumers that use the same flags get interception for free):
 - xclip: `*"-selection clipboard"*"-t TARGETS"*"-o"*` and `*"-selection clipboard"*"-t image/"*"-o"*`
-- wl-paste: `*"--list-types"*` and `*"--type"*"image/"*`
+- wl-paste: `*"--list-types"*`, `*" -l"`, `*"-l "*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude uses `--type`, opencode uses `-t`)
 
-Everything else passes through to the real binary via `exec`.
+Everything else passes through to the real binary via `exec`. End-to-end coverage of these patterns is asserted by `TestShimMatchesClientInvocations` in `internal/shim/template_test.go`, which runs the generated bash against a fake "real" binary and verifies each client's invocation lands on the right branch.
 
 ## Cross-Architecture Binary Delivery
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,9 +109,9 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 
 The shim intercepts these invocation shapes (covers Claude Code and opencode; other consumers that use the same flags get interception for free):
 - xclip: `*"-selection clipboard"*"-t TARGETS"*"-o"*` and `*"-selection clipboard"*"-t image/"*"-o"*`
-- wl-paste: `*"--list-types"*`, `*" -l"`, `*"-l "*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude uses `--type`, opencode uses `-t`)
+- wl-paste: `*"--list-types"*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude uses `--type`, opencode uses `-t`)
 
-Everything else passes through to the real binary via `exec`. End-to-end coverage of these patterns is asserted by `TestShimMatchesClientInvocations` in `internal/shim/template_test.go`, which runs the generated bash against a fake "real" binary and verifies each client's invocation lands on the right branch.
+Everything else passes through to the real binary via `exec`. The `-l` short form of `--list-types` is deliberately not matched because no current consumer uses it and matching standalone `-l` without false positives is non-trivial. End-to-end coverage is asserted by `TestShimInterceptsMatchingInvocations` in `internal/shim/template_test.go`, which runs the generated bash against a mock HTTP daemon and verifies stdout contains the daemon's payload for matched patterns (proving interception took the HTTP path) and fallback captures the original args for unmatched patterns.
 
 ## Cross-Architecture Binary Delivery
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 <h1 align="center">cc-clip</h1>
 <p align="center">
-  <b>Paste images &amp; receive notifications across SSH — remote Claude Code &amp; Codex CLI feel local.</b>
+  <b>Paste images &amp; receive notifications across SSH — remote Claude Code, Codex CLI &amp; opencode feel local.</b>
 </p>
 <p align="center">
   <a href="https://github.com/ShunmeiCho/cc-clip/releases"><img src="https://img.shields.io/github/v/release/ShunmeiCho/cc-clip?color=D97706" alt="Release"></a>
@@ -47,7 +47,7 @@
 
 ## The Problem
 
-When running Claude Code or Codex CLI on a remote server via SSH, **image paste often doesn't work** and **notifications don't reach you**. The remote clipboard is empty — no screenshots, no diagrams. And when Claude finishes a task or needs approval, you have no idea unless you're staring at the terminal.
+When running Claude Code, Codex CLI, or opencode on a remote server via SSH, **image paste often doesn't work** and **notifications don't reach you**. The remote clipboard is empty — no screenshots, no diagrams. And when your coding agent finishes a task or needs approval, you have no idea unless you're staring at the terminal.
 
 ## The Solution
 
@@ -480,6 +480,19 @@ All settings have sensible defaults. Override via environment variables:
 | macOS (Apple Silicon) | Linux (amd64) | Stable |
 | macOS (Intel) | Linux (arm64) | Stable |
 | Windows 10/11 | Linux (amd64/arm64) | Experimental (`send` / `hotkey`) |
+
+### Supported Remote CLIs
+
+cc-clip works with **any coding agent that reads the clipboard via `xclip` or `wl-paste`** on Linux. No per-CLI configuration is needed — the transparent shim intercepts clipboard reads from any process that invokes these binaries.
+
+| CLI | Image paste | Notifications |
+|-----|-------------|----------------|
+| [Claude Code](https://www.anthropic.com/claude-code) | ✅ out of the box (xclip / wl-paste shim) | ✅ via `cc-clip-hook` in `Stop` / `Notification` hooks |
+| [Codex CLI](https://github.com/openai/codex) | ✅ out of the box (Xvfb + x11-bridge; needs `--codex`) | ✅ auto-configured during `cc-clip connect` if `~/.codex/` exists |
+| [opencode](https://opencode.ai) | ✅ out of the box (xclip shim on X11, wl-paste shim on Wayland) | ⚠️ not auto-configured — wire your own notifier if desired |
+| Any other `xclip`/`wl-paste` consumer | ✅ should just work — please [open a discussion](https://github.com/ShunmeiCho/cc-clip/discussions) if it doesn't | — |
+
+`cc-clip setup HOST` installs the xclip and wl-paste shims regardless of which CLI you use; opencode picks them up automatically the next time it reads the clipboard.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -764,6 +764,16 @@ make build && make test
 - [openai/codex#8929](https://github.com/openai/codex/issues/8929) — Notify hook not getting triggered
 - [openai/codex#8189](https://github.com/openai/codex/issues/8189) — WSL2: notifications fail for approval prompts
 
+**opencode — Clipboard:**
+- [anomalyco/opencode#19294](https://github.com/anomalyco/opencode/issues/19294) — Image paste works over SSH, but sending fails with "invalid image data"
+- [anomalyco/opencode#16962](https://github.com/anomalyco/opencode/issues/16962) — Clipboard copy not working over SSH (Mac-to-Mac)
+- [anomalyco/opencode#15907](https://github.com/anomalyco/opencode/issues/15907) — Clipboard copy not working over SSH + tmux in Ghostty
+- [anomalyco/opencode#19502](https://github.com/anomalyco/opencode/issues/19502) — Windows Terminal + WSL: Ctrl+V image paste is inconsistent
+- [anomalyco/opencode#17616](https://github.com/anomalyco/opencode/issues/17616) — Image paste from clipboard broken on Windows
+
+**opencode — Notifications:**
+- [anomalyco/opencode#18004](https://github.com/anomalyco/opencode/issues/18004) — Allow notifications even when opencode is focused
+
 **Terminal / Multiplexer:**
 - [manaflow-ai/cmux#833](https://github.com/manaflow-ai/cmux/issues/833) — Notifications over SSH+tmux sessions
 - [manaflow-ai/cmux#559](https://github.com/manaflow-ai/cmux/issues/559) — Better SSH integration

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -250,10 +250,14 @@ _cc_clip_fetch_binary() {
 
 ARGS="$*"
 
+# Supported invocation shapes:
+#   Claude Code: wl-paste --list-types / wl-paste --type image/png
+#   opencode:    wl-paste -t image/png   (short -t instead of --type)
+# The patterns below cover both.
 case "$ARGS" in
-    *"--list-types"*)
-        # Claude checks available types
-        _cc_clip_log "intercepting --list-types"
+    *"--list-types"*|*" -l"|*"-l "*)
+        # Type listing (Claude)
+        _cc_clip_log "intercepting type listing"
         if _cc_clip_probe; then
             RESULT=$(_cc_clip_fetch_json "/clipboard/type" 2>/dev/null) || {
                 _cc_clip_fallback "$@"
@@ -270,8 +274,9 @@ case "$ARGS" in
         fi
         ;;
 
-    *"--type"*"image/"*)
-        # Claude reads image data — fetch to temp file then cat (binary-safe + fallback-safe)
+    *"--type"*"image/"*|*"-t image/"*)
+        # Image read (Claude --type / opencode -t) — fetch to temp file then cat
+        # (binary-safe + fallback-safe)
         _cc_clip_log "intercepting image read"
         if _cc_clip_probe; then
             if _cc_clip_fetch_binary "/clipboard/image"; then

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -251,11 +251,13 @@ _cc_clip_fetch_binary() {
 ARGS="$*"
 
 # Supported invocation shapes:
-#   Claude Code: wl-paste --list-types / wl-paste --type image/png
-#   opencode:    wl-paste -t image/png   (short -t instead of --type)
-# The patterns below cover both.
+#   Claude Code: wl-paste --list-types  /  wl-paste --type image/png
+#   opencode:    wl-paste -t image/png  (short -t instead of --type)
+# The patterns below cover both. We intentionally do not match the -l
+# short form of --list-types because no current consumer uses it and
+# matching standalone "-l" without false positives is non-trivial.
 case "$ARGS" in
-    *"--list-types"*|*" -l"|*"-l "*)
+    *"--list-types"*)
         # Type listing (Claude)
         _cc_clip_log "intercepting type listing"
         if _cc_clip_probe; then

--- a/internal/shim/template_test.go
+++ b/internal/shim/template_test.go
@@ -1,0 +1,139 @@
+package shim
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestXclipShimSubstitutesPortAndRealBinary(t *testing.T) {
+	got := XclipShim(18339, "/usr/bin/xclip")
+	if !strings.Contains(got, `CC_CLIP_PORT="${CC_CLIP_PORT:-18339}"`) {
+		t.Fatalf("port substitution missing: %q", got)
+	}
+	if !strings.Contains(got, `REAL_XCLIP="/usr/bin/xclip"`) {
+		t.Fatalf("real xclip path substitution missing: %q", got)
+	}
+}
+
+func TestWlPasteShimSubstitutesPortAndRealBinary(t *testing.T) {
+	got := WlPasteShim(18339, "/usr/bin/wl-paste")
+	if !strings.Contains(got, `CC_CLIP_PORT="${CC_CLIP_PORT:-18339}"`) {
+		t.Fatalf("port substitution missing: %q", got)
+	}
+	if !strings.Contains(got, `REAL_WL_PASTE="/usr/bin/wl-paste"`) {
+		t.Fatalf("real wl-paste path substitution missing: %q", got)
+	}
+}
+
+// TestShimMatchesClientInvocations executes the generated shim patterns against
+// real Bash using a `fake` REAL binary, verifying that each supported client's
+// invocation either reaches the image-read branch (exit 10 when tunnel is down,
+// which triggers fallback) or the TARGETS/list-types branch (which also
+// fallthroughs). This gives real coverage of the bash case-statement glob
+// rules — a subtle change to the patterns would be caught.
+//
+// The test does not need a running daemon. The `_cc_clip_probe` call returns
+// non-zero because no daemon is listening, and we assert that the fallback
+// real binary (captured to a sentinel file) is invoked with the expected
+// arguments.
+func TestShimMatchesClientInvocations(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	cases := []struct {
+		name  string
+		shim  string
+		args  []string
+		label string
+	}{
+		{
+			name:  "claude_xclip_targets",
+			shim:  XclipShim(65000, "__REAL__"),
+			args:  []string{"-selection", "clipboard", "-t", "TARGETS", "-o"},
+			label: "claude targets",
+		},
+		{
+			name:  "claude_xclip_image",
+			shim:  XclipShim(65000, "__REAL__"),
+			args:  []string{"-selection", "clipboard", "-t", "image/png", "-o"},
+			label: "claude image",
+		},
+		{
+			name:  "opencode_xclip_image",
+			shim:  XclipShim(65000, "__REAL__"),
+			args:  []string{"-selection", "clipboard", "-t", "image/png", "-o"},
+			label: "opencode image (same as claude on xclip)",
+		},
+		{
+			name:  "claude_wlpaste_list_types",
+			shim:  WlPasteShim(65000, "__REAL__"),
+			args:  []string{"--list-types"},
+			label: "claude list-types",
+		},
+		{
+			name:  "claude_wlpaste_type_long",
+			shim:  WlPasteShim(65000, "__REAL__"),
+			args:  []string{"--type", "image/png"},
+			label: "claude --type image/png",
+		},
+		{
+			name:  "opencode_wlpaste_type_short",
+			shim:  WlPasteShim(65000, "__REAL__"),
+			args:  []string{"-t", "image/png"},
+			label: "opencode -t image/png (short form)",
+		},
+		{
+			name:  "passthrough_unrelated_flag",
+			shim:  WlPasteShim(65000, "__REAL__"),
+			args:  []string{"--watch"},
+			label: "unrelated invocation — must pass through to fallback",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			sentinel := filepath.Join(tmpDir, "fallback.log")
+
+			// Build a fake "real" binary that records the arguments it was
+			// invoked with into the sentinel file, then exits 0.
+			realBin := filepath.Join(tmpDir, "fake-real")
+			fakeScript := "#!/bin/bash\n" +
+				"printf '%s\\n' \"$*\" > \"" + sentinel + "\"\n" +
+				"exit 0\n"
+			if err := os.WriteFile(realBin, []byte(fakeScript), 0755); err != nil {
+				t.Fatalf("write fake real: %v", err)
+			}
+
+			// Render the shim with the fake real binary as the fallback target.
+			shim := strings.ReplaceAll(tc.shim, "__REAL__", realBin)
+			shimPath := filepath.Join(tmpDir, "shim.sh")
+			if err := os.WriteFile(shimPath, []byte(shim), 0755); err != nil {
+				t.Fatalf("write shim: %v", err)
+			}
+
+			// Run the shim. Daemon is down → all supported patterns fall
+			// through to fallback; unmatched patterns also fall through.
+			cmd := exec.Command("bash", append([]string{shimPath}, tc.args...)...)
+			cmd.Env = append(os.Environ(),
+				"CC_CLIP_PORT=65000",
+				"CC_CLIP_PROBE_TIMEOUT_MS=50",
+			)
+			_ = cmd.Run() // fallback exits 0 via exec; don't fail on cmd error
+
+			recorded, err := os.ReadFile(sentinel)
+			if err != nil {
+				t.Fatalf("[%s] fallback was not invoked (sentinel absent): %v", tc.label, err)
+			}
+			got := strings.TrimSpace(string(recorded))
+			want := strings.Join(tc.args, " ")
+			if got != want {
+				t.Fatalf("[%s] fallback args mismatch\n  got:  %q\n  want: %q", tc.label, got, want)
+			}
+		})
+	}
+}

--- a/internal/shim/template_test.go
+++ b/internal/shim/template_test.go
@@ -1,9 +1,14 @@
 package shim
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -28,69 +33,130 @@ func TestWlPasteShimSubstitutesPortAndRealBinary(t *testing.T) {
 	}
 }
 
-// TestShimMatchesClientInvocations executes the generated shim patterns against
-// real Bash using a `fake` REAL binary, verifying that each supported client's
-// invocation either reaches the image-read branch (exit 10 when tunnel is down,
-// which triggers fallback) or the TARGETS/list-types branch (which also
-// fallthroughs). This gives real coverage of the bash case-statement glob
-// rules — a subtle change to the patterns would be caught.
+// imagePayload is a distinctive byte sequence served by the mock daemon for
+// /clipboard/image. Tests assert that when a shim pattern actually intercepts
+// an invocation, this exact payload reaches stdout — which is only possible if
+// the shim went through the HTTP path rather than falling through to the real
+// binary.
+var imagePayload = []byte("CC-CLIP-INTERCEPTED-PAYLOAD")
+
+const expectedTypeToken = "image/png"
+
+// startMockDaemon serves the two endpoints the shim consumes when
+// intercepting: /clipboard/type (JSON `{"type":"image","format":"png"}`) and
+// /clipboard/image (raw bytes). Returns (port, tokenFilePath).
+func startMockDaemon(t *testing.T, tmpDir string) (int, string) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch r.URL.Path {
+		case "/clipboard/type":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"type": "image", "format": "png"})
+		case "/clipboard/image":
+			w.Header().Set("Content-Type", "image/png")
+			_, _ = w.Write(imagePayload)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse mock URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parse mock port: %v", err)
+	}
+
+	tokenFile := filepath.Join(tmpDir, "session.token")
+	if err := os.WriteFile(tokenFile, []byte("test-token\n"), 0600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	return port, tokenFile
+}
+
+// TestShimInterceptsMatchingInvocations runs the generated bash shim against a
+// real mock HTTP daemon. For each case where the pattern *should* match, it
+// asserts that the shim's stdout contains the daemon's response (proving the
+// HTTP path was taken) and that fallback was NOT invoked. For unmatched
+// patterns, it asserts the opposite: stdout is empty of the daemon payload
+// and fallback captured the original args.
 //
-// The test does not need a running daemon. The `_cc_clip_probe` call returns
-// non-zero because no daemon is listening, and we assert that the fallback
-// real binary (captured to a sentinel file) is invoked with the expected
-// arguments.
-func TestShimMatchesClientInvocations(t *testing.T) {
+// This distinguishes "pattern matched -> probe succeeded -> daemon returned
+// data" from "pattern didn't match -> default fallback", which a daemon-down
+// variant cannot do.
+func TestShimInterceptsMatchingInvocations(t *testing.T) {
 	if _, err := exec.LookPath("bash"); err != nil {
 		t.Skip("bash not available")
 	}
 
+	type expectation int
+	const (
+		expectInterceptImage expectation = iota // stdout == imagePayload, no fallback
+		expectInterceptType                     // stdout contains expectedTypeToken, no fallback
+		expectFallback                          // stdout empty of payload, fallback captures args
+	)
+
 	cases := []struct {
-		name  string
-		shim  string
-		args  []string
-		label string
+		name   string
+		render func(port int, real string) string
+		args   []string
+		expect expectation
 	}{
 		{
-			name:  "claude_xclip_targets",
-			shim:  XclipShim(65000, "__REAL__"),
-			args:  []string{"-selection", "clipboard", "-t", "TARGETS", "-o"},
-			label: "claude targets",
+			name:   "claude_xclip_targets",
+			render: XclipShim,
+			args:   []string{"-selection", "clipboard", "-t", "TARGETS", "-o"},
+			expect: expectInterceptType,
 		},
 		{
-			name:  "claude_xclip_image",
-			shim:  XclipShim(65000, "__REAL__"),
-			args:  []string{"-selection", "clipboard", "-t", "image/png", "-o"},
-			label: "claude image",
+			name:   "claude_xclip_image",
+			render: XclipShim,
+			args:   []string{"-selection", "clipboard", "-t", "image/png", "-o"},
+			expect: expectInterceptImage,
 		},
 		{
-			name:  "opencode_xclip_image",
-			shim:  XclipShim(65000, "__REAL__"),
-			args:  []string{"-selection", "clipboard", "-t", "image/png", "-o"},
-			label: "opencode image (same as claude on xclip)",
+			name:   "opencode_xclip_image",
+			render: XclipShim,
+			args:   []string{"-selection", "clipboard", "-t", "image/png", "-o"},
+			expect: expectInterceptImage,
 		},
 		{
-			name:  "claude_wlpaste_list_types",
-			shim:  WlPasteShim(65000, "__REAL__"),
-			args:  []string{"--list-types"},
-			label: "claude list-types",
+			name:   "xclip_passthrough_unrelated",
+			render: XclipShim,
+			args:   []string{"-selection", "primary", "-o"},
+			expect: expectFallback,
 		},
 		{
-			name:  "claude_wlpaste_type_long",
-			shim:  WlPasteShim(65000, "__REAL__"),
-			args:  []string{"--type", "image/png"},
-			label: "claude --type image/png",
+			name:   "claude_wlpaste_list_types",
+			render: WlPasteShim,
+			args:   []string{"--list-types"},
+			expect: expectInterceptType,
 		},
 		{
-			name:  "opencode_wlpaste_type_short",
-			shim:  WlPasteShim(65000, "__REAL__"),
-			args:  []string{"-t", "image/png"},
-			label: "opencode -t image/png (short form)",
+			name:   "claude_wlpaste_type_long",
+			render: WlPasteShim,
+			args:   []string{"--type", "image/png"},
+			expect: expectInterceptImage,
 		},
 		{
-			name:  "passthrough_unrelated_flag",
-			shim:  WlPasteShim(65000, "__REAL__"),
-			args:  []string{"--watch"},
-			label: "unrelated invocation — must pass through to fallback",
+			name:   "opencode_wlpaste_type_short",
+			render: WlPasteShim,
+			args:   []string{"-t", "image/png"},
+			expect: expectInterceptImage,
+		},
+		{
+			name:   "wlpaste_passthrough_unrelated",
+			render: WlPasteShim,
+			args:   []string{"--watch"},
+			expect: expectFallback,
 		},
 	}
 
@@ -99,8 +165,7 @@ func TestShimMatchesClientInvocations(t *testing.T) {
 			tmpDir := t.TempDir()
 			sentinel := filepath.Join(tmpDir, "fallback.log")
 
-			// Build a fake "real" binary that records the arguments it was
-			// invoked with into the sentinel file, then exits 0.
+			// Fake "real" binary records its args to a sentinel and exits 0.
 			realBin := filepath.Join(tmpDir, "fake-real")
 			fakeScript := "#!/bin/bash\n" +
 				"printf '%s\\n' \"$*\" > \"" + sentinel + "\"\n" +
@@ -109,30 +174,62 @@ func TestShimMatchesClientInvocations(t *testing.T) {
 				t.Fatalf("write fake real: %v", err)
 			}
 
-			// Render the shim with the fake real binary as the fallback target.
-			shim := strings.ReplaceAll(tc.shim, "__REAL__", realBin)
+			port, tokenFile := startMockDaemon(t, tmpDir)
+
+			shim := tc.render(port, realBin)
 			shimPath := filepath.Join(tmpDir, "shim.sh")
 			if err := os.WriteFile(shimPath, []byte(shim), 0755); err != nil {
 				t.Fatalf("write shim: %v", err)
 			}
 
-			// Run the shim. Daemon is down → all supported patterns fall
-			// through to fallback; unmatched patterns also fall through.
 			cmd := exec.Command("bash", append([]string{shimPath}, tc.args...)...)
 			cmd.Env = append(os.Environ(),
-				"CC_CLIP_PORT=65000",
-				"CC_CLIP_PROBE_TIMEOUT_MS=50",
+				"CC_CLIP_PORT="+strconv.Itoa(port),
+				"CC_CLIP_TOKEN_FILE="+tokenFile,
+				"CC_CLIP_PROBE_TIMEOUT_MS=2000",
+				"CC_CLIP_FETCH_TIMEOUT_MS=5000",
 			)
-			_ = cmd.Run() // fallback exits 0 via exec; don't fail on cmd error
-
-			recorded, err := os.ReadFile(sentinel)
+			out, err := cmd.Output()
 			if err != nil {
-				t.Fatalf("[%s] fallback was not invoked (sentinel absent): %v", tc.label, err)
+				t.Fatalf("shim execution failed: %v (stdout=%q)", err, string(out))
 			}
-			got := strings.TrimSpace(string(recorded))
-			want := strings.Join(tc.args, " ")
-			if got != want {
-				t.Fatalf("[%s] fallback args mismatch\n  got:  %q\n  want: %q", tc.label, got, want)
+
+			fallbackInvoked := false
+			var recordedArgs string
+			if recorded, readErr := os.ReadFile(sentinel); readErr == nil {
+				fallbackInvoked = true
+				recordedArgs = strings.TrimSpace(string(recorded))
+			}
+
+			switch tc.expect {
+			case expectInterceptImage:
+				if fallbackInvoked {
+					t.Fatalf("expected interception, but fallback was invoked with %q (stdout=%q)",
+						recordedArgs, string(out))
+				}
+				if !strings.Contains(string(out), string(imagePayload)) {
+					t.Fatalf("expected stdout to contain daemon image payload %q, got %q",
+						string(imagePayload), string(out))
+				}
+			case expectInterceptType:
+				if fallbackInvoked {
+					t.Fatalf("expected interception, but fallback was invoked with %q (stdout=%q)",
+						recordedArgs, string(out))
+				}
+				if !strings.Contains(string(out), expectedTypeToken) {
+					t.Fatalf("expected stdout to contain %q, got %q", expectedTypeToken, string(out))
+				}
+			case expectFallback:
+				if !fallbackInvoked {
+					t.Fatalf("expected fallback invocation, but sentinel was absent (stdout=%q)", string(out))
+				}
+				want := strings.Join(tc.args, " ")
+				if recordedArgs != want {
+					t.Fatalf("fallback args mismatch\n  got:  %q\n  want: %q", recordedArgs, want)
+				}
+				if strings.Contains(string(out), string(imagePayload)) {
+					t.Fatalf("fallback path unexpectedly produced daemon payload: %q", string(out))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Supersedes the closed #31. Clean rebuild from `main` after review flagged three issues in the prior attempt:

1. **Commit pollution** — #31 was branched from `fix/issue-27-clipboard-persistence` and dragged `b3a28d2` (Windows clipboard persistence, still in draft #30) into the merge path. This branch is started from `main` and contains *only* opencode-related commits.
2. **Test could not catch regression** — the old daemon-down design could not distinguish "pattern matched + probe failed → fallback" from "pattern never matched → default fallback". Rewritten to run against a mock HTTP daemon.
3. **`-l` short-form claim was false** — the added pattern did not cover a standalone `-l` arg. Dropped the claim since no current consumer needs it.

## What this PR does

opencode's clipboard flow on Linux (`packages/opencode/src/cli/cmd/tui/util/clipboard.ts` in `anomalyco/opencode`):

```ts
if (os === "linux") {
  const wayland = await Process.run(["wl-paste", "-t", "image/png"], ...)
  const x11 = await Process.run(["xclip", "-selection", "clipboard", "-t", "image/png", "-o"], ...)
}
```

- **xclip path** already matches cc-clip's existing pattern `*"-selection clipboard"*"-t image/"*"-o"*` → worked out of the box on X11 (this is what discussion #25 was reporting).
- **wl-paste path** uses the short `-t image/png`; cc-clip previously only matched the long `--type`. On pure Wayland remotes this bypassed cc-clip; on hybrid X11/Wayland opencode fell back to xclip, so the bug was masked but real.

## Changes

- **`internal/shim/template.go`** — extend wl-paste case statement to match `*"-t image/"*` in addition to `*"--type"*"image/"*`.
- **`internal/shim/template_test.go`** (new, 236 lines) — table-driven test executing the generated bash against a `httptest.NewServer` mock daemon. Three expectation shapes:
  - `expectInterceptImage` — stdout must contain the daemon's distinctive byte payload (`CC-CLIP-INTERCEPTED-PAYLOAD`), fallback must NOT fire.
  - `expectInterceptType` — stdout must contain `image/png`, fallback must NOT fire.
  - `expectFallback` — fallback sentinel must capture the original args, stdout must NOT contain the daemon payload.

  Eight subtests cover: Claude xclip TARGETS, Claude + opencode xclip image read, xclip passthrough, Claude wl-paste `--list-types`, Claude wl-paste `--type`, opencode wl-paste `-t`, wl-paste passthrough.

  **Reverse-validated**: temporarily removing `*"-t image/"*` from the shim makes `opencode_wlpaste_type_short` fail with `expected interception, but fallback was invoked with '-t image/png'`. With the fix in place, all eight pass.
- **`README.md`** — new "Supported Remote CLIs" table, opencode added to subtitle + problem statement, new "opencode — Clipboard" and "opencode — Notifications" sections cross-linking 6 relevant upstream issues on `anomalyco/opencode`.
- **`CLAUDE.md`** — shim interception documentation synced, including an explanation of why `-l` is deliberately unmatched.

## Verification

- [x] `make test` — full suite passes (8 new subtests all green)
- [x] `make vet` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — passes
- [x] Manual reverse-validation: with the `-t image/` pattern removed, the `opencode_wlpaste_type_short` subtest fails with a clear diagnostic

## Relation to #30

Completely independent. This PR does not include any `send_windows.go` or Windows clipboard persistence changes. #30 remains draft pending Windows smoke verification.

Refs: discussion #25 (tawsifkamal); supersedes: #31.