### PR TITLE
fix(cli): accept positional image path for send

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The 10 you'll actually use:
 | `cc-clip status` | Show local component status |
 | `cc-clip service install` / `service uninstall` | Manage macOS launchd daemon auto-start |
 | `cc-clip notify --title T --body B` | Send a generic notification through the tunnel |
-| `cc-clip send [<host>] --paste` | Windows: upload clipboard image and paste remote path |
+| `cc-clip send [<host>] [<file>] --paste` | Windows: upload clipboard image or saved file and paste remote path |
 | `cc-clip hotkey [<host>]` | Windows: register the remote upload/paste hotkey |
 
 Full command reference, including all flags and environment variables: **[docs/commands.md](docs/commands.md)**. Or run `cc-clip --help` for the authoritative list from the installed binary.

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -103,7 +103,8 @@ Remote:
     --host           Also clean up PATH marker on remote host
   paste              Fetch clipboard image and output path
     --out-dir        Output directory (env: CC_CLIP_OUT_DIR)
-  send [<host>]      Upload local clipboard image to remote file path
+  send [<host>] [<file>]
+                      Upload local clipboard image or file to remote file path
     --file           Upload this image file instead of reading the clipboard
     --remote-dir     Remote directory (default: ~/.cache/cc-clip/uploads)
     --paste          On Windows, paste the remote path into the active window

--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -17,30 +18,25 @@ import (
 )
 
 const defaultRemoteUploadDir = "~/.cache/cc-clip/uploads"
+const sendUsage = "usage: cc-clip send [<host>] [<file>] [--file PATH] [--remote-dir DIR] [--paste] [--delay-ms N] [--no-restore]"
+
+type sendOptions struct {
+	host      string
+	localFile string
+	remoteDir string
+	paste     bool
+	delayMS   int
+	noRestore bool
+}
 
 func cmdSend() {
-	host := ""
-	flagArgs := os.Args[2:]
-	if len(os.Args) > 2 && !strings.HasPrefix(os.Args[2], "-") {
-		host = os.Args[2]
-		flagArgs = os.Args[3:]
-	}
-
-	fs := flag.NewFlagSet("send", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
-
-	localFile := fs.String("file", "", "upload this image file instead of reading the clipboard")
-	remoteDir := fs.String("remote-dir", defaultRemoteUploadDir, "remote upload directory")
-	paste := fs.Bool("paste", false, "paste the remote path into the active window")
-	delayMS := fs.Int("delay-ms", 150, "delay before Ctrl+Shift+V when --paste is used")
-	noRestore := fs.Bool("no-restore", false, "do not restore the original image clipboard after --paste")
-
-	if err := fs.Parse(flagArgs); err != nil {
+	cfg, err := parseSendArgs(os.Args[2:], os.Stderr)
+	if err != nil {
 		log.Fatal(err)
 	}
-	if *delayMS < 0 {
-		log.Fatalf("invalid --delay-ms: %d", *delayMS)
-	}
+
+	host := cfg.host
+
 	if host == "" {
 		var ok bool
 		var err error
@@ -49,12 +45,12 @@ func cmdSend() {
 			log.Fatalf("cannot resolve default host: %v", err)
 		}
 		if !ok || host == "" {
-			log.Fatal("usage: cc-clip send [<host>] [--file PATH] [--remote-dir DIR] [--paste] [--delay-ms N] [--no-restore]")
+			log.Fatal(sendUsage)
 		}
 	}
-	restoreClipboard := !*noRestore
+	restoreClipboard := !cfg.noRestore
 
-	result, err := uploadImage(host, *remoteDir, *localFile)
+	result, err := uploadImage(host, cfg.remoteDir, cfg.localFile)
 	if err != nil {
 		log.Fatalf("send failed: %v", err)
 	}
@@ -64,13 +60,135 @@ func cmdSend() {
 
 	fmt.Println(result.RemotePath)
 
-	if !*paste {
+	if !cfg.paste {
 		return
 	}
 
-	if err := pasteRemotePath(result.RemotePath, result.LocalImagePath, time.Duration(*delayMS)*time.Millisecond, restoreClipboard); err != nil {
+	if err := pasteRemotePath(result.RemotePath, result.LocalImagePath, time.Duration(cfg.delayMS)*time.Millisecond, restoreClipboard); err != nil {
 		log.Fatalf("send uploaded the image but failed to inject the remote path: %v", err)
 	}
+}
+
+func parseSendArgs(args []string, output io.Writer) (sendOptions, error) {
+	cfg := sendOptions{
+		remoteDir: defaultRemoteUploadDir,
+		delayMS:   150,
+	}
+	flagArgs, positionalFile, err := consumeLeadingSendPositionals(&cfg, args)
+	if err != nil {
+		return cfg, err
+	}
+
+	fs := flag.NewFlagSet("send", flag.ContinueOnError)
+	fs.SetOutput(output)
+
+	localFile := fs.String("file", "", "upload this image file instead of reading the clipboard")
+	remoteDir := fs.String("remote-dir", defaultRemoteUploadDir, "remote upload directory")
+	paste := fs.Bool("paste", false, "paste the remote path into the active window")
+	delayMS := fs.Int("delay-ms", 150, "delay before Ctrl+Shift+V when --paste is used")
+	noRestore := fs.Bool("no-restore", false, "do not restore the original image clipboard after --paste")
+
+	if err := fs.Parse(flagArgs); err != nil {
+		return cfg, err
+	}
+	if *delayMS < 0 {
+		return cfg, fmt.Errorf("invalid --delay-ms: %d", *delayMS)
+	}
+
+	cfg.localFile = *localFile
+	cfg.remoteDir = *remoteDir
+	cfg.paste = *paste
+	cfg.delayMS = *delayMS
+	cfg.noRestore = *noRestore
+
+	if positionalFile != "" {
+		if err := setPositionalSendFile(&cfg, positionalFile); err != nil {
+			return cfg, err
+		}
+	}
+	if err := applySendPositionals(&cfg, fs.Args()); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func consumeLeadingSendPositionals(cfg *sendOptions, args []string) ([]string, string, error) {
+	leading := make([]string, 0, 2)
+	flagStart := 0
+	for flagStart < len(args) && !strings.HasPrefix(args[flagStart], "-") {
+		leading = append(leading, args[flagStart])
+		flagStart++
+	}
+	if len(leading) > 2 {
+		return nil, "", fmt.Errorf("unexpected positional arguments %q; %s", strings.Join(leading[2:], " "), sendUsage)
+	}
+
+	switch len(leading) {
+	case 0:
+		return args, "", nil
+	case 1:
+		if looksLikeImagePath(leading[0]) {
+			return args[flagStart:], leading[0], nil
+		}
+		cfg.host = leading[0]
+		return args[flagStart:], "", nil
+	default:
+		cfg.host = leading[0]
+		return args[flagStart:], leading[1], nil
+	}
+}
+
+func applySendPositionals(cfg *sendOptions, args []string) error {
+	if err := rejectFlagLikeSendPositionals(args); err != nil {
+		return err
+	}
+
+	switch {
+	case len(args) == 0:
+		return nil
+	case cfg.host != "":
+		if len(args) > 1 {
+			return fmt.Errorf("unexpected positional arguments %q; %s", strings.Join(args[1:], " "), sendUsage)
+		}
+		return setPositionalSendFile(cfg, args[0])
+	case len(args) == 1:
+		if looksLikeImagePath(args[0]) {
+			return setPositionalSendFile(cfg, args[0])
+		}
+		cfg.host = args[0]
+		return nil
+	case len(args) == 2:
+		cfg.host = args[0]
+		return setPositionalSendFile(cfg, args[1])
+	default:
+		return fmt.Errorf("unexpected positional arguments %q; %s", strings.Join(args[2:], " "), sendUsage)
+	}
+}
+
+func rejectFlagLikeSendPositionals(args []string) error {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			return fmt.Errorf("flag %q must appear before positional arguments; %s", arg, sendUsage)
+		}
+	}
+	return nil
+}
+
+func setPositionalSendFile(cfg *sendOptions, file string) error {
+	if cfg.localFile != "" {
+		return fmt.Errorf("cannot use both --file and positional image path %q", file)
+	}
+	cfg.localFile = file
+	return nil
+}
+
+func looksLikeImagePath(arg string) bool {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(arg)), ".")
+	switch ext {
+	case "png", "jpg", "jpeg", "gif", "webp", "bmp", "tif", "tiff", "heic":
+		return true
+	}
+	return false
 }
 
 type uploadResult struct {
@@ -93,7 +211,7 @@ func uploadClipboardImage(host, remoteDir string) (*uploadResult, error) {
 		return nil, fmt.Errorf("clipboard probe failed: %w", err)
 	}
 	if info.Type != daemon.ClipboardImage {
-		return nil, fmt.Errorf("no image in clipboard (type: %s)", info.Type)
+		return nil, fmt.Errorf("no image in clipboard (type: %s); use --file PATH or a positional image path to upload a saved image", info.Type)
 	}
 
 	data, err := clip.ImageBytes()

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestParseSendArgsTreatsTrailingImagePathAsFileWithDefaultHost(t *testing.T) {
+	opts, err := parseSendArgs([]string{"--paste", `C:\test.png`}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "" {
+		t.Fatalf("expected host to remain default-resolved, got %q", opts.host)
+	}
+	if opts.localFile != `C:\test.png` {
+		t.Fatalf("expected localFile %q, got %q", `C:\test.png`, opts.localFile)
+	}
+	if !opts.paste {
+		t.Fatal("expected --paste to be true")
+	}
+}
+
+func TestParseSendArgsTreatsTrailingNonImageAsHost(t *testing.T) {
+	opts, err := parseSendArgs([]string{"--paste", "myserver"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "myserver" {
+		t.Fatalf("expected host %q, got %q", "myserver", opts.host)
+	}
+	if opts.localFile != "" {
+		t.Fatalf("expected no localFile, got %q", opts.localFile)
+	}
+}
+
+func TestParseSendArgsAllowsHostThenTrailingFile(t *testing.T) {
+	opts, err := parseSendArgs([]string{"myserver", "--paste", `C:\test.png`}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "myserver" {
+		t.Fatalf("expected host %q, got %q", "myserver", opts.host)
+	}
+	if opts.localFile != `C:\test.png` {
+		t.Fatalf("expected localFile %q, got %q", `C:\test.png`, opts.localFile)
+	}
+}
+
+func TestParseSendArgsAllowsPostFlagHostThenFile(t *testing.T) {
+	opts, err := parseSendArgs([]string{"--paste", "myserver", `C:\test.png`}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "myserver" {
+		t.Fatalf("expected host %q, got %q", "myserver", opts.host)
+	}
+	if opts.localFile != `C:\test.png` {
+		t.Fatalf("expected localFile %q, got %q", `C:\test.png`, opts.localFile)
+	}
+}
+
+func TestParseSendArgsAllowsFileThenFlagsWithDefaultHost(t *testing.T) {
+	opts, err := parseSendArgs([]string{`C:\test.png`, "--paste"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "" {
+		t.Fatalf("expected host to remain default-resolved, got %q", opts.host)
+	}
+	if opts.localFile != `C:\test.png` {
+		t.Fatalf("expected localFile %q, got %q", `C:\test.png`, opts.localFile)
+	}
+	if !opts.paste {
+		t.Fatal("expected --paste to be true")
+	}
+}
+
+func TestParseSendArgsAllowsHostAndFileThenFlags(t *testing.T) {
+	opts, err := parseSendArgs([]string{"myserver", `C:\test.png`, "--paste"}, io.Discard)
+	if err != nil {
+		t.Fatalf("parseSendArgs returned error: %v", err)
+	}
+	if opts.host != "myserver" {
+		t.Fatalf("expected host %q, got %q", "myserver", opts.host)
+	}
+	if opts.localFile != `C:\test.png` {
+		t.Fatalf("expected localFile %q, got %q", `C:\test.png`, opts.localFile)
+	}
+	if !opts.paste {
+		t.Fatal("expected --paste to be true")
+	}
+}
+
+func TestParseSendArgsRejectsFileFlagAndPositionalFile(t *testing.T) {
+	_, err := parseSendArgs([]string{"--file", "a.png", "b.png"}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot use both --file and positional image path") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSendArgsRejectsExtraPositionalsWithHost(t *testing.T) {
+	_, err := parseSendArgs([]string{"myserver", "--paste", "a.png", "b.png"}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unexpected positional arguments") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSendArgsRejectsFlagAfterPostFlagPositionals(t *testing.T) {
+	_, err := parseSendArgs([]string{"--remote-dir", "uploads", `C:\test.png`, "--paste"}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "must appear before positional arguments") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSendArgsRejectsNegativeDelay(t *testing.T) {
+	_, err := parseSendArgs([]string{"--delay-ms", "-1"}, io.Discard)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "invalid --delay-ms") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -30,8 +30,8 @@ Complete cc-clip command reference. For the 10 most common commands, see the [Co
 
 | Command | Description |
 |---------|-------------|
-| `cc-clip send [<host>]` | Upload clipboard image to a remote file |
-| `cc-clip send [<host>] --paste` | Windows: paste the uploaded remote path into the active window |
+| `cc-clip send [<host>] [<file>]` | Upload clipboard image, or a saved image file, to a remote file |
+| `cc-clip send [<host>] [<file>] --paste` | Windows: paste the uploaded remote path into the active window |
 | `cc-clip hotkey [<host>]` | Windows: run a background remote-paste hotkey listener |
 | `cc-clip hotkey --enable-autostart` | Windows: start the hotkey listener automatically at login |
 | `cc-clip hotkey --disable-autostart` | Windows: remove hotkey auto-start at login |

--- a/docs/windows-quickstart.md
+++ b/docs/windows-quickstart.md
@@ -126,6 +126,12 @@ Or, after you already saved a default host:
 cc-clip send --paste
 ```
 
+If you already saved the image as a file, pass it directly:
+
+```powershell
+cc-clip send --paste C:\path\to\screenshot.png
+```
+
 ## Change Host or Hotkey Later
 
 Change the default remote host:


### PR DESCRIPTION
## Summary
- Treat a single positional image path as the send file input, equivalent to --file
- Preserve host-first/default-host forms and reject ambiguous extra positionals or flags after post-flag positionals
- Add parser regression coverage and update CLI/docs help text for send [<host>] [<file>]

## Context
Follow-up to the #30 Windows smoke-test feedback where cc-clip send --paste C:\test.png appeared to work. The old parser left that path in fs.Args() and silently read the clipboard instead.

## Tests
- go test ./cmd/cc-clip -run TestParseSendArgs -count=1
- go test ./... -count=1
- go vet ./...
- go run ./cmd/cc-clip --help
- env GOOS=windows GOARCH=amd64 go test -c ./cmd/cc-clip -o /tmp/cc-clip-windows.test.exe

Not tested: real Windows clipboard paste against a remote host.