### PR TITLE
chore: migrate goreleaser archives format to plural schema

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,10 +20,10 @@ builds:
 
 archives:
   - id: default
-    format: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
Flagged as a LOW finding in the v0.6.0 adversarial review. Does not block any release; cleans up two deprecation warnings from `goreleaser check`.

## Before

`goreleaser check` exited 1 with:

```
• DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
• DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
• configuration is valid, but uses deprecated properties
⨯ check failed
```

The config was still functionally valid (v0.6.0 built and shipped on it), but the deprecation will eventually become an error in a future GoReleaser release.

## After

```yaml
archives:
  - id: default
    formats: [tar.gz]
    format_overrides:
      - goos: windows
        formats: [zip]
    name_template: ...
```

`goreleaser check` now exits 0 with no warnings.

## Backwards compatibility

Verified via `goreleaser release --snapshot --clean --skip=publish`:

```
cc-clip_0.6.0-SNAPSHOT-b645c90_darwin_amd64.tar.gz
cc-clip_0.6.0-SNAPSHOT-b645c90_darwin_arm64.tar.gz
cc-clip_0.6.0-SNAPSHOT-b645c90_linux_amd64.tar.gz
cc-clip_0.6.0-SNAPSHOT-b645c90_linux_arm64.tar.gz
cc-clip_0.6.0-SNAPSHOT-b645c90_windows_amd64.zip
cc-clip_0.6.0-SNAPSHOT-b645c90_windows_arm64.zip
```

Identical asset naming to v0.6.0 — `install.sh` and the release contract check (`.github/workflows/release.yml`) keep working unchanged.

## When this ships

Picked up whenever the next release is cut (likely v0.6.1 alongside issue #27 Bug 1 after Windows smoke verification).