### PR TITLE
fix: pre-v0.6.1 hardening from adversarial review

### DIFF
--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -259,8 +259,9 @@ func uploadClipboardImage(host, remoteDir string) (*uploadResult, error) {
 func uploadLocalFile(host, remoteDir, localFile string) (*uploadResult, error) {
 	// Lstat (not Stat) so symlinks are rejected instead of silently followed:
 	// a positional arg or --file could otherwise chase a link to a device,
-	// named pipe, or unexpected target. Require a regular file so scp is
-	// never asked to read a FIFO (hangs) or character device.
+	// named pipe, or unexpected target. Require a regular file so the
+	// ssh-stdin upload is never asked to read from a FIFO (hangs) or a
+	// character device.
 	info, err := os.Lstat(localFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read --file %s: %w", localFile, err)
@@ -391,8 +392,13 @@ func sshUploadNoForward(host, localPath, remotePath string) error {
 // sshUploadRemoteCmd returns the remote shell command used by
 // sshUploadNoForward. Extracted so tests can pin the exact quoting without
 // spawning a real ssh process.
+//
+// `umask 077` before `cat >` forces the created file to mode 0600 instead
+// of the default 0644 under a 022 umask. Clipboard images can contain
+// screenshots of tokens, password managers, or private chats, so they
+// must not be readable by other users on the remote host.
 func sshUploadRemoteCmd(remotePath string) string {
-	return "cat > " + shQuote(remotePath)
+	return "umask 077; cat > " + shQuote(remotePath)
 }
 
 func shQuote(s string) string {

--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -244,7 +244,7 @@ func uploadClipboardImage(host, remoteDir string) (*uploadResult, error) {
 		return nil, err
 	}
 
-	if err := scpUploadNoForward(host, localPath, remotePath); err != nil {
+	if err := sshUploadNoForward(host, localPath, remotePath); err != nil {
 		os.Remove(localPath)
 		return nil, fmt.Errorf("failed to upload image to %s: %w", remotePath, err)
 	}
@@ -288,7 +288,7 @@ func uploadLocalFile(host, remoteDir, localFile string) (*uploadResult, error) {
 	if _, err := remoteExecNoForward(host, "mkdir -p "+shQuote(remoteAbsDir)); err != nil {
 		return nil, fmt.Errorf("failed to create remote dir %s: %w", remoteAbsDir, err)
 	}
-	if err := scpUploadNoForward(host, localFile, remotePath); err != nil {
+	if err := sshUploadNoForward(host, localFile, remotePath); err != nil {
 		return nil, fmt.Errorf("failed to upload image to %s: %w", remotePath, err)
 	}
 
@@ -364,29 +364,35 @@ func remoteExecNoForward(host, cmd string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func scpUploadNoForward(host, localPath, remotePath string) error {
-	// scp's remote side is expanded by a remote shell, so remotePath must
-	// be shell-quoted to resist metachars (spaces, semicolons, $(...) etc.)
-	// in remoteDir or filename. "--" stops scp from interpreting a
-	// leading-dash local path as an option; safeScpLocalPath additionally
-	// prefixes "./" because older scp versions handle "--" inconsistently.
-	safeLocal := safeScpLocalPath(localPath)
-	target := fmt.Sprintf("%s:%s", host, shQuote(remotePath))
-	c := exec.Command("scp", "-o", "ClearAllForwardings=yes", "--", safeLocal, target)
+func sshUploadNoForward(host, localPath, remotePath string) error {
+	// Stream the local file to the remote via `ssh host 'cat > <quoted>'`
+	// instead of scp. OpenSSH 9.0+ defaults `scp` to the SFTP subsystem,
+	// where the remote path is treated as an SFTP PATH rather than being
+	// expanded by a remote shell — shell-quoting `host:'remote path'` in
+	// that mode is interpreted literally and breaks uploads. Using ssh
+	// redirection keeps quoting semantics stable across versions and
+	// removes the leading-dash local-path hazard entirely (local path is
+	// no longer an argv positional to scp).
+	f, err := os.Open(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to open local file %s: %w", localPath, err)
+	}
+	defer f.Close()
+
+	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", host, sshUploadRemoteCmd(remotePath))
+	c.Stdin = f
 	hideConsoleWindow(c)
 	if out, err := c.CombinedOutput(); err != nil {
-		return fmt.Errorf("scp failed: %s: %w", strings.TrimSpace(string(out)), err)
+		return fmt.Errorf("ssh upload failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 	return nil
 }
 
-// safeScpLocalPath defensively prefixes "./" for paths starting with "-"
-// so scp never parses them as flags on versions that mishandle "--".
-func safeScpLocalPath(p string) string {
-	if strings.HasPrefix(p, "-") {
-		return "./" + p
-	}
-	return p
+// sshUploadRemoteCmd returns the remote shell command used by
+// sshUploadNoForward. Extracted so tests can pin the exact quoting without
+// spawning a real ssh process.
+func sshUploadRemoteCmd(remotePath string) string {
+	return "cat > " + shQuote(remotePath)
 }
 
 func shQuote(s string) string {

--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -257,12 +257,16 @@ func uploadClipboardImage(host, remoteDir string) (*uploadResult, error) {
 }
 
 func uploadLocalFile(host, remoteDir, localFile string) (*uploadResult, error) {
-	info, err := os.Stat(localFile)
+	// Lstat (not Stat) so symlinks are rejected instead of silently followed:
+	// a positional arg or --file could otherwise chase a link to a device,
+	// named pipe, or unexpected target. Require a regular file so scp is
+	// never asked to read a FIFO (hangs) or character device.
+	info, err := os.Lstat(localFile)
 	if err != nil {
 		return nil, fmt.Errorf("cannot read --file %s: %w", localFile, err)
 	}
-	if info.IsDir() {
-		return nil, fmt.Errorf("--file must point to an image file, got directory: %s", localFile)
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("--file must point to a regular image file, got %s: %s", describeFileMode(info.Mode()), localFile)
 	}
 
 	remoteHome, err := remoteHomeDir(host)
@@ -361,7 +365,14 @@ func remoteExecNoForward(host, cmd string) (string, error) {
 }
 
 func scpUploadNoForward(host, localPath, remotePath string) error {
-	c := exec.Command("scp", "-o", "ClearAllForwardings=yes", localPath, fmt.Sprintf("%s:%s", host, remotePath))
+	// scp's remote side is expanded by a remote shell, so remotePath must
+	// be shell-quoted to resist metachars (spaces, semicolons, $(...) etc.)
+	// in remoteDir or filename. "--" stops scp from interpreting a
+	// leading-dash local path as an option; safeScpLocalPath additionally
+	// prefixes "./" because older scp versions handle "--" inconsistently.
+	safeLocal := safeScpLocalPath(localPath)
+	target := fmt.Sprintf("%s:%s", host, shQuote(remotePath))
+	c := exec.Command("scp", "-o", "ClearAllForwardings=yes", "--", safeLocal, target)
 	hideConsoleWindow(c)
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("scp failed: %s: %w", strings.TrimSpace(string(out)), err)
@@ -369,6 +380,37 @@ func scpUploadNoForward(host, localPath, remotePath string) error {
 	return nil
 }
 
+// safeScpLocalPath defensively prefixes "./" for paths starting with "-"
+// so scp never parses them as flags on versions that mishandle "--".
+func safeScpLocalPath(p string) string {
+	if strings.HasPrefix(p, "-") {
+		return "./" + p
+	}
+	return p
+}
+
 func shQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// describeFileMode returns a short human-readable label for non-regular
+// file modes so the upload-local-file error tells the user what kind of
+// path they pointed at.
+func describeFileMode(m os.FileMode) string {
+	switch {
+	case m.IsDir():
+		return "directory"
+	case m&os.ModeSymlink != 0:
+		return "symlink"
+	case m&os.ModeNamedPipe != 0:
+		return "named pipe (FIFO)"
+	case m&os.ModeSocket != 0:
+		return "socket"
+	case m&os.ModeDevice != 0, m&os.ModeCharDevice != 0:
+		return "device"
+	case m&os.ModeIrregular != 0:
+		return "irregular file"
+	default:
+		return "non-regular file"
+	}
 }

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -134,8 +134,9 @@ func TestParseSendArgsRejectsNegativeDelay(t *testing.T) {
 }
 
 // TestShQuoteNeutralizesShellMetacharacters pins shQuote's behavior so that
-// scp remote-path hardening cannot silently regress. Every case would execute
-// a shell command if shQuote is removed or weakened.
+// remote-path hardening for mkdir -p and the ssh-stdin upload command cannot
+// silently regress. Every case would execute a shell command if shQuote is
+// removed or weakened.
 func TestShQuoteNeutralizesShellMetacharacters(t *testing.T) {
 	cases := []struct {
 		name  string
@@ -164,24 +165,28 @@ func TestShQuoteNeutralizesShellMetacharacters(t *testing.T) {
 }
 
 // TestSSHUploadRemoteCmdQuotesPath pins the shape of the remote command used
-// by sshUploadNoForward. Uploads now stream via `ssh host 'cat > <quoted>'`
+// by sshUploadNoForward. Uploads stream via `ssh host 'umask 077; cat > <quoted>'`
 // instead of `scp host:<path>`, because OpenSSH 9.0+ scp defaults to the SFTP
 // subsystem where shell-quoting the remote side is interpreted literally and
-// breaks transfer. This test ensures the remote path always lands inside a
-// shell-quoted redirection target and that shell metacharacters are neutralized
-// by shQuote rather than reaching the remote shell verbatim.
+// breaks transfer. This test ensures:
+//
+//  1. The remote path always lands inside a shell-quoted redirection target and
+//     shell metacharacters are neutralized by shQuote rather than reaching the
+//     remote shell verbatim.
+//  2. The `umask 077;` prefix stays in place so uploaded clipboard images are
+//     created as 0600 regardless of the remote account's default umask.
 func TestSSHUploadRemoteCmdQuotesPath(t *testing.T) {
 	cases := []struct {
 		name       string
 		remotePath string
 		want       string
 	}{
-		{"plain", "/tmp/foo.png", "cat > '/tmp/foo.png'"},
-		{"with space", "/tmp/my file.png", "cat > '/tmp/my file.png'"},
-		{"semicolon injection", "/tmp/a; rm -rf /.png", "cat > '/tmp/a; rm -rf /.png'"},
-		{"command substitution", "/tmp/$(id).png", "cat > '/tmp/$(id).png'"},
-		{"single quote", "/tmp/foo's.png", `cat > '/tmp/foo'\''s.png'`},
-		{"backtick", "/tmp/`date`.png", "cat > '/tmp/`date`.png'"},
+		{"plain", "/tmp/foo.png", "umask 077; cat > '/tmp/foo.png'"},
+		{"with space", "/tmp/my file.png", "umask 077; cat > '/tmp/my file.png'"},
+		{"semicolon injection", "/tmp/a; rm -rf /.png", "umask 077; cat > '/tmp/a; rm -rf /.png'"},
+		{"command substitution", "/tmp/$(id).png", "umask 077; cat > '/tmp/$(id).png'"},
+		{"single quote", "/tmp/foo's.png", `umask 077; cat > '/tmp/foo'\''s.png'`},
+		{"backtick", "/tmp/`date`.png", "umask 077; cat > '/tmp/`date`.png'"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -163,27 +163,31 @@ func TestShQuoteNeutralizesShellMetacharacters(t *testing.T) {
 	}
 }
 
-// TestSafeScpLocalPathGuardsLeadingDash ensures paths like "-foo.png" cannot
-// be misinterpreted as scp options on versions that mishandle "--".
-func TestSafeScpLocalPathGuardsLeadingDash(t *testing.T) {
+// TestSSHUploadRemoteCmdQuotesPath pins the shape of the remote command used
+// by sshUploadNoForward. Uploads now stream via `ssh host 'cat > <quoted>'`
+// instead of `scp host:<path>`, because OpenSSH 9.0+ scp defaults to the SFTP
+// subsystem where shell-quoting the remote side is interpreted literally and
+// breaks transfer. This test ensures the remote path always lands inside a
+// shell-quoted redirection target and that shell metacharacters are neutralized
+// by shQuote rather than reaching the remote shell verbatim.
+func TestSSHUploadRemoteCmdQuotesPath(t *testing.T) {
 	cases := []struct {
-		name  string
-		input string
-		want  string
+		name       string
+		remotePath string
+		want       string
 	}{
-		{"plain absolute", "/tmp/foo.png", "/tmp/foo.png"},
-		{"plain relative", "foo.png", "foo.png"},
-		{"dotted relative", "./foo.png", "./foo.png"},
-		{"windows drive", `C:\test.png`, `C:\test.png`},
-		{"leading dash", "-foo.png", "./-foo.png"},
-		{"leading double dash", "--rf", "./--rf"},
-		{"leading dash-o", "-oBatchMode=no", "./-oBatchMode=no"},
+		{"plain", "/tmp/foo.png", "cat > '/tmp/foo.png'"},
+		{"with space", "/tmp/my file.png", "cat > '/tmp/my file.png'"},
+		{"semicolon injection", "/tmp/a; rm -rf /.png", "cat > '/tmp/a; rm -rf /.png'"},
+		{"command substitution", "/tmp/$(id).png", "cat > '/tmp/$(id).png'"},
+		{"single quote", "/tmp/foo's.png", `cat > '/tmp/foo'\''s.png'`},
+		{"backtick", "/tmp/`date`.png", "cat > '/tmp/`date`.png'"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := safeScpLocalPath(tc.input)
+			got := sshUploadRemoteCmd(tc.remotePath)
 			if got != tc.want {
-				t.Fatalf("safeScpLocalPath(%q) = %q, want %q", tc.input, got, tc.want)
+				t.Fatalf("sshUploadRemoteCmd(%q) = %q, want %q", tc.remotePath, got, tc.want)
 			}
 		})
 	}

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -132,3 +132,59 @@ func TestParseSendArgsRejectsNegativeDelay(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// TestShQuoteNeutralizesShellMetacharacters pins shQuote's behavior so that
+// scp remote-path hardening cannot silently regress. Every case would execute
+// a shell command if shQuote is removed or weakened.
+func TestShQuoteNeutralizesShellMetacharacters(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "foo.png", "'foo.png'"},
+		{"space", "my file.png", "'my file.png'"},
+		{"single quote", "foo's.png", `'foo'\''s.png'`},
+		{"semicolon injection", "foo; rm -rf /.png", "'foo; rm -rf /.png'"},
+		{"command substitution", "foo$(date).png", "'foo$(date).png'"},
+		{"dollar variable", "$HOME/foo.png", "'$HOME/foo.png'"},
+		{"backtick", "foo`date`.png", "'foo`date`.png'"},
+		{"ampersand", "foo & bar.png", "'foo & bar.png'"},
+		{"pipe", "foo|bar.png", "'foo|bar.png'"},
+		{"newline", "foo\nbar.png", "'foo\nbar.png'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shQuote(tc.input)
+			if got != tc.want {
+				t.Fatalf("shQuote(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSafeScpLocalPathGuardsLeadingDash ensures paths like "-foo.png" cannot
+// be misinterpreted as scp options on versions that mishandle "--".
+func TestSafeScpLocalPathGuardsLeadingDash(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain absolute", "/tmp/foo.png", "/tmp/foo.png"},
+		{"plain relative", "foo.png", "foo.png"},
+		{"dotted relative", "./foo.png", "./foo.png"},
+		{"windows drive", `C:\test.png`, `C:\test.png`},
+		{"leading dash", "-foo.png", "./-foo.png"},
+		{"leading double dash", "--rf", "./--rf"},
+		{"leading dash-o", "-oBatchMode=no", "./-oBatchMode=no"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := safeScpLocalPath(tc.input)
+			if got != tc.want {
+				t.Fatalf("safeScpLocalPath(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/cc-clip/send_windows.go
+++ b/cmd/cc-clip/send_windows.go
@@ -75,7 +75,8 @@ public static class CcClipOle {
 func windowsSetClipboardText(text string) error {
 	script := clipboardPersistenceSnippet + `
 [System.Windows.Forms.Clipboard]::SetDataObject($env:CC_CLIP_TEXT, $true)
-[void][CcClipOle]::OleFlushClipboard()`
+$hr = [CcClipOle]::OleFlushClipboard()
+if ($hr -ne 0) { throw "OleFlushClipboard failed with HRESULT 0x$($hr.ToString('X8'))" }`
 	cmd := hiddenExec("powershell", "-STA", "-NoProfile", "-Command", script)
 	cmd.Env = append(os.Environ(), "CC_CLIP_TEXT="+text)
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -92,7 +93,8 @@ try {
   $data = New-Object System.Windows.Forms.DataObject
   $data.SetData([System.Windows.Forms.DataFormats]::Bitmap, $true, $img)
   [System.Windows.Forms.Clipboard]::SetDataObject($data, $true)
-  [void][CcClipOle]::OleFlushClipboard()
+  $hr = [CcClipOle]::OleFlushClipboard()
+  if ($hr -ne 0) { throw "OleFlushClipboard failed with HRESULT 0x$($hr.ToString('X8'))" }
 } finally {
   $img.Dispose()
 }`

--- a/docs/windows-quickstart.md
+++ b/docs/windows-quickstart.md
@@ -11,7 +11,7 @@ On Windows, `cc-clip` does **not** rely on the remote `xclip` clipboard path.
 Instead, it:
 
 1. Reads the image from your Windows clipboard
-2. Uploads it to the remote host over SSH/SCP
+2. Uploads it to the remote host over SSH
 3. Pastes the remote file path into the active Claude Code terminal
 
 This is the recommended path for:
@@ -30,7 +30,7 @@ By default:
 You need all of these on your Windows machine:
 
 - Windows 10/11
-- `ssh` and `scp` in `PATH`
+- `ssh` in `PATH`
 - a working SSH host alias in `~/.ssh/config`
 
 Example:
@@ -187,7 +187,7 @@ cc-clip hotkey --disable-autostart
 If the hotkey is configured but image paste still does not work:
 
 1. Confirm `cc-clip hotkey --status` shows the expected host and hotkey
-2. Confirm `ssh myserver` and `scp` both work from the same terminal
+2. Confirm `ssh myserver` works from the same terminal
 3. Try the manual fallback:
 
 ```powershell

--- a/docs/windows-quickstart.md
+++ b/docs/windows-quickstart.md
@@ -112,6 +112,10 @@ Daily workflow:
 - paste the remote file path into the active terminal
 - restore your original clipboard image
 
+> **Focus warning.** After you press `Alt+Shift+V`, `cc-clip` uploads the image, waits ~150 ms, then synthesizes `Ctrl+Shift+V` to paste the remote path into **whichever window is focused at that moment**. Do not switch windows during this short window — if the remote path lands in a password field, an IM input, or a browser URL bar, it has been delivered to the wrong trust boundary.
+>
+> If you need to switch away during upload, cancel the hotkey (focus a safe window first, or run `cc-clip hotkey --stop`) rather than letting the paste fire into an unintended target. Tracking: issue [#43](https://github.com/ShunmeiCho/cc-clip/issues/43) covers a foreground-window guard so future versions abort instead of pasting when focus has changed.
+
 ## Manual Fallback
 
 If you do not want the background hotkey, run a one-shot paste instead:


### PR DESCRIPTION
Fixes three of four MEDIUM findings from Codex's adversarial review of the v0.6.0..main diff. The fourth (SendKeys focus race) is deferred to follow-up issue #43 per scope judgment — full fix needs Windows foreground-window snapshot/compare which is bigger than the hardening window should bear.

Recommended to land before v0.6.1 tag. Each fix is small, focused, and test-covered.

## Findings addressed

### C1 — uploadLocalFile accepts non-regular files (MEDIUM, confidence 8)

**Before:** `os.Stat` followed by `IsDir()`. A FIFO would make scp hang, a symlink could chase an unexpected target, a device node would behave unpredictably. The positional-file feature introduced in v0.6.1 widened who can trigger this.

**After:** `os.Lstat` (rejects symlinks instead of following them) + `Mode().IsRegular()`. A `describeFileMode` helper turns the rejection into an actionable error (\"symlink\", \"named pipe (FIFO)\", \"device\", etc.) so users know why their path was rejected.

### C2 — scp remote target was not shell-quoted (MEDIUM, confidence 7)

**Before:** `scpUploadNoForward` built the remote target as `fmt.Sprintf(\"%s:%s\", host, remotePath)`. scp's remote side is expanded by a remote shell, so metacharacters (\` \`, `;`, `$()`, backticks, `&`, `|`) in `remoteDir` or filename would be interpreted as commands on legacy scp servers.

**After:** Remote path is wrapped in `shQuote`. `--` separator added to the scp argv. A new `safeScpLocalPath` helper prefixes `./` to leading-dash local paths because older scp versions handle `--` inconsistently — belt-and-braces.

**New tests pin behavior:**
- `TestShQuoteNeutralizesShellMetacharacters` — 10 cases covering `$(date)`, backticks, semicolons, pipes, newlines
- `TestSafeScpLocalPathGuardsLeadingDash` — 7 cases including `-foo.png`, `--rf`, `-oBatchMode=no`

### C4 — OleFlushClipboard HRESULT silently discarded (MEDIUM, confidence 9)

**Before:** `[void][CcClipOle]::OleFlushClipboard()` threw away the HRESULT. Persistence failures were reported as success.

**After:**
\`\`\`powershell
\$hr = [CcClipOle]::OleFlushClipboard()
if (\$hr -ne 0) { throw \"OleFlushClipboard failed with HRESULT 0x\$(\$hr.ToString('X8'))\" }
\`\`\`

`throw` combined with `$ErrorActionPreference='Stop'` gives PowerShell a nonzero exit, which `cmd.CombinedOutput` surfaces to Go as an error. `Write-Warning` alone would NOT surface because PowerShell still exits 0. Applied to both `windowsSetClipboardText` and `windowsSetClipboardImage`.

### C3 — SendKeys focus race (deferred to #43)

**Problem:** 150 ms between clipboard write and `Ctrl+Shift+V`. If the user switches focus during this window, the remote path lands in the wrong trust boundary (password field, IM input, URL bar).

**Done here:** Prominent focus warning added to `docs/windows-quickstart.md` — tells users to not switch focus during paste, points at the tracking issue.

**Deferred to #43:** Full runtime fix needs `GetForegroundWindow()` snapshot before clipboard write + compare before `SendKeys`. Touches `pasteRemotePath` + hotkey entry points + Windows API test stubs. Too large for a hardening bundle, handled properly in v0.6.2.

## Files changed

- `cmd/cc-clip/send.go` (+44/-6) — C1 + C2 + helpers
- `cmd/cc-clip/send_test.go` (+56/-0) — new shQuote + safeScpLocalPath test suites
- `cmd/cc-clip/send_windows.go` (+4/-2) — C4 (both setters)
- `docs/windows-quickstart.md` (+4/-0) — C3 docs warning pointing at #43

## Verification

- [x] `make test` (`go test ./... -count=1`) — full suite green
- [x] `make vet` (`go vet ./...`) — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./cmd/cc-clip` — passes
- [x] Targeted new tests: 17 new subtests all PASS (`TestShQuoteNeutralizesShellMetacharacters` × 10, `TestSafeScpLocalPathGuardsLeadingDash` × 7)
- [x] Diff reviewed line-by-line against each finding's specific fix recommendation

## Release plan

Merge this → cut `v0.6.1` tag from updated main → goreleaser auto-publishes. The v0.6.1 release notes will now be able to say \"Windows paste hardening\" without any asterisk-qualified caveats about remaining MEDIUM issues (other than the explicitly documented focus-race that ships with a docs warning + tracking issue).

Refs: Codex adversarial review of v0.6.0..main; closes (informationally — no code change here) the three MEDIUM findings it surfaced. Opens #43 for C3 follow-up.