### PR TITLE
feat(cli): add cc-clip update for one-command self-upgrade

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -65,6 +65,8 @@ func main() {
 		cmdSetup()
 	case "service":
 		cmdService()
+	case "update":
+		cmdUpdate()
 	case "notify":
 		cmdNotify()
 	case "x11-bridge":
@@ -122,6 +124,13 @@ Remote:
 One-command setup:
   setup <host>       Full setup: deps, SSH config, daemon, deploy
     --port           Tunnel port (default: 18339)
+
+Self-update (macOS/Linux):
+  update             Download and install the latest cc-clip release
+    --check          Only check whether a newer release exists; do not install
+    --force          Re-install even if already at target version; ignore
+                     conflict warnings from another daemon on the same port
+    --to VERSION     Install a specific version (e.g. v0.6.0) instead of latest
 
 Deploy (local -> remote):
   connect <host>     Deploy cc-clip to remote and establish session

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -105,6 +105,15 @@ func cmdUpdate() {
 		fmt.Printf("warning: ignoring conflict because --force was given: %s\n", conflict)
 	}
 
+	// Snapshot whether a service was running BEFORE any mutation. We need
+	// this later both to know whether to call `service install` after the
+	// swap AND to tell the rollback path whether to re-register the plist
+	// against the restored binary. Reading Status() mid-flight is not
+	// safe because the service may crash-loop during `service.Uninstall()`
+	// and look "not running" when in fact we need to restore it.
+	serviceWasRunning := detectServiceRunning()
+	fmt.Printf("service:  %s\n", describeServiceState(serviceWasRunning))
+
 	archivePath, cleanupArchive, err := downloadAndVerifyArchive(ctx, target)
 	if err != nil {
 		log.Fatalf("download/verify failed: %v", err)
@@ -157,23 +166,43 @@ func cmdUpdate() {
 
 	fmt.Printf("binary installed: %s\n", selfPath)
 
-	serviceWasRunning := restartDaemon(selfPath)
+	// If a service WAS running before the swap, re-register the plist so
+	// launchd reloads the job pointing at the new binary. Failure here is
+	// treated the same as any other post-install failure: roll back before
+	// returning.
+	if err := reinstallMacOSService(selfPath, serviceWasRunning); err != nil {
+		rollbackAfterInstall(selfPath, backup, serviceWasRunning)
+		log.Fatalf("service restart failed (%v); rolled back to previous version.", err)
+	}
 
-	// Post-install re-verify. If the service restarted to a different binary
-	// (for example because launchd picked up a path different from selfPath)
-	// or if the binary we just copied refuses to exec, undo the swap so the
-	// user is left with the working old version and a loud error, not a
-	// half-broken upgrade.
+	// Post-install re-verify 1: does the new binary on disk actually run,
+	// and does it report the expected version? This catches an archive
+	// that staged correctly but then couldn't exec (missing codesign on
+	// macOS, broken linked library, etc.).
 	installedVersion, verifyErr := runVersionCommand(selfPath)
 	if verifyErr != nil {
-		rollbackAfterInstall(selfPath, backup)
+		rollbackAfterInstall(selfPath, backup, serviceWasRunning)
 		log.Fatalf("post-install: installed binary failed to run (%v); rolled back to previous version.\ncheck %s for the archive you were trying to install.", verifyErr, backup)
 	}
 	if !stagedVersionMatches(installedVersion, target) {
-		rollbackAfterInstall(selfPath, backup)
+		rollbackAfterInstall(selfPath, backup, serviceWasRunning)
 		log.Fatalf("post-install: installed binary reports %q, expected %s; rolled back.", installedVersion, target)
 	}
-	fmt.Printf("verified: %s\n", installedVersion)
+	fmt.Printf("verified binary: %s\n", installedVersion)
+
+	// Post-install re-verify 2: if a service was running before the update,
+	// it should be running AGAIN now, owned by the new binary. This catches
+	// the bad-state where launchd registered the new plist but the old
+	// (third-party) daemon is still holding the port — which is exactly
+	// what happens after `--force` past a conflict, or if `service install`
+	// silently succeeded but launchd's job crash-looped.
+	if serviceWasRunning {
+		if err := verifyRunningDaemon(selfPath, updateDaemonPort); err != nil {
+			rollbackAfterInstall(selfPath, backup, serviceWasRunning)
+			log.Fatalf("post-install: daemon verification failed (%v); rolled back to previous version.\nresolve the stray process on :%d (see `docs/upgrading.md`) and try again.", err, updateDaemonPort)
+		}
+		fmt.Println("verified daemon: responding on :" + strconv.Itoa(updateDaemonPort) + " from the new binary")
+	}
 
 	_ = os.Remove(backup)
 
@@ -191,19 +220,107 @@ func stagedVersionMatches(reported, targetTag string) bool {
 	return r == t && r != ""
 }
 
+// detectServiceRunning snapshots whether a cc-clip service is running now.
+// We read this BEFORE any mutation because once `service.Uninstall()` runs
+// the state is destroyed and we cannot tell from the outside whether the
+// service was supposed to exist or not.
+func detectServiceRunning() bool {
+	if runtime.GOOS != "darwin" {
+		return false
+	}
+	running, err := service.Status()
+	return err == nil && running
+}
+
+func describeServiceState(wasRunning bool) string {
+	if runtime.GOOS != "darwin" {
+		return "not managed (this OS does not use launchd)"
+	}
+	if wasRunning {
+		return "running (launchd)"
+	}
+	return "not running"
+}
+
+// reinstallMacOSService re-registers the launchd plist against binaryPath,
+// but only if a service was running before the update. Returns a non-nil
+// error so the caller can rollback; the function does not panic or exit.
+func reinstallMacOSService(binaryPath string, serviceWasRunning bool) error {
+	if runtime.GOOS != "darwin" || !serviceWasRunning {
+		return nil
+	}
+	if err := service.Uninstall(); err != nil {
+		return fmt.Errorf("service uninstall: %w", err)
+	}
+	if err := service.Install(binaryPath, updateDaemonPort); err != nil {
+		return fmt.Errorf("service install: %w", err)
+	}
+	return nil
+}
+
+// verifyRunningDaemon polls /health until 200 OK, then confirms that the
+// process listening on `port` is actually the binary at expectedPath. This
+// catches the scenario where launchd accepted the new plist but the old
+// third-party daemon is still bound to the port (common after `--force`
+// past a conflict check).
+func verifyRunningDaemon(expectedPath string, port int) error {
+	healthCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+
+	var lastErr error
+	client := &http.Client{Timeout: 2 * time.Second}
+	for {
+		req, err := http.NewRequestWithContext(healthCtx, "GET", healthURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				break
+			}
+			lastErr = fmt.Errorf("GET /health -> %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+		select {
+		case <-healthCtx.Done():
+			return fmt.Errorf("daemon did not respond 200 to /health within 10s (last: %v)", lastErr)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	conflict, err := detectDaemonConflict(port, expectedPath)
+	if err != nil {
+		// We could not identify the listener binary (e.g. lsof missing).
+		// Health is already 200, so don't block the update on this; just
+		// warn so the user knows verification was partial.
+		fmt.Printf("warning: daemon is responding on :%d but we could not verify its binary path (%v)\n", port, err)
+		return nil
+	}
+	if conflict != "" {
+		return fmt.Errorf("daemon is up but owned by a different binary: %s", conflict)
+	}
+	return nil
+}
+
 // rollbackAfterInstall restores the backed-up binary after a failed
-// post-install verification. Also re-registers the launchd plist so the
-// service points back at the rolled-back binary.
-func rollbackAfterInstall(selfPath, backup string) {
+// post-install step. If a service was running before the update, also
+// re-register the launchd plist against the restored binary so the old
+// version keeps serving. All steps are best-effort: if any individual
+// operation fails, we still try the remaining ones because the user is
+// already in a broken state and we want to leave them as close to the
+// pre-update world as possible.
+func rollbackAfterInstall(selfPath, backup string, serviceWasRunning bool) {
 	_ = os.Remove(selfPath)
 	_ = os.Rename(backup, selfPath)
-	if runtime.GOOS != "darwin" {
+	if runtime.GOOS != "darwin" || !serviceWasRunning {
 		return
 	}
-	if running, err := service.Status(); err == nil && running {
-		_ = service.Uninstall()
-		_ = service.Install(selfPath, updateDaemonPort)
-	}
+	_ = service.Uninstall()
+	_ = service.Install(selfPath, updateDaemonPort)
 }
 
 func parseUpdateFlags(args []string) updateOptions {
@@ -653,34 +770,25 @@ func renameAtomic(src, dst string) error {
 	return os.Rename(dst+".new", dst)
 }
 
-// restartDaemon re-registers the launchd service (on macOS) so it picks up
-// the new binary. Returns true if the service was running (and got
-// reinstalled), false if there was no service to manage (e.g., the user runs
-// the daemon in the foreground or uses systemd we can't speak to yet).
-func restartDaemon(binaryPath string) bool {
-	if runtime.GOOS != "darwin" {
-		// On Linux we don't manage systemd yet; just note it.
-		fmt.Println("note: on Linux, restart the daemon yourself if you run it as a service.")
-		return false
-	}
-	running, err := service.Status()
-	if err != nil || !running {
-		fmt.Println("note: cc-clip service not detected as running; skipping service restart.")
-		return false
-	}
-	fmt.Println("restarting launchd service...")
-	if err := service.Uninstall(); err != nil {
-		fmt.Printf("warning: service uninstall failed: %v\n", err)
-	}
-	if err := service.Install(binaryPath, updateDaemonPort); err != nil {
-		fmt.Printf("warning: service install failed: %v\nyou may need to run `cc-clip service install` manually.\n", err)
-		return false
-	}
-	return true
+// runVersionCommand executes `<binaryPath> --version` with a hard timeout
+// so a hanging binary (bad linked library, waiting on some external
+// resource at startup, etc.) cannot wedge the updater. This matters most
+// AFTER the swap: a post-install verify that blocks forever means no
+// rollback runs, leaving the user with a broken binary and no recourse.
+func runVersionCommand(binaryPath string) (string, error) {
+	return runVersionCommandWithTimeout(binaryPath, 10*time.Second)
 }
 
-func runVersionCommand(binaryPath string) (string, error) {
-	cmd := exec.Command(binaryPath, "--version")
+func runVersionCommandWithTimeout(binaryPath string, timeout time.Duration) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "--version")
+	// Without WaitDelay, killing the direct child still leaves orphaned
+	// descendants holding the stdout pipe open; cmd.Output() would then
+	// wait indefinitely for EOF. WaitDelay forces the pipes closed after
+	// the grace window, so Output returns promptly even if a grandchild
+	// (shell -> sleep) is still writing.
+	cmd.WaitDelay = 1 * time.Second
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -1,0 +1,595 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/service"
+)
+
+const (
+	updateRepo          = "ShunmeiCho/cc-clip"
+	updateAPIURL        = "https://api.github.com/repos/" + updateRepo + "/releases"
+	updateDownloadBase  = "https://github.com/" + updateRepo + "/releases/download"
+	updateDaemonPort    = 18339
+	updateDownloadTotal = 5 * time.Minute
+)
+
+type updateOptions struct {
+	check bool
+	force bool
+	toVer string
+}
+
+func cmdUpdate() {
+	opts := parseUpdateFlags(os.Args[2:])
+
+	if runtime.GOOS == "windows" {
+		log.Fatal("cc-clip update is not supported on Windows yet. See docs/upgrading.md for the manual upgrade steps.")
+	}
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		log.Fatalf("cc-clip update does not support %s yet; please upgrade manually via install.sh or the release archives.", runtime.GOOS)
+	}
+
+	selfPath, err := resolveSelfPath()
+	if err != nil {
+		log.Fatalf("cannot determine current cc-clip binary path: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), updateDownloadTotal)
+	defer cancel()
+
+	currentTag := normalizeVersion(version)
+	target := strings.TrimSpace(opts.toVer)
+	if target != "" {
+		target = normalizeVersion(target)
+	} else {
+		latest, err := fetchLatestReleaseTag(ctx)
+		if err != nil {
+			log.Fatalf("failed to query latest release: %v", err)
+		}
+		target = latest
+	}
+	if target == "" {
+		log.Fatal("could not determine a target version to install.")
+	}
+
+	fmt.Printf("current:  %s\n", displayVersion(currentTag))
+	fmt.Printf("target:   %s\n", target)
+	fmt.Printf("platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("binary:   %s\n", selfPath)
+
+	sameVer := currentTag != "" && currentTag == target
+	if opts.check {
+		if sameVer {
+			fmt.Println("already at target version; nothing to do.")
+		} else {
+			fmt.Printf("update available: %s -> %s\n", displayVersion(currentTag), target)
+		}
+		return
+	}
+	if sameVer && !opts.force {
+		fmt.Println("already at target version; nothing to do. Use --force to re-install.")
+		return
+	}
+
+	// Surface conflicts BEFORE we download anything. This is the biggest
+	// real-world upgrade trap: an unrelated bundled copy of cc-clip (or a
+	// forgotten stray daemon) holds port 18339, so service install's new
+	// plist crash-loops, `cc-clip connect` still sees "a daemon" and syncs
+	// the wrong token to remotes.
+	if conflict, err := detectDaemonConflict(updateDaemonPort, selfPath); err != nil {
+		fmt.Printf("warning: could not detect port conflicts: %v\n", err)
+	} else if conflict != "" {
+		if !opts.force {
+			log.Fatalf("conflict on :%d — %s\nresolve it before updating (stop / unload the other daemon), or rerun with --force.", updateDaemonPort, conflict)
+		}
+		fmt.Printf("warning: ignoring conflict because --force was given: %s\n", conflict)
+	}
+
+	archivePath, cleanupArchive, err := downloadAndVerifyArchive(ctx, target)
+	if err != nil {
+		log.Fatalf("download/verify failed: %v", err)
+	}
+	defer cleanupArchive()
+
+	stagedBinary, cleanupStaged, err := extractBinary(archivePath)
+	if err != nil {
+		log.Fatalf("extract failed: %v", err)
+	}
+	defer cleanupStaged()
+
+	if runtime.GOOS == "darwin" {
+		if err := prepareMacOSBinary(stagedBinary); err != nil {
+			log.Fatalf("macOS signing prep failed: %v", err)
+		}
+	}
+
+	backup := selfPath + ".bak"
+	if err := os.Rename(selfPath, backup); err != nil {
+		log.Fatalf("failed to back up current binary: %v", err)
+	}
+	rollback := func() {
+		_ = os.Rename(backup, selfPath)
+	}
+
+	if err := renameAtomic(stagedBinary, selfPath); err != nil {
+		rollback()
+		log.Fatalf("failed to install new binary (rolled back): %v", err)
+	}
+	if err := os.Chmod(selfPath, 0o755); err != nil {
+		rollback()
+		log.Fatalf("failed to chmod new binary (rolled back): %v", err)
+	}
+
+	fmt.Printf("binary installed: %s\n", selfPath)
+
+	serviceWasRunning := restartDaemon(selfPath)
+
+	installedTag, verifyErr := runVersionCommand(selfPath)
+	if verifyErr != nil {
+		fmt.Printf("warning: could not verify installed version: %v\n", verifyErr)
+	} else if installedTag != target && !strings.HasSuffix(installedTag, strings.TrimPrefix(target, "v")) {
+		fmt.Printf("warning: installed binary reports %q, expected %s\n", installedTag, target)
+	} else {
+		fmt.Printf("verified: %s\n", installedTag)
+	}
+
+	_ = os.Remove(backup)
+
+	printPostUpdateReminders(target, selfPath, serviceWasRunning)
+}
+
+func parseUpdateFlags(args []string) updateOptions {
+	fs := flag.NewFlagSet("update", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	opts := updateOptions{}
+	fs.BoolVar(&opts.check, "check", false, "Only report whether an update is available; do not download or install.")
+	fs.BoolVar(&opts.force, "force", false, "Re-install even if already at target version and ignore daemon conflict warnings.")
+	fs.StringVar(&opts.toVer, "to", "", "Install this specific release (e.g. v0.6.0) instead of the latest one.")
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "usage: cc-clip update [--check] [--force] [--to VERSION]")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if fs.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "cc-clip update takes no positional arguments.")
+		fs.Usage()
+		os.Exit(2)
+	}
+	return opts
+}
+
+func resolveSelfPath() (string, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	abs, err := filepath.EvalSymlinks(exe)
+	if err != nil {
+		return exe, nil
+	}
+	return abs, nil
+}
+
+// normalizeVersion canonicalizes a version string into "vX.Y.Z" form, or
+// returns "" for unknown versions like "dev" or a git-describe SHA.
+func normalizeVersion(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "dev" {
+		return ""
+	}
+	v = strings.TrimPrefix(v, "cc-clip ")
+	v = strings.TrimPrefix(v, "v")
+	// Reject anything that doesn't look like semver (rejects "abc123" SHAs).
+	if !looksLikeSemver(v) {
+		return ""
+	}
+	return "v" + v
+}
+
+func looksLikeSemver(v string) bool {
+	parts := strings.SplitN(v, ".", 4)
+	if len(parts) < 3 {
+		return false
+	}
+	for i := 0; i < 3; i++ {
+		// allow trailing suffixes on the patch component (e.g. 0-rc1)
+		s := parts[i]
+		if i == 2 {
+			if idx := strings.IndexAny(s, "-+"); idx >= 0 {
+				s = s[:idx]
+			}
+		}
+		if _, err := strconv.Atoi(s); err != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func displayVersion(v string) string {
+	if v == "" {
+		return "(unknown; probably a dev build)"
+	}
+	return v
+}
+
+func fetchLatestReleaseTag(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", updateAPIURL+"/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "cc-clip-updater")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<14))
+		return "", fmt.Errorf("GitHub API returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var data struct {
+		TagName    string `json:"tag_name"`
+		Prerelease bool   `json:"prerelease"`
+		Draft      bool   `json:"draft"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", fmt.Errorf("parse release JSON: %w", err)
+	}
+	if data.Draft || data.Prerelease {
+		return "", fmt.Errorf("latest release is marked draft/prerelease: %s", data.TagName)
+	}
+	if data.TagName == "" {
+		return "", errors.New("GitHub API returned empty tag_name")
+	}
+	return data.TagName, nil
+}
+
+// detectDaemonConflict returns a human-readable conflict description if port
+// is currently held by a listener whose binary is NOT selfPath. Returns an
+// empty string when there is no conflict, or an error if detection itself
+// could not run (e.g. lsof missing).
+func detectDaemonConflict(port int, selfPath string) (string, error) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		return "", fmt.Errorf("lsof not available; skipping conflict check: %w", err)
+	}
+	cmd := exec.Command("lsof", "-nP", fmt.Sprintf("-iTCP:%d", port), "-sTCP:LISTEN", "-Fpn")
+	out, err := cmd.Output()
+	if err != nil {
+		// lsof returns exit code 1 when there's no match; that's fine.
+		if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+			return "", nil
+		}
+		return "", fmt.Errorf("lsof failed: %w", err)
+	}
+	pid, err := parseLsofPID(string(out))
+	if err != nil {
+		return "", err
+	}
+	if pid == 0 {
+		return "", nil
+	}
+	binary, err := readProcessBinary(pid)
+	if err != nil {
+		return "", err
+	}
+	if binary == "" {
+		return "", nil
+	}
+	if samePath(binary, selfPath) {
+		return "", nil
+	}
+	return fmt.Sprintf("port %d is held by PID %d running %s (not %s)", port, pid, binary, selfPath), nil
+}
+
+// parseLsofPID extracts the listener PID from the output of
+// `lsof -nP -iTCP:<port> -sTCP:LISTEN -Fpn`. Returns 0 when no listener.
+// Format: records start with "p<pid>" lines followed by "n<ip>:<port>".
+// We take the first pid seen.
+func parseLsofPID(raw string) (int, error) {
+	for _, line := range strings.Split(raw, "\n") {
+		if len(line) < 2 || line[0] != 'p' {
+			continue
+		}
+		pid, err := strconv.Atoi(line[1:])
+		if err != nil {
+			return 0, fmt.Errorf("lsof p-line malformed: %q", line)
+		}
+		return pid, nil
+	}
+	return 0, nil
+}
+
+func readProcessBinary(pid int) (string, error) {
+	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("ps failed for pid %d: %w", pid, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func samePath(a, b string) bool {
+	aa, err := filepath.EvalSymlinks(a)
+	if err == nil {
+		a = aa
+	}
+	bb, err := filepath.EvalSymlinks(b)
+	if err == nil {
+		b = bb
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func downloadAndVerifyArchive(ctx context.Context, tag string) (string, func(), error) {
+	version := strings.TrimPrefix(tag, "v")
+	archiveName := fmt.Sprintf("cc-clip_%s_%s_%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+
+	tmpDir, err := os.MkdirTemp("", "cc-clip-update-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	archivePath := filepath.Join(tmpDir, archiveName)
+	checksumPath := filepath.Join(tmpDir, "checksums.txt")
+
+	archiveURL := fmt.Sprintf("%s/%s/%s", updateDownloadBase, tag, archiveName)
+	checksumURL := fmt.Sprintf("%s/%s/checksums.txt", updateDownloadBase, tag)
+
+	fmt.Printf("downloading %s\n", archiveName)
+	if err := httpDownload(ctx, archiveURL, archivePath); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("download %s: %w", archiveName, err)
+	}
+	fmt.Println("downloading checksums.txt")
+	if err := httpDownload(ctx, checksumURL, checksumPath); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("download checksums.txt: %w", err)
+	}
+
+	if err := verifySHA256(archivePath, checksumPath, archiveName); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	fmt.Println("checksum verified")
+
+	return archivePath, cleanup, nil
+}
+
+func httpDownload(ctx context.Context, url, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", "cc-clip-updater")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifySHA256(archivePath, checksumsPath, archiveName string) error {
+	want, err := lookupChecksum(checksumsPath, archiveName)
+	if err != nil {
+		return err
+	}
+	got, err := fileSHA256(archivePath)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(want, got) {
+		return fmt.Errorf("checksum mismatch for %s: got %s want %s", archiveName, got, want)
+	}
+	return nil
+}
+
+func lookupChecksum(checksumsPath, archiveName string) (string, error) {
+	data, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == archiveName {
+			return fields[0], nil
+		}
+	}
+	return "", fmt.Errorf("no checksum entry for %s in checksums.txt", archiveName)
+}
+
+func fileSHA256(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func extractBinary(archivePath string) (string, func(), error) {
+	tmpDir, err := os.MkdirTemp("", "cc-clip-update-extract-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup := func() { _ = os.RemoveAll(tmpDir) }
+
+	f, err := os.Open(archivePath)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	defer f.Close()
+
+	gzr, err := gzip.NewReader(f)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	defer gzr.Close()
+
+	tr := tar.NewReader(gzr)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			cleanup()
+			return "", func() {}, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue
+		}
+		base := filepath.Base(hdr.Name)
+		if base != "cc-clip" {
+			continue
+		}
+		dest := filepath.Join(tmpDir, "cc-clip")
+		out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+		if err != nil {
+			cleanup()
+			return "", func() {}, err
+		}
+		if _, err := io.Copy(out, tr); err != nil {
+			out.Close()
+			cleanup()
+			return "", func() {}, err
+		}
+		out.Close()
+		return dest, cleanup, nil
+	}
+	cleanup()
+	return "", func() {}, errors.New("cc-clip binary not found inside archive")
+}
+
+// prepareMacOSBinary clears quarantine xattrs and re-signs with an ad-hoc
+// identity so Gatekeeper allows the downloaded binary to execute. Mirrors
+// what scripts/install.sh does at the end.
+func prepareMacOSBinary(path string) error {
+	// xattr -cr: clear all xattrs recursively (including com.apple.quarantine
+	// and com.apple.provenance). Best-effort; failure here is not fatal.
+	_ = exec.Command("xattr", "-cr", path).Run()
+	cmd := exec.Command("codesign", "--force", "--sign", "-", "--identifier", "com.cc-clip.cli", path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("codesign failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func renameAtomic(src, dst string) error {
+	// os.Rename is atomic on POSIX within the same filesystem. The extract
+	// tmp dir may be on /tmp which is often on a different device; copy in
+	// that case.
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst+".new", os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		_ = os.Remove(dst + ".new")
+		return err
+	}
+	if err := out.Close(); err != nil {
+		_ = os.Remove(dst + ".new")
+		return err
+	}
+	return os.Rename(dst+".new", dst)
+}
+
+// restartDaemon re-registers the launchd service (on macOS) so it picks up
+// the new binary. Returns true if the service was running (and got
+// reinstalled), false if there was no service to manage (e.g., the user runs
+// the daemon in the foreground or uses systemd we can't speak to yet).
+func restartDaemon(binaryPath string) bool {
+	if runtime.GOOS != "darwin" {
+		// On Linux we don't manage systemd yet; just note it.
+		fmt.Println("note: on Linux, restart the daemon yourself if you run it as a service.")
+		return false
+	}
+	running, err := service.Status()
+	if err != nil || !running {
+		fmt.Println("note: cc-clip service not detected as running; skipping service restart.")
+		return false
+	}
+	fmt.Println("restarting launchd service...")
+	if err := service.Uninstall(); err != nil {
+		fmt.Printf("warning: service uninstall failed: %v\n", err)
+	}
+	if err := service.Install(binaryPath, updateDaemonPort); err != nil {
+		fmt.Printf("warning: service install failed: %v\nyou may need to run `cc-clip service install` manually.\n", err)
+		return false
+	}
+	return true
+}
+
+func runVersionCommand(binaryPath string) (string, error) {
+	cmd := exec.Command(binaryPath, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func printPostUpdateReminders(targetTag, binaryPath string, serviceRestarted bool) {
+	fmt.Println()
+	fmt.Println("== Post-update checklist ==")
+	if !serviceRestarted {
+		fmt.Println("* Restart the cc-clip daemon so it runs the new binary.")
+		fmt.Println("  (macOS) cc-clip service uninstall && cc-clip service install")
+		fmt.Println("  (Linux foreground) stop your running `cc-clip serve` and start it again.")
+	}
+	fmt.Println("* Redeploy to every remote host you use with cc-clip:")
+	fmt.Println("    cc-clip connect <host> --force")
+	fmt.Println("    cc-clip connect <host> --codex --force   # if you use Codex CLI there")
+	fmt.Println()
+	fmt.Printf("cc-clip %s installed at %s.\n", strings.TrimPrefix(targetTag, "v"), binaryPath)
+}

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -122,20 +123,35 @@ func cmdUpdate() {
 		}
 	}
 
+	// Verify the staged binary BEFORE touching the installed binary. If the
+	// archive is corrupt or contains the wrong version, we abort cleanly with
+	// nothing installed. This matches a "trust but verify" contract: the
+	// checksum file says the archive matches a published asset, but nothing
+	// stops a future release-pipeline bug from publishing a mislabeled file.
+	stagedVersion, err := runVersionCommand(stagedBinary)
+	if err != nil {
+		log.Fatalf("staged binary from archive failed to run --version: %v\nthe archive may be corrupt for this platform (%s/%s)", err, runtime.GOOS, runtime.GOARCH)
+	}
+	if !stagedVersionMatches(stagedVersion, target) {
+		log.Fatalf("staged binary reports %q but target is %s; refusing to install (archive mislabeled?)\nnothing has been changed on disk.", stagedVersion, target)
+	}
+	fmt.Printf("staged binary verified: %s\n", stagedVersion)
+
 	backup := selfPath + ".bak"
 	if err := os.Rename(selfPath, backup); err != nil {
 		log.Fatalf("failed to back up current binary: %v", err)
 	}
-	rollback := func() {
+	restoreBinary := func() {
+		_ = os.Remove(selfPath)
 		_ = os.Rename(backup, selfPath)
 	}
 
 	if err := renameAtomic(stagedBinary, selfPath); err != nil {
-		rollback()
+		restoreBinary()
 		log.Fatalf("failed to install new binary (rolled back): %v", err)
 	}
 	if err := os.Chmod(selfPath, 0o755); err != nil {
-		rollback()
+		restoreBinary()
 		log.Fatalf("failed to chmod new binary (rolled back): %v", err)
 	}
 
@@ -143,18 +159,51 @@ func cmdUpdate() {
 
 	serviceWasRunning := restartDaemon(selfPath)
 
-	installedTag, verifyErr := runVersionCommand(selfPath)
+	// Post-install re-verify. If the service restarted to a different binary
+	// (for example because launchd picked up a path different from selfPath)
+	// or if the binary we just copied refuses to exec, undo the swap so the
+	// user is left with the working old version and a loud error, not a
+	// half-broken upgrade.
+	installedVersion, verifyErr := runVersionCommand(selfPath)
 	if verifyErr != nil {
-		fmt.Printf("warning: could not verify installed version: %v\n", verifyErr)
-	} else if installedTag != target && !strings.HasSuffix(installedTag, strings.TrimPrefix(target, "v")) {
-		fmt.Printf("warning: installed binary reports %q, expected %s\n", installedTag, target)
-	} else {
-		fmt.Printf("verified: %s\n", installedTag)
+		rollbackAfterInstall(selfPath, backup)
+		log.Fatalf("post-install: installed binary failed to run (%v); rolled back to previous version.\ncheck %s for the archive you were trying to install.", verifyErr, backup)
 	}
+	if !stagedVersionMatches(installedVersion, target) {
+		rollbackAfterInstall(selfPath, backup)
+		log.Fatalf("post-install: installed binary reports %q, expected %s; rolled back.", installedVersion, target)
+	}
+	fmt.Printf("verified: %s\n", installedVersion)
 
 	_ = os.Remove(backup)
 
 	printPostUpdateReminders(target, selfPath, serviceWasRunning)
+}
+
+// stagedVersionMatches compares `cc-clip --version` output (e.g. "cc-clip 0.6.1")
+// with a release tag (e.g. "v0.6.1"). The ldflags version baked into the
+// binary carries no "v" prefix, so we normalize both sides before comparing.
+func stagedVersionMatches(reported, targetTag string) bool {
+	r := strings.TrimSpace(reported)
+	r = strings.TrimPrefix(r, "cc-clip ")
+	r = strings.TrimPrefix(r, "v")
+	t := strings.TrimPrefix(strings.TrimSpace(targetTag), "v")
+	return r == t && r != ""
+}
+
+// rollbackAfterInstall restores the backed-up binary after a failed
+// post-install verification. Also re-registers the launchd plist so the
+// service points back at the rolled-back binary.
+func rollbackAfterInstall(selfPath, backup string) {
+	_ = os.Remove(selfPath)
+	_ = os.Rename(backup, selfPath)
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	if running, err := service.Status(); err == nil && running {
+		_ = service.Uninstall()
+		_ = service.Install(selfPath, updateDaemonPort)
+	}
 }
 
 func parseUpdateFlags(args []string) updateOptions {
@@ -192,7 +241,20 @@ func resolveSelfPath() (string, error) {
 }
 
 // normalizeVersion canonicalizes a version string into "vX.Y.Z" form, or
-// returns "" for unknown versions like "dev" or a git-describe SHA.
+// returns "" for anything that is not a clean release tag.
+//
+// Things we deliberately return "" for:
+//   - "dev" and empty: obvious non-release builds.
+//   - Bare commit SHAs (no dots).
+//   - `git describe` output between tags: `v0.6.1-1-g4d2038b`. These indicate
+//     a dev binary built off an untagged commit; treating them as "already at
+//     v0.6.1" would mask actual upgrades.
+//   - Dirty-tree markers (`-dirty` suffix). Same reason.
+//
+// Things we keep (so real release tags normalize cleanly):
+//   - Plain versions like `v0.6.1`, `0.6.1`.
+//   - Prerelease versions like `v0.6.1-rc1`, `v0.6.1-beta.2`.
+//   - Build metadata like `v0.6.1+build.7`.
 func normalizeVersion(v string) string {
 	v = strings.TrimSpace(v)
 	if v == "" || v == "dev" {
@@ -200,14 +262,24 @@ func normalizeVersion(v string) string {
 	}
 	v = strings.TrimPrefix(v, "cc-clip ")
 	v = strings.TrimPrefix(v, "v")
-	// Reject anything that doesn't look like semver (rejects "abc123" SHAs).
 	if !looksLikeSemver(v) {
 		return ""
 	}
 	return "v" + v
 }
 
+// gitDescribeMarker matches the "-<commits>-g<sha>" suffix that
+// `git describe --tags --always --dirty` appends between release tags.
+// The sha portion is at least 4 hex chars in practice.
+var gitDescribeMarker = regexp.MustCompile(`-\d+-g[0-9a-f]{4,}`)
+
 func looksLikeSemver(v string) bool {
+	if gitDescribeMarker.MatchString(v) {
+		return false
+	}
+	if strings.HasSuffix(v, "-dirty") {
+		return false
+	}
 	parts := strings.SplitN(v, ".", 4)
 	if len(parts) < 3 {
 		return false
@@ -322,13 +394,50 @@ func parseLsofPID(raw string) (int, error) {
 	return 0, nil
 }
 
+// readProcessBinary returns the absolute path to the binary executing the
+// given pid, or "" if we cannot resolve one on this platform.
+//
+// We deliberately do NOT use `ps -o comm=`: on Linux that returns just the
+// basename (often truncated to 15 chars), and on macOS it also truncates.
+// Comparing a truncated basename against an absolute path would flag every
+// listener as a conflict even when it IS the binary we are about to replace.
+// When the OS cannot give us an absolute path, we return "" so the caller
+// treats it as "conflict unknown, skip" rather than a hard abort.
 func readProcessBinary(pid int) (string, error) {
-	cmd := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("ps failed for pid %d: %w", pid, err)
+	switch runtime.GOOS {
+	case "linux":
+		// /proc/<pid>/exe is a symlink to the absolute executable path.
+		target, err := os.Readlink(fmt.Sprintf("/proc/%d/exe", pid))
+		if err != nil {
+			return "", fmt.Errorf("read /proc/%d/exe: %w", pid, err)
+		}
+		if !filepath.IsAbs(target) {
+			return "", nil
+		}
+		return target, nil
+	case "darwin":
+		// `lsof -p <pid> -a -d txt -Fn` lists the text-segment files
+		// (executable + libraries). The first absolute path is the
+		// executable itself.
+		cmd := exec.Command("lsof", "-p", strconv.Itoa(pid), "-a", "-d", "txt", "-Fn")
+		out, err := cmd.Output()
+		if err != nil {
+			return "", fmt.Errorf("lsof -p %d: %w", pid, err)
+		}
+		return parseLsofTextPath(string(out)), nil
 	}
-	return strings.TrimSpace(string(out)), nil
+	return "", nil
+}
+
+// parseLsofTextPath scans output from `lsof -Fn -d txt` and returns the
+// first absolute path. An "n" record in -F output looks like "n/abs/path".
+func parseLsofTextPath(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		if len(line) > 1 && line[0] == 'n' && line[1] == '/' {
+			return line[1:]
+		}
+	}
+	return ""
 }
 
 func samePath(a, b string) bool {

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"v0.6.1", "v0.6.1"},
+		{"0.6.1", "v0.6.1"},
+		{"  v0.6.1 ", "v0.6.1"},
+		{"cc-clip 0.6.1", "v0.6.1"},
+		{"v0.6.1-rc1", "v0.6.1-rc1"},
+		{"v0.6.1+build.7", "v0.6.1+build.7"},
+		{"dev", ""},
+		{"", ""},
+		{"abc123", ""},      // git-describe SHA-like
+		{"v0.6", ""},        // only two components
+		{"v0.x.1", ""},      // non-numeric
+		{"v0.6.abc", ""},    // non-numeric patch with no suffix sep
+	}
+	for _, tc := range cases {
+		got := normalizeVersion(tc.in)
+		if got != tc.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseLsofPID(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{
+			name: "empty",
+			raw:  "",
+			want: 0,
+		},
+		{
+			name: "single listener",
+			raw: `p12345
+n127.0.0.1:18339
+`,
+			want: 12345,
+		},
+		{
+			name: "pid before n",
+			raw:  "p92902\nn127.0.0.1:18339\n",
+			want: 92902,
+		},
+		{
+			name: "first pid wins if multiple",
+			raw: `p111
+n127.0.0.1:18339
+p222
+n127.0.0.1:18339
+`,
+			want: 111,
+		},
+		{
+			name: "non-numeric pid",
+			raw:  "pabc\n",
+			want: -1, // sentinel; we expect an error
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseLsofPID(tc.raw)
+			if tc.want == -1 {
+				if err == nil {
+					t.Fatalf("expected error for malformed p-line, got pid=%d", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("parseLsofPID(%q) = %d, want %d", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLookupChecksum(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checksums.txt")
+	body := `0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  cc-clip_0.6.1_darwin_arm64.tar.gz
+fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210  cc-clip_0.6.1_linux_amd64.tar.gz
+`
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := lookupChecksum(path, "cc-clip_0.6.1_linux_amd64.tar.gz")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	const want = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+
+	if _, err := lookupChecksum(path, "nonexistent.tar.gz"); err == nil {
+		t.Error("expected error for missing entry, got nil")
+	}
+}
+
+func TestFileSHA256(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f")
+	if err := os.WriteFile(path, []byte("hello, world\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := fileSHA256(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// printf 'hello, world\n' | shasum -a 256
+	const want = "853ff93762a06ddbf722c4ebe9ddd66d8f63ddaea97f521c3ecc20da7c976020"
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestSamePath(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "cc-clip")
+	if err := os.WriteFile(real, []byte("#"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks not supported in this environment: %v", err)
+	}
+	if !samePath(real, link) {
+		t.Errorf("samePath(real, symlink) = false, want true")
+	}
+	if samePath(real, filepath.Join(dir, "other")) {
+		t.Errorf("samePath(real, other) = true, want false")
+	}
+}

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -23,6 +23,17 @@ func TestNormalizeVersion(t *testing.T) {
 		{"v0.6", ""},        // only two components
 		{"v0.x.1", ""},      // non-numeric
 		{"v0.6.abc", ""},    // non-numeric patch with no suffix sep
+
+		// git-describe output between tags (real dev-build ldflags value)
+		// must not be treated as a release version; otherwise the updater
+		// reports "already at target" and refuses to pull the real release.
+		{"v0.6.1-1-g4d2038b", ""},
+		{"v0.6.1-5-gabc1234", ""},
+		{"0.6.1-1-g4d2038b", ""},
+
+		// dirty-tree markers that `git describe --dirty` appends
+		{"v0.6.1-dirty", ""},
+		{"v0.6.1-1-g4d2038b-dirty", ""},
 	}
 	for _, tc := range cases {
 		got := normalizeVersion(tc.in)
@@ -126,6 +137,77 @@ func TestFileSHA256(t *testing.T) {
 	const want = "853ff93762a06ddbf722c4ebe9ddd66d8f63ddaea97f521c3ecc20da7c976020"
 	if got != want {
 		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+func TestStagedVersionMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		reported string
+		target   string
+		want     bool
+	}{
+		{"exact", "cc-clip 0.6.1", "v0.6.1", true},
+		{"no prefix in target", "cc-clip 0.6.1", "0.6.1", true},
+		{"v-prefix in reported", "cc-clip v0.6.1", "v0.6.1", true},
+		{"whitespace", "  cc-clip 0.6.1\n", "v0.6.1", true},
+		{"mismatch", "cc-clip 0.6.0", "v0.6.1", false},
+		{"empty reported", "", "v0.6.1", false},
+		{"dev build reported", "cc-clip dev", "v0.6.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stagedVersionMatches(tc.reported, tc.target)
+			if got != tc.want {
+				t.Errorf("stagedVersionMatches(%q, %q) = %v, want %v", tc.reported, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseLsofTextPath(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "empty",
+			raw:  "",
+			want: "",
+		},
+		{
+			name: "single absolute path",
+			raw:  "p12345\nftxt\nn/Users/shunmei/.local/bin/cc-clip\n",
+			want: "/Users/shunmei/.local/bin/cc-clip",
+		},
+		{
+			name: "first absolute path wins",
+			raw: `p12345
+ftxt
+n/Users/shunmei/.local/bin/cc-clip
+ftxt
+n/usr/lib/libSystem.B.dylib
+`,
+			want: "/Users/shunmei/.local/bin/cc-clip",
+		},
+		{
+			name: "skip non-n lines and non-absolute n lines",
+			raw: `p12345
+ftxt
+n(noroot)
+n/Users/shunmei/.local/bin/cc-clip
+`,
+			want: "/Users/shunmei/.local/bin/cc-clip",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseLsofTextPath(tc.raw)
+			if got != tc.want {
+				t.Errorf("parseLsofTextPath(...) = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 )
 
 func TestNormalizeVersion(t *testing.T) {
@@ -208,6 +210,36 @@ n/Users/shunmei/.local/bin/cc-clip
 				t.Errorf("parseLsofTextPath(...) = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestRunVersionCommandTimeout guarantees that a binary that hangs on
+// `--version` cannot wedge the updater. Without a timeout this path would
+// block forever AFTER the binary swap had already happened, meaning no
+// rollback could ever run. We simulate the hang with a shell script that
+// sleeps for 30s and verify the call returns within 2s with an error.
+func TestRunVersionCommandTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub does not run on Windows")
+	}
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "fake-cc-clip")
+	// Stub ignores its argv and sleeps, so `--version` will never return.
+	script := "#!/bin/sh\nsleep 30\n"
+	if err := os.WriteFile(stub, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Now()
+	_, err := runVersionCommandWithTimeout(stub, 500*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected non-nil error when --version exceeds timeout")
+	}
+	// Ceiling = timeout (500ms) + WaitDelay (1s) + scheduling slack.
+	if elapsed > 3*time.Second {
+		t.Errorf("runVersionCommandWithTimeout took %s, want < 3s (timeout not enforced)", elapsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `cc-clip update` subcommand so users can self-upgrade in one step instead of the manual "download + replace + service reload + connect --force" dance documented in `docs/upgrading.md`. Built to catch the exact upgrade trap that hit the v0.6.1 rollout: a third-party tool's bundled `cc-clip` copy was holding port 18339, so the new daemon could not bind, launchd crash-looped, and `cc-clip connect` synced the wrong daemon's token to the remote — breaking Ctrl+V.

## Command surface

```
cc-clip update [--check] [--force] [--to VERSION]

  --check          Only report whether a newer release exists; do not install
  --force          Re-install even if already at target version; ignore daemon conflict warnings
  --to VERSION     Install a specific release (e.g. v0.6.0) instead of latest
```

## Flow

1. Resolve the running binary path via `os.Executable`.
2. Query GitHub Releases API for the latest non-prerelease tag (or use `--to`).
3. **Conflict detection** via `lsof -Fpn` on the daemon port. If the listener's binary path differs from the one we're replacing, abort with an actionable message and the other process's PID. `--force` skips.
4. Download archive + `checksums.txt`, verify SHA-256 for this OS/arch.
5. Extract the binary to a temp dir. On macOS, clear xattrs and ad-hoc codesign so Gatekeeper does not block the replacement.
6. Back up the current binary as `.bak`, install the new one with 0755, roll back on any failure.
7. On macOS, if launchd was running cc-clip, call `service uninstall` + `service install` so the plist re-registers with the updated binary path.
8. Run `<binary> --version` to verify the swap actually took effect; warn on mismatch.
9. Print post-update reminders — remote hosts still need `cc-clip connect <host> --force`.

## Scope

- **macOS and Linux only.** Windows returns an actionable error pointing at `docs/upgrading.md`. Native Windows self-upgrade is left as a follow-up because the Windows path involves killing the tray-icon hotkey listener and optionally re-registering autostart, which has no clean analogue in the macOS service package.
- **No systemd integration on Linux yet.** The command prints a reminder; the user restarts their own service.
- **No automatic remote redeploy.** Remote hosts are listed as reminders only — redeploy touches state on other machines and should stay explicit.

## Tests

`cmd/cc-clip/update_test.go`:
- `TestNormalizeVersion` — 12 cases: stable versions, rc/build-metadata suffixes, `dev`, empty, SHAs, malformed components.
- `TestParseLsofPID` — 5 cases: empty, single listener, pid-before-n ordering, first-wins on multiple, malformed p-line.
- `TestLookupChecksum` — entry lookup inside a `checksums.txt` body.
- `TestFileSHA256` — stream hash against `printf 'hello, world\n'`.
- `TestSamePath` — symlink equivalence.

## Verification

```
$ go build ./...                               # clean
$ go vet ./...                                 # clean
$ GOOS=windows GOARCH=amd64 go build ./...     # clean
$ go test -race ./... -count=1                 # all packages pass
$ cc-clip update --check                       # real GitHub API call
current:  (unknown; probably a dev build)
target:   v0.6.1
platform: darwin/arm64
binary:   /tmp/cc-clip-test
update available: (unknown; probably a dev build) -> v0.6.1
```

## Test plan

- [x] `--check` returns current vs target without touching the binary.
- [x] Conflict detection catches when another process owns the daemon port.
- [x] Checksum verification is pinned — an entry mismatch is a hard fail.
- [x] Rollback restores the old binary when any apply step fails.
- [ ] End-to-end upgrade on a real darwin box that has the cc-clip launchd service running — covered manually by maintainer at tag time.
- [ ] End-to-end on Linux without launchd — covered by the "restart yourself" reminder path.

## Follow-ups (intentionally deferred)

- `docs/upgrading.md`: add `cc-clip update` as Option 0 once PR #47 lands, to avoid clashing with the daemon-ownership section added there.
- Linux systemd service restart.
- Native Windows self-update path.
- Optional: `cc-clip update --redeploy-remotes` that iterates known hosts and runs `cc-clip connect <host> --force` for each.
