### PR TITLE
ci: sync release contract check with goreleaser v2 plural schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,14 @@ jobs:
           # goreleaser must produce cc-clip_{version}_{os}_{arch}.tar.gz
           grep -qP 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
           # install.sh must expect the same format with version stripped of v prefix
-          grep -q 'cc-clip_${VERSION#v}_${PLATFORM}.tar.gz' scripts/install.sh
-          # archive format must be tar.gz (not bare binary)
-          grep -q 'format: tar.gz' .goreleaser.yaml
+          # (-F is literal match: the pattern contains ${...} / . which are
+          #  regex metacharacters — -F keeps this robust across grep flavors.)
+          grep -Fq 'cc-clip_${VERSION#v}_${PLATFORM}.tar.gz' scripts/install.sh
+          # goreleaser archives must default to tar.gz (darwin/linux); windows
+          # uses the `formats: [zip]` override in the same block. Schema is the
+          # plural GoReleaser v2 form introduced in PR #33.
+          grep -Fq 'formats: [tar.gz]' .goreleaser.yaml
+          grep -Fq 'formats: [zip]' .goreleaser.yaml
 
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:


### PR DESCRIPTION
## Summary

PR #33 migrated \`.goreleaser.yaml\` from the singular \`format:\` schema to the plural \`formats: [tar.gz]\` + \`format_overrides\` form, but \`.github/workflows/release.yml\`'s **Verify release contract** step still greps for the old singular schema. Because no release has been cut since #33, the regression was latent — it would first surface at the moment of pushing the \`v0.6.1\` tag, killing the release before it reaches goreleaser.

Caught during a pre-tag adversarial review while preparing v0.6.1.

## Changes

- Replace \`grep -q 'format: tar.gz'\` with \`grep -Fq 'formats: [tar.gz]'\` to match the current plural schema.
- Add a second \`grep -Fq 'formats: [zip]'\` so the Windows override can't silently be deleted either (symmetric product coverage).
- Switch the \`install.sh\` contract check to \`grep -Fq\` so \`\${...}\` metacharacters in the pattern are not subject to BRE/ERE flavor differences across grep implementations (BSD grep on macOS already fails this regex; GNU grep on the Ubuntu runner happens to pass, but \`-F\` closes the accident).
- Inline comments explaining which schema version is being checked and why \`-F\` is used, so a future goreleaser upgrade hits a visible tripwire.

## Verification

Local:

\`\`\`
$ grep -qP 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml; echo \$?
0
$ grep -Fq 'cc-clip_\${VERSION#v}_\${PLATFORM}.tar.gz' scripts/install.sh; echo \$?
0
$ grep -Fq 'formats: [tar.gz]' .goreleaser.yaml; echo \$?
0
$ grep -Fq 'formats: [zip]' .goreleaser.yaml; echo \$?
0
$ goreleaser check
  • 1 configuration file(s) validated
  • thanks for using GoReleaser!
\`\`\`

## Test plan

- [x] Each updated grep exits 0 against current \`.goreleaser.yaml\` / \`scripts/install.sh\`
- [x] \`goreleaser check\` passes on the repo
- [ ] On merge, the v0.6.1 tag push will run the updated workflow and should progress past the Verify release contract step into the goreleaser release step