### PR TITLE
feat(release): release contract covers updater assumptions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ release-preflight: test vet
 		|| { echo "FAIL: .goreleaser.yaml no longer declares formats: [tar.gz]"; exit 1; }
 	@grep -Fq 'formats: [zip]' .goreleaser.yaml \
 		|| { echo "FAIL: .goreleaser.yaml no longer declares the Windows formats: [zip] override"; exit 1; }
+	@echo "==> cc-clip update contract greps (keep update.go aligned with above)"
+	@grep -Fq 'cc-clip_%s_%s_%s.tar.gz' cmd/cc-clip/update.go \
+		|| { echo "FAIL: cmd/cc-clip/update.go archive-name drift; releaseArchiveName() must stay aligned with goreleaser name_template and scripts/install.sh"; exit 1; }
+	@grep -Fq 'checksums.txt' cmd/cc-clip/update.go \
+		|| { echo "FAIL: cmd/cc-clip/update.go no longer fetches checksums.txt; integrity verification broken"; exit 1; }
 	@echo "==> goreleaser snapshot build (no publish)"
 	@goreleaser release --snapshot --clean --skip=publish
 	@echo "==> release preflight OK. Safe to tag."

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -569,9 +569,26 @@ func samePath(a, b string) bool {
 	return filepath.Clean(a) == filepath.Clean(b)
 }
 
-func downloadAndVerifyArchive(ctx context.Context, tag string) (string, func(), error) {
+// releaseArchiveName returns the filename goreleaser publishes for a given
+// release tag + target triple. This is the single place where the
+// cc-clip-update path encodes its assumption about release asset naming.
+//
+// The same filename shape appears in two other places that MUST stay aligned:
+//
+//   - `.goreleaser.yaml` `name_template` (what goreleaser actually emits).
+//   - `scripts/install.sh` `ARCHIVE_NAME` (what the install-script path
+//     expects).
+//
+// `make release-preflight` greps for this constant in update.go alongside
+// the goreleaser/install.sh checks, so any future drift in one spot fails
+// the contract gate before a tag can be pushed.
+func releaseArchiveName(tag, goos, goarch string) string {
 	version := strings.TrimPrefix(tag, "v")
-	archiveName := fmt.Sprintf("cc-clip_%s_%s_%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("cc-clip_%s_%s_%s.tar.gz", version, goos, goarch)
+}
+
+func downloadAndVerifyArchive(ctx context.Context, tag string) (string, func(), error) {
+	archiveName := releaseArchiveName(tag, runtime.GOOS, runtime.GOARCH)
 
 	tmpDir, err := os.MkdirTemp("", "cc-clip-update-*")
 	if err != nil {

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -8,6 +8,37 @@ import (
 	"time"
 )
 
+// TestReleaseArchiveName pins the exact filename the updater expects at
+// `<release>/cc-clip_<version>_<os>_<arch>.tar.gz`. If this shape ever
+// changes in goreleaser or scripts/install.sh without being reflected here
+// (or vice versa), the matching `make release-preflight` grep ensures the
+// drift is caught before a tag ships.
+func TestReleaseArchiveName(t *testing.T) {
+	cases := []struct {
+		name   string
+		tag    string
+		goos   string
+		goarch string
+		want   string
+	}{
+		{"darwin arm64", "v0.6.2", "darwin", "arm64", "cc-clip_0.6.2_darwin_arm64.tar.gz"},
+		{"linux amd64", "v0.6.2", "linux", "amd64", "cc-clip_0.6.2_linux_amd64.tar.gz"},
+		{"linux arm64", "v0.6.2", "linux", "arm64", "cc-clip_0.6.2_linux_arm64.tar.gz"},
+		{"darwin amd64", "v0.6.2", "darwin", "amd64", "cc-clip_0.6.2_darwin_amd64.tar.gz"},
+		{"tag without v prefix", "0.6.2", "darwin", "arm64", "cc-clip_0.6.2_darwin_arm64.tar.gz"},
+		{"older release", "v0.5.0", "linux", "amd64", "cc-clip_0.5.0_linux_amd64.tar.gz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := releaseArchiveName(tc.tag, tc.goos, tc.goarch)
+			if got != tc.want {
+				t.Errorf("releaseArchiveName(%q, %q, %q) = %q, want %q",
+					tc.tag, tc.goos, tc.goarch, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNormalizeVersion(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/docs/release.md
+++ b/docs/release.md
@@ -52,14 +52,26 @@ This target runs, in order:
 3. Cross-compile sanity for all six target triples.
 4. `goreleaser check` — validates `.goreleaser.yaml` against the current
    GoReleaser schema.
-5. The four contract greps the workflow runs
-   (`name_template`, `install.sh` archive name, `formats: [tar.gz]`,
-   `formats: [zip]`).
+5. The release-contract greps. These enforce that the three files below
+   agree on the archive naming and asset layout, because if any one of
+   them drifts alone, a real user-visible path breaks silently:
+   - `.goreleaser.yaml` — what goreleaser actually emits
+     (`name_template`, `formats: [tar.gz]`, `formats: [zip]`).
+   - `scripts/install.sh` — what the install-script path expects to
+     download.
+   - `cmd/cc-clip/update.go` — `releaseArchiveName()` is the single
+     source of truth for the `cc-clip update` command. The grep pins
+     the format string and the `checksums.txt` fetch, so any future
+     change to asset naming forces a matching update in the updater.
 6. `goreleaser release --snapshot --clean --skip=publish` — actually builds
    every archive to `dist/` without publishing, so archive-time issues
    surface locally.
 
 Stop and fix on the first failure.
+
+If a grep fails, fix the drift in the file it names AND in every other
+file in the list above. The contract is a three-way agreement, not
+two separate pairs.
 
 ## Phase 3: Cut and push the tag
 
@@ -129,6 +141,42 @@ gh run watch "$RUN_ID" --exit-status
 ```
 
 Non-zero exit means the release was not published. See **Phase 6** for recovery.
+
+## Phase 4.5: Write real release notes
+
+GoReleaser's default release body is a two-line commit list with SHAs,
+which is the minimum the release page can legally show. For every tag
+worth cutting, replace it with a user-facing summary before moving on.
+The tag annotation from Phase 3 is `git show $V` forever, but it is NOT
+what end users see on GitHub until this step happens.
+
+```bash
+V=v0.6.2
+gh release edit "$V" --notes-file path/to/notes.md
+```
+
+The notes file should cover, in this order:
+
+1. **What's New** — the flagship change, with a short code block if it
+   introduces a new command or flag.
+2. **Other Improvements** — documentation, tooling, CI, everything else
+   that users might notice but is not the headline.
+3. **Upgrade** — concrete commands per platform. On cc-clip this is
+   `cc-clip update` for 0.6.2+ users, `install.sh` for fresh installs
+   and Windows-to-manual, and always the `cc-clip connect <host> --force`
+   reminder for remote hosts.
+4. **Not in This Release** — features deferred, known limitations, links
+   to issues tracking follow-ups. This stops users filing "why didn't
+   X ship" questions.
+5. **Verification** — a short snippet showing how to check the archive
+   against `checksums.txt`. Makes integrity verification a copy-paste
+   one-liner.
+6. **Full Commit List + Diff link** — short SHAs, link to
+   `https://github.com/<repo>/compare/<prev>...<tag>`.
+
+Compare the end result against the release pages for the previous two
+versions — the shape should match so users subscribed to releases can
+skim instead of re-reading the format each time.
 
 ## Phase 5: Verify the published release
 
@@ -207,3 +255,27 @@ either (a) a drift between `.github/workflows/release.yml` contract checks and
 not normally compile for. Both classes are cheap to catch locally and expensive
 to catch after pushing a tag. `make release-preflight` is the one-shot that
 mirrors CI exactly, so the tag push becomes a ceremony rather than a gamble.
+
+### Appendix: the release contract is three-way
+
+The asset layout a cc-clip release ships is a shared contract across
+three files that MUST stay aligned:
+
+| File | Role | What it encodes |
+|---|---|---|
+| `.goreleaser.yaml` | emits | `name_template`, per-arch `formats` |
+| `scripts/install.sh` | consumes (new install) | `ARCHIVE_NAME` = `cc-clip_${VERSION#v}_${PLATFORM}.tar.gz` |
+| `cmd/cc-clip/update.go` | consumes (self-upgrade) | `releaseArchiveName()` format string + `checksums.txt` fetch |
+
+If any one of these changes alone, real users break silently:
+
+- drift in `.goreleaser.yaml` -> published archive filename no longer
+  matches what the downstream consumers expect.
+- drift in `install.sh` -> new installs 404 on download URL.
+- drift in `update.go` -> existing users on the previous release
+  cannot self-upgrade and get a 404 from `cc-clip update`.
+
+`make release-preflight` greps all three in the same step precisely so
+that a single-sided change trips the gate before it ships. If you ever
+find yourself changing asset naming, change all three in the same PR
+and verify `make release-preflight` still passes.


### PR DESCRIPTION
## Summary

Closes the drift gap surfaced by "how do we guarantee `cc-clip update` keeps working after a future release?". Before this PR, `make release-preflight` aligned `.goreleaser.yaml` and `scripts/install.sh` but said nothing about `cmd/cc-clip/update.go`, whose hand-rolled filename shape was its own source of truth. A PR that changed asset naming in two of three places would pass preflight and silently break self-upgrade for every existing user at the next tag push.

## Changes

1. **`cmd/cc-clip/update.go`** — extract `releaseArchiveName(tag, goos, goarch) string`. `downloadAndVerifyArchive` calls it instead of hand-rolling the filename. Comment on the helper names the other two files the contract binds together.
2. **`cmd/cc-clip/update_test.go`** — `TestReleaseArchiveName` pins the shape across darwin/linux × amd64/arm64 plus v-prefix tolerance and an older-release case.
3. **`Makefile`** — `release-preflight` gains two greps after the existing goreleaser/install.sh block:
   - `cc-clip_%s_%s_%s.tar.gz` must still be present in `update.go`.
   - `checksums.txt` must still be referenced (integrity check still wired up).
4. **`docs/release.md`** Phase 2 — updated to call the contract three-way (`.goreleaser.yaml` + `scripts/install.sh` + `cmd/cc-clip/update.go`) and explains "fix the drift in every file in the list, not just the one the grep flagged". Appendix adds a role-by-role table.
5. **`docs/release.md`** Phase 4.5 — new section codifying the `gh release edit --notes-file` step that v0.6.2 needed. Mandates the six-section template (What's New / Other Improvements / Upgrade / Not in This Release / Verification / Full Commit List) with explicit rationale for why each section belongs.

## Out of scope (intentional)

- No httptest-based end-to-end test of the full `cc-clip update` flow. The static grep is enough to catch drift; e2e is a separate, heavier investment.
- No goreleaser template change to auto-populate release bodies. Phase 4.5 documents the manual step; automating it can come later if the manual step proves tedious across multiple releases.

## Verification

```
$ make release-preflight
...
==> cc-clip update contract greps (keep update.go aligned with above)
==> goreleaser snapshot build (no publish)
  • release succeeded after 2s
==> release preflight OK. Safe to tag.
```

```
$ go test ./cmd/cc-clip/ -run 'TestReleaseArchiveName' -v
=== RUN   TestReleaseArchiveName
=== RUN   TestReleaseArchiveName/darwin_arm64
=== RUN   TestReleaseArchiveName/linux_amd64
=== RUN   TestReleaseArchiveName/linux_arm64
=== RUN   TestReleaseArchiveName/darwin_amd64
=== RUN   TestReleaseArchiveName/tag_without_v_prefix
=== RUN   TestReleaseArchiveName/older_release
--- PASS: TestReleaseArchiveName (0.00s)
```

## Test plan

- [x] New grep fires when the helper's format string is altered (trivially checked — the grep is for a literal string).
- [x] `TestReleaseArchiveName` exercises all four shipped triples.
- [x] `make release-preflight` still passes end-to-end.
- [x] `docs/release.md` Phase 2 + Appendix + Phase 4.5 reads consistently.
- [ ] Next release to go through `make release-preflight` will exercise the three-way contract for real.
