### PR TITLE
docs(cli): list --from-codex-stdin in cc-clip --help

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -143,11 +143,12 @@ Diagnostics:
 
 Notifications:
   notify             Send a notification to the local daemon
-    --title          Notification title
-    --body           Notification body
-    --urgency        Urgency level (default: 1)
-    --from-codex     Parse Codex JSON payload (extracts last-assistant-message)
-    --port           Daemon port (default: 18339, env: CC_CLIP_PORT)
+    --title              Notification title
+    --body               Notification body
+    --urgency            Urgency level (default: 1)
+    --from-codex         Parse Codex JSON payload (extracts last-assistant-message)
+    --from-codex-stdin   Read Codex JSON payload from stdin (mutually exclusive with --from-codex)
+    --port               Daemon port (default: 18339, env: CC_CLIP_PORT)
 
 Internal (used by deploy):
   x11-bridge         X11 clipboard bridge daemon (started by connect --codex)


### PR DESCRIPTION
Closes #36.

## Problem

`cc-clip notify` supports two mutually-exclusive Codex JSON input modes:

- `--from-codex "$1"` — parse JSON passed as a string argument
- `--from-codex-stdin` — read JSON from stdin

Both are real, both work at runtime, and both have been documented in `docs/commands.md` since #35. The top-level `cc-clip --help` output, however, only listed `--from-codex`. Users who discover flags by running `cc-clip` with no args (before reading `docs/`) would miss the stdin variant.

Surfaced in the #35 review as a LOW-priority CLI discoverability gap and tracked as #36 for opportunistic patching.

## Fix

Pure help-text change in `cmd/cc-clip/main.go`. Added one line under `--from-codex` for `--from-codex-stdin`, noting that the two flags are mutually exclusive (which the runtime already enforces at `main.go:1522`, but was invisible to help-only readers).

Also widened flag-description column alignment from 16 to 21 characters so the longest flag name fits consistently across the whole Notifications block.

## Before

```
Notifications:
  notify             Send a notification to the local daemon
    --title          Notification title
    --body           Notification body
    --urgency        Urgency level (default: 1)
    --from-codex     Parse Codex JSON payload (extracts last-assistant-message)
    --port           Daemon port (default: 18339, env: CC_CLIP_PORT)
```

## After

```
Notifications:
  notify             Send a notification to the local daemon
    --title              Notification title
    --body               Notification body
    --urgency            Urgency level (default: 1)
    --from-codex         Parse Codex JSON payload (extracts last-assistant-message)
    --from-codex-stdin   Read Codex JSON payload from stdin (mutually exclusive with --from-codex)
    --port               Daemon port (default: 18339, env: CC_CLIP_PORT)
```

## Verification

- [x] `go build ./cmd/cc-clip` — passes
- [x] Running the built binary with no args shows the new line in the expected place
- [x] `make test` — full suite passes (no code paths touched, only the embedded help string)
- [x] `make vet` — clean

## Size

`cmd/cc-clip/main.go`: +6 / -5 lines. No other files touched.

Refs #35 (review origin), closes #36.