### PR TITLE
docs(i18n): scaffold for EN/ZH/JA README and subdocs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- i18n-source: README.md @ d15a990 -->
+<!-- i18n-source: README.md @ d15a990fdccf3c2686a9dc69c26635f525ce65a1 -->
 
 <p align="center">
   <a href="README.md">English</a> ·

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,26 @@
+<!-- i18n-source: README.md @ d15a990 -->
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <b>日本語</b>
+</p>
+
+<p align="center">
+  <img src="docs/logo.png" alt="cc-clip logo" width="200">
+</p>
+<h1 align="center">cc-clip</h1>
+
+> これは英語版 README の日本語訳です。内容に差異がある場合は [English README](README.md) を正とします。この翻訳は英語版のメインラインより遅れている場合があります。
+>
+> *This is the Japanese translation of the English README. If any content differs, the [English README](README.md) is authoritative. This translation may lag behind the English main line.*
+
+---
+
+## 翻訳プレースホルダー · Translation Placeholder
+
+このファイルは i18n scaffold の一部です。完全な日本語訳は準備中です。それまでは最新のプロジェクト情報については [English README](README.md) をご覧ください。
+
+メンテナー向けメモ:
+- 翻訳完了時に、ファイル先頭の `i18n-source` コメントを、そのときの英語版 `README.md` の commit SHA に更新してください。
+- 翻訳作業は [`docs/i18n/TRANSLATION_BRIEF.md`](docs/i18n/TRANSLATION_BRIEF.md) と [`docs/i18n/glossary.md`](docs/i18n/glossary.md) に従ってください。

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <p align="center">
+  <b>English</b> ·
+  <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
   <img src="docs/logo.png" alt="cc-clip logo" width="200">
 </p>
 <h1 align="center">cc-clip</h1>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- i18n-source: README.md @ d15a990 -->
+<!-- i18n-source: README.md @ d15a990fdccf3c2686a9dc69c26635f525ce65a1 -->
 
 <p align="center">
   <a href="README.md">English</a> ·

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,26 @@
+<!-- i18n-source: README.md @ d15a990 -->
+
+<p align="center">
+  <a href="README.md">English</a> ·
+  <b>简体中文</b> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+
+<p align="center">
+  <img src="docs/logo.png" alt="cc-clip logo" width="200">
+</p>
+<h1 align="center">cc-clip</h1>
+
+> 这是英文 README 的简体中文翻译。如果翻译版与 [English README](README.md) 存在差异，以英文原版为准。翻译版本可能晚于英文主线更新。
+>
+> *This is the Simplified Chinese translation of the English README. If any content differs, the [English README](README.md) is authoritative. This translation may lag behind the English main line.*
+
+---
+
+## 翻译占位符 · Translation Placeholder
+
+本文件是 i18n scaffold 的一部分。完整中文翻译正在准备中；在此之前，请阅读 [English README](README.md) 获取最新项目信息。
+
+维护者注记：
+- 翻译完成后，请把文件顶部的 `i18n-source` 注释更新为当时的英文 `README.md` commit SHA。
+- 翻译过程请遵循 [`docs/i18n/TRANSLATION_BRIEF.md`](docs/i18n/TRANSLATION_BRIEF.md) 和 [`docs/i18n/glossary.md`](docs/i18n/glossary.md)。

--- a/docs/i18n/TRANSLATION_BRIEF.md
+++ b/docs/i18n/TRANSLATION_BRIEF.md
@@ -1,0 +1,146 @@
+# Translation Brief
+
+This brief sets the rules for translating cc-clip user documentation into Simplified Chinese and Japanese. It exists so every translator (human or agent) produces files that share the same voice, structure, and source-tracking discipline.
+
+## What gets translated
+
+| File | Translated? | Notes |
+|---|---|---|
+| `README.md` | ✅ → `README.zh-CN.md`, `README.ja.md` | Root entrypoint, highest priority. |
+| `docs/troubleshooting.md` | ✅ → `docs/zh-CN/`, `docs/ja/` | User-facing debug guide. |
+| `docs/windows-quickstart.md` | ✅ → `docs/zh-CN/`, `docs/ja/` | User-facing platform guide. |
+| `docs/notifications.md` | ✅ → `docs/zh-CN/`, `docs/ja/` | User-facing feature guide. |
+| `docs/commands.md` | ✅ → `docs/zh-CN/`, `docs/ja/` | User-facing reference. |
+| `CLAUDE.md` | ❌ | Agent/contributor instructions; English is the canonical working language for AI tooling. |
+| `AGENTS.md` | ❌ | Same as CLAUDE.md. |
+| `CONTRIBUTING.md` | ❌ | Contributor-facing; keeps English. |
+| `docs/marketing/*` | ❌ | Market copy should be culturally adapted, not translated. |
+| `docs/plans/*` | ❌ | Internal planning artifacts. |
+| Commit messages, PR titles, issue templates, code comments | ❌ | Collaboration surface stays English. |
+| CLI `--help` text and error messages | ❌ | Unless a real runtime i18n system is added later. |
+
+English is the **canonical source**. When in doubt, keep a term in English rather than invent a translation.
+
+## Source hash markers (mandatory)
+
+Every translated file MUST begin with a marker comment:
+
+```markdown
+<!-- i18n-source: README.md @ <english-commit-sha> -->
+```
+
+- `<english-commit-sha>` is the full SHA of the English source's most recent commit at the time of translation.
+- Rule: when you update a translation, update the SHA at the same time. The CI (when added in the final step of the i18n sequence) will compare the marker SHA against the current canonical file's latest SHA and fail if the translation is behind the declared source.
+- Do NOT invent an SHA. Use `git log -1 --format=%H -- <source-file>` to get the current value.
+- If you are translating from a specific upstream commit, use that SHA even if the `main` branch has moved — the marker reflects "this translation is based on source state X," not "this translation exists at time Y."
+
+## Language switcher (mandatory on every translated file)
+
+Each translated file (and the English original) starts with a language bar like:
+
+```markdown
+<p align="center">
+  <a href="README.md">English</a> ·
+  <b>简体中文</b> ·
+  <a href="README.ja.md">日本語</a>
+</p>
+```
+
+- The current language is **bold** (not a link).
+- Other languages are links.
+- Order and wording (English · 简体中文 · 日本語) are fixed across all files to reduce cognitive load.
+- For subdocs under `docs/`, link targets adjust relatively (e.g., `../README.md` → `../README.zh-CN.md`).
+
+## Canonical disclaimer
+
+Each translated file (including subdocs) must include, right after the language bar and logo:
+
+- **Simplified Chinese:**
+  > 本文是英文原文的简体中文翻译。若内容有差异，以 [English 原文](<source-link>) 为准。翻译版本可能晚于英文主线更新。
+
+- **Japanese:**
+  > これは英語版の日本語訳です。内容に差異がある場合は [English 原文](<source-link>) を正とします。この翻訳は英語版のメインラインより遅れている場合があります。
+
+## Tone
+
+### Simplified Chinese
+
+- **Voice**: direct, technical, no marketing hype.
+- **Pronouns**: avoid formal "您"; use plain 2nd-person or imperative. "Run this command" → "运行此命令" (imperative), not "您需要运行此命令".
+- **Sentence structure**: mirror the English paragraph structure. Do not reorganize unless a literal translation reads as unnatural Mandarin.
+- **Technical terms**: prefer English on first use if the glossary does not force a translation, then use the translation in follow-ups.
+
+### Japanese
+
+- **Register**: です・ます体 (desu/masu form). Not 常体 (plain form), not overly formal 謙譲語.
+- **Imperative**: prefer `-ください` or `-してください` over raw imperative.
+- **Technical terms**: same rule as Chinese — prefer katakana transliteration only when the glossary forces it. Otherwise keep English.
+- **Particle economy**: the English original is terse; do not add "という" or "ということ" unless genuinely needed for clarity.
+
+## Structure rules
+
+- **Preserve markdown structure exactly.** Headings (`##`, `###`, `####`), tables, code fences, callouts (`>`), and list levels must match the English source. A reviewer should be able to diff the rendered English and rendered translation and see the same section count, in the same order.
+- **Code blocks**: translate *only* shell / config comments (lines starting with `#` or `//` inside the code fence). Do not translate command names, flag names, paths, URLs, or output text. When in doubt, leave it English.
+- **Anchor links**: translations may keep the same English slug (GitHub auto-generates anchors from the visible text, which differs per language, so cross-file anchor links need adjustment — use the original English-header anchor on the English file, and the translated anchor on the translated file).
+- **Images**: the `src="..."` path is shared across all three language versions (e.g., all three READMEs use `docs/logo.png`). `alt="..."` text may be translated.
+- **Output**: produce exactly one markdown file. No meta-commentary, no "here is the translation" preamble, no trailing signature.
+
+## Review checklist (per translated file)
+
+Before a translation PR is marked ready:
+
+- [ ] The `i18n-source` marker at the top references the current English commit SHA
+- [ ] The language switcher is present and order-consistent with other files
+- [ ] The canonical disclaimer paragraph is present
+- [ ] Every H2 / H3 in the English source has a corresponding heading in the translation
+- [ ] Every code block in the English source has a corresponding code block in the translation (same fence language, same number of blocks)
+- [ ] Every glossary term used appears in the form the glossary mandates
+- [ ] No untranslated English paragraphs remain (other than intentionally preserved technical text)
+- [ ] No added / removed sections that the English source does not have
+- [ ] File ends with a single trailing newline
+
+## Subdoc directory layout
+
+For files outside the root (troubleshooting, windows quickstart, notifications, commands), place translations at:
+
+```
+docs/
+├── troubleshooting.md         ← English canonical
+├── windows-quickstart.md
+├── notifications.md
+├── commands.md
+├── zh-CN/
+│   ├── troubleshooting.md
+│   ├── windows-quickstart.md
+│   ├── notifications.md
+│   └── commands.md
+└── ja/
+    ├── troubleshooting.md
+    ├── windows-quickstart.md
+    ├── notifications.md
+    └── commands.md
+```
+
+The language switcher on translated subdocs links back to the English canonical and across to the peer-language subdoc:
+
+```markdown
+<p align="center">
+  <a href="../troubleshooting.md">English</a> ·
+  <b>简体中文</b> ·
+  <a href="../ja/troubleshooting.md">日本語</a>
+</p>
+```
+
+## When a translation falls out of sync
+
+If the English source changes and the translation has not been updated:
+
+1. Do not silently edit the SHA marker to the new English SHA — that hides a real drift.
+2. Open a translation-update PR that actually propagates the English change into the translation, then update the marker.
+3. The CI (final i18n step) will block merges on a marker SHA that does not match the canonical file's latest.
+
+## Expressly non-goals
+
+- **Not goal**: Translate once and freeze. Translations are expected to follow English every time it changes meaningfully.
+- **Not goal**: Provide localized runtime text in the CLI. The CLI stays English unless a real i18n framework is added later.
+- **Not goal**: Machine-translate English files into target languages without human or agent review. A translator (human or agent) must apply this brief and the glossary, not just run Google Translate.

--- a/docs/i18n/glossary.md
+++ b/docs/i18n/glossary.md
@@ -1,0 +1,37 @@
+# Translation Glossary (English / 简体中文 / 日本語)
+
+This document fixes translations of core cc-clip terminology so every translated file uses consistent wording. If a term is missing or a row is ambiguous, propose an edit here *before* translating documentation that uses the term — that keeps all translated files aligned to the same dictionary.
+
+| English | 简体中文 | 日本語 | Notes |
+|---|---|---|---|
+| clipboard | 剪贴板 | クリップボード | Standard translation in all three languages. |
+| shim | shim / 兼容层 | shim / 互換レイヤー | Prefer the English word on first use, then 兼容层 / 互換レイヤー in follow-ups. |
+| tunnel | 隧道 | トンネル | Refers to the SSH `RemoteForward` tunnel. |
+| daemon | 守护进程 | デーモン | The local `cc-clip serve` process. |
+| hotkey | 热键 | ホットキー | Windows global hotkey for remote paste. |
+| RemoteForward | RemoteForward | RemoteForward | Do not translate — SSH config keyword. |
+| x11-bridge | x11-bridge | x11-bridge | Do not translate — project component name. |
+| Xvfb | Xvfb | Xvfb | Do not translate — external tool name. |
+| setup | 初始化 / 设置 | セットアップ | `cc-clip setup` command itself stays in English; use 初始化/设置 when describing the action in prose. |
+| connect | 部署 / 连接 | デプロイ / 接続 | `cc-clip connect` command itself stays in English. |
+| session | 会话 | セッション | The SSH session or cc-clip session token. |
+| nonce | nonce | nonce | Do not translate — security term; same spelling in all three. |
+| bridge | 桥接器 | ブリッジ | Use for the broader pattern (notification bridge, clipboard bridge). |
+| hook (Claude Code / shell) | hook / 钩子 | フック | Technical contract; prefer English word on first use. |
+| SSH tunnel | SSH 隧道 | SSH トンネル | — |
+| launchd service | launchd 服务 | launchd サービス | macOS-specific system service. |
+| shim interception | shim 拦截 | shim によるインターセプト | Describes how cc-clip intercepts `xclip` / `wl-paste` calls. |
+
+## Non-translated surface
+
+The following stay in English in every translated file:
+
+- All command names, flags, and file paths: `cc-clip setup --codex`, `~/.ssh/config`, `127.0.0.1:18339`, etc.
+- Product names: Claude Code, Codex CLI, opencode, Ghostty, tmux, macOS, launchd, Debian/Ubuntu, RHEL/Fedora.
+- Environment variables: `CC_CLIP_PORT`, `CC_CLIP_TOKEN_TTL`, etc.
+- MIME types and protocol terms: `image/png`, `OSC 52`, `TARGETS`.
+- GitHub links, issue numbers, release tags: `#27`, `v0.6.0`, `anomalyco/opencode#19294`.
+
+## Style cross-reference
+
+When in doubt about tone, pronoun usage, or section structure, consult [TRANSLATION_BRIEF.md](TRANSLATION_BRIEF.md).

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -1,0 +1,21 @@
+# docs/ja/ — 日本語翻訳ディレクトリ
+
+このディレクトリには、`docs/` 配下の user-facing サブドキュメントの日本語訳を配置します。
+
+## 翻訳済みドキュメント
+
+現在は i18n scaffold フェーズで、翻訳ファイルはまだコミットされていません。サブドキュメント一覧（英語版が正本）:
+
+- `troubleshooting.md` → トラブルシューティング
+- `windows-quickstart.md` → Windows クイックスタート
+- `notifications.md` → 通知
+- `commands.md` → コマンドリファレンス
+
+## 翻訳ルール
+
+翻訳フロー、文体、用語、source-hash marker 規約は以下を参照してください:
+
+- ルール: [`docs/i18n/TRANSLATION_BRIEF.md`](../i18n/TRANSLATION_BRIEF.md)
+- 用語集: [`docs/i18n/glossary.md`](../i18n/glossary.md)
+
+それまでは英語版を参照してください: [English docs](../).

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -1,0 +1,21 @@
+# docs/zh-CN/ — 简体中文翻译目录
+
+本目录存放 `docs/` 下各 user-facing 子文档的简体中文翻译。
+
+## 已翻译文档
+
+目前为 i18n scaffold 阶段，翻译文件尚未提交。完整子文档清单（以英文原版为准）：
+
+- `troubleshooting.md` → 排查指南
+- `windows-quickstart.md` → Windows 快速上手
+- `notifications.md` → 通知
+- `commands.md` → 命令参考
+
+## 翻译规则
+
+翻译流程、风格、术语、source-hash marker 约定详见：
+
+- 规则：[`docs/i18n/TRANSLATION_BRIEF.md`](../i18n/TRANSLATION_BRIEF.md)
+- 术语表：[`docs/i18n/glossary.md`](../i18n/glossary.md)
+
+在此之前，请参阅对应的 [English docs](../).


### PR DESCRIPTION
Step 2 of the 5-step i18n sequence (step 1 landed as #35). Lays down the directory layout, language switcher, source-hash marker convention, translation brief, and glossary before translation work starts.

**Intentionally left as draft** until the translation work (step 3) is ready to start — kept visible on the PR board so the scaffold shape is reviewable, but not yet expected to merge.

## What this PR does

### Adds
- `README.zh-CN.md`, `README.ja.md` — stubs with language switcher, canonical-English disclaimer, and `i18n-source: README.md @ d15a990` marker pinned to the current README.md HEAD.
- `docs/i18n/TRANSLATION_BRIEF.md` — voice / tone / structure / source-marker rules. Per-language tone guidance (Chinese: plain 2nd-person, no "您"; Japanese: です・ます form). Covers what does and does not get translated. Specifies how CI-of-the-future will enforce the source-hash markers.
- `docs/i18n/glossary.md` — 17 core terms with EN / 简体中文 / 日本語 mappings. Lists non-translated surface (command names, flags, env vars, GitHub IDs).
- `docs/zh-CN/README.md`, `docs/ja/README.md` — directory placeholders so the subdoc translation targets are discoverable now.

### Modifies
- `README.md` — adds a language switcher bar at the top. Current language is bold; other languages are links.

## What it does NOT do

- Does not translate any content. All translated surface is either placeholder text directing readers to the English canonical or scaffolding describing the i18n convention.
- Does not add CI. Source-hash enforcement comes in step 5 of the sequence.
- Does not touch agent-facing files (`CLAUDE.md`, `AGENTS.md`) — those stay English by explicit brief.

## Rationale for each design choice

| Choice | Why |
|---|---|
| Root-level `README.zh-CN.md` / `README.ja.md` (not nested in `docs/i18n/`) | GitHub repo browse + SEO discoverability. Three top-level READMEs are the industry convention (Vue, Next.js, zod). |
| Subdocs under `docs/zh-CN/` / `docs/ja/` (not at root) | Avoids cluttering the root for long-tail files. The subdoc translations are content-heavy and less surface-visible than READMEs. |
| `<!-- i18n-source: README.md @ <sha> -->` marker | Reviewer-preferred: a commit-hash anchor is falsifiable (CI can check) and semantically means "this translation reflects source state X," unlike a plain timestamp. |
| `简体中文` only, no `繁體中文` (yet) | Scope control. zh-TW is a deliberate future decision; adding it doubles maintenance. |
| です・ます 日本語 体 | Technical documentation convention; preserves clarity and professionalism without tipping into overly-formal 敬語. |

## Next steps in the i18n sequence

3. Translate `README.md` into `README.zh-CN.md` and `README.ja.md` (separate PR, can be handed to a translation-specialized agent following `docs/i18n/TRANSLATION_BRIEF.md`).
4. Translate each `docs/*.md` user-facing file.
5. Add the `i18n-sync-check` CI workflow that parses the `i18n-source` marker and fails the build if translations fall behind.

This PR stays in draft until translation PRs are ready to stack on top, to avoid landing empty placeholders on `main`. If you want to merge it as scaffold-only and let translation PRs target a populated but not-yet-content main, just mark ready.

## Verification

- [x] `make test` — full suite passes (no code changed)
- [x] All scaffold files present; language bar reachable from every entry point
- [x] Current English `README.md` commit SHA used in stubs matches the canonical at branch-point (`d15a990`)
- [x] No files modified outside of intended scaffold scope

Refs: v0.6.0 post-release plan; follows #35 (slim + Codex clarity) as step 2 of 5.