### PR TITLE
docs: release SOP + user upgrade guide + make release-preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Verify release contract
         run: |
           # goreleaser must produce cc-clip_{version}_{os}_{arch}.tar.gz
-          grep -qP 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
+          # -E (ERE) rather than -P (PCRE) so the same pattern is portable
+          # between the Ubuntu runner's GNU grep and BSD grep on developer
+          # macOS machines running `make release-preflight`.
+          grep -qE 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
           # install.sh must expect the same format with version stripped of v prefix
           # (-F is literal match: the pattern contains ${...} / . which are
           #  regex metacharacters — -F keeps this robust across grep flavors.)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS := -ldflags "-s -w -X main.version=$(VERSION)"
 PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
 
-.PHONY: build test vet clean release-local
+.PHONY: build test vet clean release-local release-preflight
 
 build:
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/cc-clip/
@@ -20,6 +20,38 @@ vet:
 clean:
 	rm -f $(BINARY)
 	rm -rf dist/
+
+# Mirrors everything the `Release` GitHub Actions workflow does before
+# invoking GoReleaser, plus a real snapshot build across every target arch.
+# Run this before tagging a new release so any drift between the workflow,
+# .goreleaser.yaml, or scripts/install.sh surfaces locally instead of after
+# a tag push has already burned a version number.
+release-preflight: test vet
+	@echo "==> cross-compile sanity (6 target triples)"
+	@for platform in $(PLATFORMS); do \
+		os=$${platform%%/*}; \
+		arch=$${platform##*/}; \
+		echo "  $$os/$$arch"; \
+		GOOS=$$os GOARCH=$$arch go build ./... || { echo "FAIL: $$os/$$arch"; exit 1; }; \
+	done
+	@echo "==> goreleaser check"
+	@command -v goreleaser >/dev/null 2>&1 || { \
+		echo "goreleaser is not installed. Install with: brew install goreleaser/tap/goreleaser"; \
+		exit 1; \
+	}
+	@goreleaser check
+	@echo "==> release contract greps (mirrors .github/workflows/release.yml)"
+	@grep -qE 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml \
+		|| { echo "FAIL: name_template drift in .goreleaser.yaml"; exit 1; }
+	@grep -Fq 'cc-clip_$${VERSION#v}_$${PLATFORM}.tar.gz' scripts/install.sh \
+		|| { echo "FAIL: scripts/install.sh archive name drift"; exit 1; }
+	@grep -Fq 'formats: [tar.gz]' .goreleaser.yaml \
+		|| { echo "FAIL: .goreleaser.yaml no longer declares formats: [tar.gz]"; exit 1; }
+	@grep -Fq 'formats: [zip]' .goreleaser.yaml \
+		|| { echo "FAIL: .goreleaser.yaml no longer declares the Windows formats: [zip] override"; exit 1; }
+	@echo "==> goreleaser snapshot build (no publish)"
+	@goreleaser release --snapshot --clean --skip=publish
+	@echo "==> release preflight OK. Safe to tag."
 
 release-local: clean
 	@mkdir -p dist

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,190 @@
+# Releasing cc-clip
+
+> Looking for how to **install or upgrade** cc-clip as a user? See
+> [upgrading.md](upgrading.md). This document is for maintainers cutting a
+> new release.
+
+Production releases are cut by pushing a signed `v<semver>` tag to the `main`
+branch. The `Release` workflow in `.github/workflows/release.yml` reacts to the
+tag push, runs the test suite, validates the release contract, and invokes
+GoReleaser to publish the archives and checksums.
+
+**Do not** run `make release-local` plus `gh release create` by hand.
+`make release-local` produces bare binaries named `cc-clip-<os>-<arch>`,
+whereas `scripts/install.sh` expects GoReleaser's `cc-clip_<version>_<os>_<arch>.<ext>`
+layout. Mixing the two silently breaks `install.sh` downloads.
+
+## Phase 0: Decide the version
+
+Follow semver against the user-visible surface (CLI flags, shim contract,
+notification schema, public HTTP endpoints):
+
+| Change | Bump |
+|---|---|
+| Breaking CLI / shim / env-var removal or rename | major |
+| New user-facing feature (new subcommand, new client support) | minor |
+| Bug fix, security hardening, compatibility fix | patch |
+
+## Phase 1: Make sure `main` is ready
+
+```bash
+git checkout main
+git pull --ff-only
+git status                        # must be clean
+git log v<previous>..HEAD --oneline   # confirm all intended PRs are in
+```
+
+## Phase 2: Pre-flight (reproduce every CI step locally)
+
+Running this **before** tagging is the single most important step. The release
+workflow has a `Verify release contract` grep block that is easy to fall out of
+sync with `.goreleaser.yaml` or `scripts/install.sh`; catching that locally
+costs nothing, catching it after pushing a tag wastes a version number.
+
+```bash
+make release-preflight
+```
+
+This target runs, in order:
+
+1. `make test` — same `go test ./...` CI runs.
+2. `go vet ./...`.
+3. Cross-compile sanity for all six target triples.
+4. `goreleaser check` — validates `.goreleaser.yaml` against the current
+   GoReleaser schema.
+5. The four contract greps the workflow runs
+   (`name_template`, `install.sh` archive name, `formats: [tar.gz]`,
+   `formats: [zip]`).
+6. `goreleaser release --snapshot --clean --skip=publish` — actually builds
+   every archive to `dist/` without publishing, so archive-time issues
+   surface locally.
+
+Stop and fix on the first failure.
+
+## Phase 3: Cut and push the tag
+
+```bash
+V=v0.6.2   # adjust
+
+# Reject accidental retag of an existing remote version
+if git ls-remote --tags origin "$V" | grep -q "refs/tags/$V$"; then
+  echo "ERROR: $V already on origin" >&2
+  exit 1
+fi
+
+# Remove any local leftover from a previous attempt
+git tag -d "$V" 2>/dev/null || true
+
+# Annotated tag with human-readable release summary.
+# GoReleaser auto-generates the GitHub release notes from commits, but this
+# tag body is what shows up in `git show $V` forever.
+git tag -a "$V" -F - <<EOF
+$V — <one-line subject>
+
+<grouped bullets of what users get, e.g.:>
+
+Security:
+- ...
+
+Features:
+- ...
+
+Fixes:
+- ...
+EOF
+
+# Confirm the tag points at HEAD (the commit you just validated in Phase 2)
+test "$(git rev-parse $V^{commit})" = "$(git rev-parse HEAD)" || {
+  echo "ERROR: tag is not at HEAD" >&2
+  exit 1
+}
+
+git push origin "$V"
+```
+
+## Phase 4: Watch CI
+
+```bash
+RUN_ID=$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --exit-status
+```
+
+Non-zero exit means the release was not published. See **Phase 6** for recovery.
+
+## Phase 5: Verify the published release
+
+Never skip this — CI passing is necessary but not sufficient. The artifacts
+need to actually install cleanly.
+
+```bash
+V=v0.6.2
+Vnum=${V#v}
+
+# 1. Assets present
+gh release view "$V" --json assets --jq '.assets[].name'
+# Expected: 4 tar.gz (darwin/linux × amd64/arm64) + 2 zip (windows × amd64/arm64) + checksums.txt
+
+# 2. /releases/latest points at this version (install.sh resolves via latest)
+LATEST=$(curl -sL -o /dev/null -w "%{url_effective}" \
+  https://github.com/ShunmeiCho/cc-clip/releases/latest)
+case "$LATEST" in
+  */tag/$V) echo "latest=$V ok" ;;
+  *) echo "ERROR: latest=$LATEST" >&2; exit 1 ;;
+esac
+
+# 3. Download + checksum + execute one archive end-to-end
+TMP=$(mktemp -d)
+gh release download "$V" --repo ShunmeiCho/cc-clip \
+  --pattern "cc-clip_${Vnum}_darwin_arm64.tar.gz" \
+  --pattern "checksums.txt" \
+  --dir "$TMP"
+(cd "$TMP" && shasum -a 256 -c checksums.txt --ignore-missing)
+tar -xzf "$TMP/cc-clip_${Vnum}_darwin_arm64.tar.gz" -C "$TMP"
+"$TMP/cc-clip" --version   # Must print "cc-clip $Vnum"
+rm -rf "$TMP"
+```
+
+## Phase 6: Recovering from failures
+
+### CI failed before publishing (tests, contract, goreleaser)
+
+The tag was pushed but no release was created.
+
+Do **not** force-push the tag. Instead:
+
+```bash
+git push origin --delete "$V"   # remove bad remote tag
+git tag -d "$V"                 # remove local tag
+# open a PR fixing the root cause, merge it, rerun Phase 2, then retag from new HEAD
+```
+
+### Release was published but has a serious bug
+
+Tags are immutable by convention — do not delete published tags.
+Mark the release as non-latest so `install.sh` stops handing it out, then cut a
+patch:
+
+```bash
+gh release edit "$V" --prerelease
+# fix on main, tag v<next patch>, release again
+```
+
+### Phase 5 verification fails (checksums mismatch, binary fails to run)
+
+Treat this as compromised and immediately quarantine:
+
+```bash
+gh release edit "$V" --prerelease
+```
+
+Then investigate GoReleaser logs (`gh run view $RUN_ID --log`) for the build
+step that produced the broken archive.
+
+## Appendix: Why Phase 2 exists
+
+Every new trap caught at release time in this project's history has been
+either (a) a drift between `.github/workflows/release.yml` contract checks and
+`.goreleaser.yaml`, or (b) a build-time issue on an arch the developer does
+not normally compile for. Both classes are cheap to catch locally and expensive
+to catch after pushing a tag. `make release-preflight` is the one-shot that
+mirrors CI exactly, so the tag push becomes a ceremony rather than a gamble.

--- a/docs/release.md
+++ b/docs/release.md
@@ -4,7 +4,7 @@
 > [upgrading.md](upgrading.md). This document is for maintainers cutting a
 > new release.
 
-Production releases are cut by pushing a signed `v<semver>` tag to the `main`
+Production releases are cut by pushing an annotated `v<semver>` tag to the `main`
 branch. The `Release` workflow in `.github/workflows/release.yml` reacts to the
 tag push, runs the test suite, validates the release contract, and invokes
 GoReleaser to publish the archives and checksums.

--- a/docs/release.md
+++ b/docs/release.md
@@ -104,8 +104,27 @@ git push origin "$V"
 
 ## Phase 4: Watch CI
 
+`gh run list --limit 1` picks "whatever the newest release workflow run is",
+which is a race: the tag push takes a few seconds to create a new run, and
+in that window you get the previous release's run id. Filter by the commit
+the tag points at, and poll until a matching run exists.
+
 ```bash
-RUN_ID=$(gh run list --workflow=release.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+V=v0.6.2                                  # same tag as Phase 3
+COMMIT=$(git rev-parse "$V^{commit}")
+RUN_ID=""
+for attempt in $(seq 1 30); do
+  RUN_ID=$(gh run list \
+    --workflow=release.yml --event push --commit "$COMMIT" \
+    --limit 1 --json databaseId --jq '.[0].databaseId // empty')
+  [ -n "$RUN_ID" ] && break
+  sleep 2
+done
+[ -z "$RUN_ID" ] && {
+  echo "ERROR: no release workflow run appeared for $COMMIT within 60s" >&2
+  exit 1
+}
+
 gh run watch "$RUN_ID" --exit-status
 ```
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,170 @@
+# Upgrading cc-clip
+
+This page is for **users** of `cc-clip`. If you want to cut a new release,
+see [release.md](release.md).
+
+## How to find out a new version is available
+
+cc-clip does not currently auto-check for updates. Pick whichever of these
+fits your workflow:
+
+- **Watch the repository on GitHub.** Open
+  <https://github.com/ShunmeiCho/cc-clip>, click **Watch -> Custom -> Releases**.
+  GitHub will email you whenever a tag ships.
+- **Subscribe to the releases Atom feed** at
+  <https://github.com/ShunmeiCho/cc-clip/releases.atom>.
+- **Check your current version against the latest:**
+
+  ```sh
+  cc-clip --version
+  curl -fsSL https://api.github.com/repos/ShunmeiCho/cc-clip/releases/latest \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4
+  ```
+
+## What you should upgrade
+
+When a new cc-clip version ships, every machine that runs cc-clip needs the
+new binary:
+
+| Where cc-clip runs | What it does | Needs upgrade when |
+|---|---|---|
+| Your local Mac or Linux laptop | Runs the HTTP daemon, hosts the clipboard | Always |
+| Your Windows laptop | Runs the hotkey listener, sends files over SSH | Always |
+| Each remote host you use with cc-clip | Hosts the xclip/wl-paste shim, the claude wrapper, and optionally x11-bridge/Xvfb | Whenever the local binary is updated (the remote side and local side share a protocol) |
+
+The remote update is driven from your local machine via
+`cc-clip connect <host>`. You do not SSH in and upgrade remotely by hand.
+
+## macOS / Linux upgrade
+
+### Option A: re-run the install script (recommended)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/ShunmeiCho/cc-clip/main/scripts/install.sh | sh
+```
+
+This fetches the archive for the latest `v*` tag, extracts it, replaces the
+binary at `~/.local/bin/cc-clip`, clears macOS Gatekeeper quarantine, and
+re-signs with `codesign --sign -`. The script is safe to re-run any time.
+
+### Option B: manual download
+
+Pick the archive matching your OS and arch from
+<https://github.com/ShunmeiCho/cc-clip/releases/latest>, then:
+
+```sh
+V=0.6.1   # latest version without the v prefix
+OS=darwin         # or linux
+ARCH=arm64        # or amd64
+
+cd /tmp
+curl -fsSL -o cc-clip.tar.gz \
+  "https://github.com/ShunmeiCho/cc-clip/releases/download/v${V}/cc-clip_${V}_${OS}_${ARCH}.tar.gz"
+tar -xzf cc-clip.tar.gz
+install -m 0755 cc-clip ~/.local/bin/cc-clip
+# macOS only: clear quarantine + ad-hoc sign so Gatekeeper allows it
+[ "$(uname -s)" = "Darwin" ] && xattr -cr ~/.local/bin/cc-clip \
+  && codesign --force --sign - --identifier com.cc-clip.cli ~/.local/bin/cc-clip
+```
+
+### After the local binary is replaced
+
+1. **Restart the clipboard daemon.** If you are running it as a user service:
+
+    ```sh
+    cc-clip service uninstall
+    cc-clip service install
+    cc-clip service status       # should show "running"
+    ```
+
+    If you run it in the foreground yourself, just stop the old process
+    (`Ctrl+C`) and start it again with `cc-clip serve`.
+
+2. **Redeploy to every remote host** you use with cc-clip. This pushes the new
+   binary to the remote and rebuilds the shim / hooks / x11-bridge entries:
+
+    ```sh
+    cc-clip connect myserver --force
+    # add --codex if you use Codex CLI on that host
+    cc-clip connect myserver --codex --force
+    ```
+
+    `--force` is important when upgrading: it bypasses the hash-based
+    "binary unchanged, skipping" optimization so the new version actually
+    lands on the remote.
+
+3. **Verify**:
+
+    ```sh
+    cc-clip --version
+    ssh myserver 'cc-clip --version'   # optional cross-check of the remote binary
+    ```
+
+## Windows upgrade
+
+The install script does not support Windows. Upgrade is manual.
+
+1. Stop any running cc-clip hotkey listener:
+
+    ```powershell
+    cc-clip hotkey --disable-autostart
+    # or kill the tray icon process, or log out of the Windows session
+    ```
+
+2. Download the new zip from
+   <https://github.com/ShunmeiCho/cc-clip/releases/latest> (pick
+   `cc-clip_<version>_windows_amd64.zip` or `..._arm64.zip`).
+
+3. Extract `cc-clip.exe` on top of your existing install location
+   (typically `C:\Users\<you>\.local\bin`). Overwrite the old file.
+
+4. Restart the hotkey listener:
+
+    ```powershell
+    cc-clip hotkey --install
+    cc-clip hotkey --status          # confirms the new version is registered
+    ```
+
+5. **Windows does not need `cc-clip connect`** — the Windows workflow talks
+   to the remote over SSH/stdin directly, not via the xclip/wl-paste shim.
+   There is no remote binary to redeploy for the Windows-only path. If you
+   also use this remote from a Mac/Linux machine, run `cc-clip connect`
+   from **that** machine after upgrading it.
+
+## Pitfalls to know about
+
+- **Daemon holding a stale binary:** macOS launchd keeps the old binary open
+  until the service is restarted. If `cc-clip --version` on the CLI shows
+  the new version but clipboard paste still behaves like the old one,
+  `cc-clip service uninstall && cc-clip service install`.
+- **Remote cache says "unchanged":** `cc-clip connect` tracks the remote
+  binary hash in `~/.cache/cc-clip/deploy-state.json` on the remote. If that
+  file claims the binary is already current, `connect` will skip the upload.
+  Use `--force` on upgrade runs.
+- **Token vs binary upgrade:** If you only rotated the daemon token and did
+  not change the binary, run `cc-clip connect myserver --token-only`
+  instead — it syncs the token without a full redeploy.
+- **macOS Gatekeeper:** the install script re-signs the binary after
+  download. If you download manually you need to either run the two
+  `xattr -cr` + `codesign ...` commands above, or Gatekeeper will refuse
+  to execute the new binary.
+
+## Rollback
+
+cc-clip version upgrades are reversible — just install an older version the
+same way.
+
+- **Via install script, pinned to a specific tag:**
+
+    ```sh
+    # install.sh always fetches /releases/latest. To install a specific version
+    # manually, use the Option B commands above with V= set to the version
+    # you want. For example, V=0.5.0 downgrades to v0.5.0.
+    ```
+
+- **After downgrading, re-run `cc-clip connect <host> --force`** for each
+  remote you use, so the remote side also goes back in sync.
+
+If a release was published in error by the maintainer, they will mark it
+`prerelease` on GitHub. `install.sh` will then skip it automatically and
+fall back to the previous stable `v*` tag on the next run.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -80,7 +80,25 @@ install -m 0755 cc-clip ~/.local/bin/cc-clip
     If you run it in the foreground yourself, just stop the old process
     (`Ctrl+C`) and start it again with `cc-clip serve`.
 
-2. **Redeploy to every remote host** you use with cc-clip. This pushes the new
+2. **Confirm the upgraded daemon owns the port.** If another cc-clip bundle or
+   old helper process is still listening on the daemon port, `connect` can talk
+   to the wrong daemon and sync the wrong token to the remote.
+
+    ```sh
+    launchctl list | grep -i cc-clip
+    lsof -nP -iTCP:18339 -sTCP:LISTEN
+    curl -i http://127.0.0.1:18339/register-nonce
+    ```
+
+    Expected:
+    - `launchctl` should show only the cc-clip daemon you intentionally run.
+    - `lsof` should show the listener path/PID belongs to your upgraded
+      `cc-clip` binary, not another bundled copy.
+    - `/register-nonce` should return `401` or `403` without auth. A `404`
+      means an old daemon that does not support notification nonce registration
+      is answering.
+
+3. **Redeploy to every remote host** you use with cc-clip. This pushes the new
    binary to the remote and rebuilds the shim / hooks / x11-bridge entries:
 
     ```sh
@@ -93,7 +111,7 @@ install -m 0755 cc-clip ~/.local/bin/cc-clip
     "binary unchanged, skipping" optimization so the new version actually
     lands on the remote.
 
-3. **Verify**:
+4. **Verify**:
 
     ```sh
     cc-clip --version
@@ -121,7 +139,9 @@ The install script does not support Windows. Upgrade is manual.
 4. Restart the hotkey listener:
 
     ```powershell
-    cc-clip hotkey --install
+    cc-clip hotkey
+    # or, to keep auto-start enabled:
+    cc-clip hotkey myserver --enable-autostart
     cc-clip hotkey --status          # confirms the new version is registered
     ```
 
@@ -137,6 +157,10 @@ The install script does not support Windows. Upgrade is manual.
   until the service is restarted. If `cc-clip --version` on the CLI shows
   the new version but clipboard paste still behaves like the old one,
   `cc-clip service uninstall && cc-clip service install`.
+- **Another daemon owns port 18339:** If `cc-clip connect` says the daemon is
+  running but paste still fails, inspect `lsof -nP -iTCP:18339 -sTCP:LISTEN`.
+  The process must be the upgraded cc-clip daemon you intend to use. Stop any
+  old bundled copy before running `cc-clip connect <host> --force` again.
 - **Remote cache says "unchanged":** `cc-clip connect` tracks the remote
   binary hash in `~/.cache/cc-clip/deploy-state.json` on the remote. If that
   file claims the binary is already current, `connect` will skip the upload.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -87,16 +87,17 @@ install -m 0755 cc-clip ~/.local/bin/cc-clip
     ```sh
     launchctl list | grep -i cc-clip
     lsof -nP -iTCP:18339 -sTCP:LISTEN
-    curl -i http://127.0.0.1:18339/register-nonce
+    curl -i -X POST http://127.0.0.1:18339/register-nonce
     ```
 
     Expected:
     - `launchctl` should show only the cc-clip daemon you intentionally run.
     - `lsof` should show the listener path/PID belongs to your upgraded
       `cc-clip` binary, not another bundled copy.
-    - `/register-nonce` should return `401` or `403` without auth. A `404`
-      means an old daemon that does not support notification nonce registration
-      is answering.
+    - `/register-nonce` is a `POST`-only endpoint. Without an auth header it
+      should return `401` or `403`. A `404` means an older daemon that does
+      not know about notification nonces is answering; a `405` (from a GET)
+      just means you forgot `-X POST`.
 
 3. **Redeploy to every remote host** you use with cc-clip. This pushes the new
    binary to the remote and rebuilds the shim / hooks / x11-bridge entries:


### PR DESCRIPTION
## Summary

- Codify the pre-tag checklist that the v0.6.1 release series should have had from day one. Driven by three near-misses caught only during adversarial review (SFTP/scp protocol split, 0644 umask on uploaded images, release workflow grep schema drift).
- Add a user-facing upgrade guide so users can discover and apply new releases without hand-holding.
- Provide a one-shot \`make release-preflight\` that runs every check the Release workflow runs, plus a real cross-arch snapshot build, so drift between \`.github/workflows/release.yml\`, \`.goreleaser.yaml\`, and \`scripts/install.sh\` surfaces locally before a tag push burns a version number.

## Files

| File | Audience | Purpose |
|---|---|---|
| \`docs/release.md\` | Maintainer | Six-phase release SOP (version -> preflight -> tag -> watch CI -> verify -> recover) |
| \`docs/upgrading.md\` | User | How to find new releases, upgrade on macOS/Linux/Windows, restart daemons, redeploy to remotes, roll back |
| \`Makefile\` | Maintainer tooling | New \`make release-preflight\` target |
| \`.github/workflows/release.yml\` | CI | \`-qP\` -> \`-qE\` on the \`name_template\` contract grep for BSD grep portability |

## Why the workflow change is in scope

\`make release-preflight\` claims to mirror CI exactly. With \`grep -qP\` in the workflow the target wouldn't actually mirror it on macOS BSD grep (the original caught me locally). Since the pattern uses no PCRE-only feature, switching both sides to \`-qE\` makes the mirror real without changing semantics on the Ubuntu runner.

## Verification

\`\`\`
$ make release-preflight
...
==> goreleaser snapshot build (no publish)
  • release succeeded after 2s
  • thanks for using GoReleaser!
==> release preflight OK. Safe to tag.
\`\`\`

All six cross-compiles pass, four contract greps pass on BSD grep, \`goreleaser check\` validates, and snapshot builds 4 tar.gz + 2 zip + checksums.txt in \`dist/\`.

## Test plan

- [x] \`make release-preflight\` completes successfully on macOS (BSD grep).
- [x] Each of the four contract greps exits 0 against current repo state.
- [x] \`goreleaser check\` validates \`.goreleaser.yaml\` under v2 schema.
- [x] Snapshot build produces all 6 arch archives plus checksums.
- [ ] Future \`v*\` tag push uses the updated workflow and still reaches \`goreleaser release\`.