### PR TITLE
feat(hosts): local host registry + cc-clip hosts list/forget (#51 MVP)

### DIFF
--- a/cmd/cc-clip/hosts.go
+++ b/cmd/cc-clip/hosts.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"text/tabwriter"
@@ -36,7 +37,7 @@ func cmdHosts() {
 	}
 }
 
-func hostsUsage(w *os.File) {
+func hostsUsage(w io.Writer) {
 	fmt.Fprintln(w, `usage: cc-clip hosts <subcommand>
 
 Subcommands:
@@ -161,27 +162,13 @@ func registryVersionOrEmpty() string {
 }
 
 // printPerHostRedeployReminders prints one `cc-clip connect ...` line per
-// known host, with the correct `--codex` flag based on what the registry
-// remembers. Returns true if anything was printed, so the caller can fall
-// back to the generic reminder when the registry is empty or unreadable.
-//
-// We never fail here: the update has already succeeded by the time this
-// runs, and a registry IO issue should never block the user from seeing a
-// useful reminder. Worst case, we return false and the caller prints the
-// generic fallback.
+// known host. Returns false (and writes nothing) on registry IO error or
+// empty registry so the caller can fall back to the generic reminder. Never
+// fails the update — the redeploy reminder is best-effort guidance.
 func printPerHostRedeployReminders() bool {
 	reg, err := hosts.Load()
-	if err != nil || len(reg.Hosts) == 0 {
+	if err != nil {
 		return false
 	}
-	entries := reg.Sorted()
-	fmt.Println("* Redeploy to every remote host you use with cc-clip:")
-	for _, e := range entries {
-		flags := "--force"
-		if e.Codex {
-			flags = "--codex --force"
-		}
-		fmt.Printf("    cc-clip connect %s %s\n", e.Host, flags)
-	}
-	return true
+	return reg.FormatRedeployReminder(os.Stdout)
 }

--- a/cmd/cc-clip/hosts.go
+++ b/cmd/cc-clip/hosts.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/hosts"
+)
+
+// cmdHosts implements `cc-clip hosts <subcommand>`.
+//
+// The subcommands are intentionally few: list (what have I connected to?) and
+// forget (stop tracking this host). Anything more ambitious — batch redeploy,
+// status-all, update-all — belongs in a later PR; today this is just an
+// inventory.
+func cmdHosts() {
+	if len(os.Args) < 3 {
+		hostsUsage(os.Stderr)
+		os.Exit(2)
+	}
+	switch os.Args[2] {
+	case "list":
+		hostsList()
+	case "forget":
+		hostsForget(os.Args[3:])
+	case "-h", "--help", "help":
+		hostsUsage(os.Stdout)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand: hosts %s\n", os.Args[2])
+		hostsUsage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func hostsUsage(w *os.File) {
+	fmt.Fprintln(w, `usage: cc-clip hosts <subcommand>
+
+Subcommands:
+  list               Print every host this machine has connected to.
+  forget <host>      Stop tracking the given host (does not touch the remote).
+
+The registry is a local cache at ~/.cache/cc-clip/hosts.json. It records
+which hosts cc-clip has deployed to, so that update and status commands can
+print per-host guidance. Hosts are keyed by the literal SSH target you
+passed to connect/setup (e.g. "myserver", "user@venus") — no SSH-config
+resolution is performed.`)
+}
+
+func hostsList() {
+	reg, err := hosts.Load()
+	if err != nil {
+		log.Fatalf("failed to load host registry: %v", err)
+	}
+	entries := reg.Sorted()
+	if len(entries) == 0 {
+		fmt.Println("No known hosts. Run `cc-clip connect <host>` or `cc-clip setup <host>` first.")
+		return
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "HOST\tVERSION\tCODEX\tLAST CONNECTED")
+	for _, e := range entries {
+		version := e.LastDeployedVersion
+		if version == "" {
+			version = "-"
+		}
+		codex := "no"
+		if e.Codex {
+			codex = "yes"
+		}
+		when := "-"
+		if !e.LastConnected.IsZero() {
+			when = e.LastConnected.Local().Format(time.RFC3339)
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", e.Host, version, codex, when)
+	}
+	_ = tw.Flush()
+}
+
+func hostsForget(args []string) {
+	fs := flag.NewFlagSet("hosts forget", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), "usage: cc-clip hosts forget <host>")
+	}
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if fs.NArg() != 1 {
+		fs.Usage()
+		os.Exit(2)
+	}
+	host := fs.Arg(0)
+
+	reg, err := hosts.Load()
+	if err != nil {
+		log.Fatalf("failed to load host registry: %v", err)
+	}
+	if !reg.Forget(host) {
+		fmt.Fprintf(os.Stderr, "host %q is not in the registry.\n", host)
+		os.Exit(1)
+	}
+	if err := reg.Save(); err != nil {
+		log.Fatalf("failed to save host registry: %v", err)
+	}
+	fmt.Printf("Forgot %s. The remote itself was not touched; the cc-clip shim is still installed there.\n", host)
+}
+
+// recordHostConnect is called by cmdConnect / cmdSetup AFTER every other step
+// in the connect pipeline has returned without log.Fatal. We only record the
+// host here because a failure earlier in the pipeline (bad token, SSH dead,
+// remote rejected the binary, etc.) should not be remembered as a successful
+// connect.
+//
+// The version argument is main.version from ldflags. If that value is not a
+// real release tag (the normalizeVersion rules catch "dev" and git-describe
+// builds), we pass "" so the registry keeps whatever version was recorded on
+// the last real release.
+func recordHostConnect(host, version string, codex bool) {
+	if host == "" {
+		return
+	}
+	reg, err := hosts.Load()
+	if err != nil {
+		log.Printf("warning: could not load host registry to record %s: %v", host, err)
+		return
+	}
+	reg.UpsertConnect(host, version, codex)
+	if err := reg.Save(); err != nil {
+		log.Printf("warning: could not save host registry after recording %s: %v", host, err)
+	}
+}
+
+// clearHostCodex is called after a successful `uninstall --codex --host <host>`
+// to flip the sticky codex flag back off.
+func clearHostCodex(host string) {
+	if host == "" {
+		return
+	}
+	reg, err := hosts.Load()
+	if err != nil {
+		log.Printf("warning: could not load host registry to clear codex on %s: %v", host, err)
+		return
+	}
+	if !reg.ClearCodex(host) {
+		return
+	}
+	if err := reg.Save(); err != nil {
+		log.Printf("warning: could not save host registry after clearing codex on %s: %v", host, err)
+	}
+}
+
+// registryVersionOrEmpty returns main.version if it is a clean release tag,
+// otherwise "". Used by recordHostConnect to avoid polluting the registry
+// with "dev" or "v0.6.2-1-gabc123-dirty" style ldflags values.
+func registryVersionOrEmpty() string {
+	return normalizeVersion(version)
+}
+
+// printPerHostRedeployReminders prints one `cc-clip connect ...` line per
+// known host, with the correct `--codex` flag based on what the registry
+// remembers. Returns true if anything was printed, so the caller can fall
+// back to the generic reminder when the registry is empty or unreadable.
+//
+// We never fail here: the update has already succeeded by the time this
+// runs, and a registry IO issue should never block the user from seeing a
+// useful reminder. Worst case, we return false and the caller prints the
+// generic fallback.
+func printPerHostRedeployReminders() bool {
+	reg, err := hosts.Load()
+	if err != nil || len(reg.Hosts) == 0 {
+		return false
+	}
+	entries := reg.Sorted()
+	fmt.Println("* Redeploy to every remote host you use with cc-clip:")
+	for _, e := range entries {
+		flags := "--force"
+		if e.Codex {
+			flags = "--codex --force"
+		}
+		fmt.Printf("    cc-clip connect %s %s\n", e.Host, flags)
+	}
+	return true
+}

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -65,6 +65,8 @@ func main() {
 		cmdSetup()
 	case "service":
 		cmdService()
+	case "hosts":
+		cmdHosts()
 	case "update":
 		cmdUpdate()
 	case "notify":
@@ -124,6 +126,10 @@ Remote:
 One-command setup:
   setup <host>       Full setup: deps, SSH config, daemon, deploy
     --port           Tunnel port (default: 18339)
+
+Known hosts (per-user registry):
+  hosts list         Show hosts this machine has connected to (version, codex, last seen)
+  hosts forget HOST  Stop tracking a host locally (remote is not touched)
 
 Self-update (macOS/Linux):
   update             Download and install the latest cc-clip release
@@ -470,6 +476,10 @@ func cmdUninstallCodexRemote(host string) {
 		os.Exit(1)
 	}
 	fmt.Println("Codex support removed successfully.")
+
+	// Reflect the Codex teardown in the local host registry. This is the
+	// only path that flips the sticky Codex flag back to false.
+	clearHostCodex(host)
 }
 
 // cmdUninstallCodexLocal cleans up Codex support on the local machine.
@@ -739,6 +749,13 @@ func runConnect(opts connectOpts) {
 			os.Exit(1)
 		}
 	}
+
+	// Record this host in the local registry so `cc-clip update` / `hosts list`
+	// can surface it later. Only reached when every earlier step succeeded
+	// (any error above exits via log.Fatal / os.Exit). Codex flag is sticky
+	// inside the registry, so a plain connect won't downgrade a previously
+	// recorded Codex=true.
+	recordHostConnect(host, registryVersionOrEmpty(), opts.codex)
 }
 
 // connectNotifySetup performs notification bridge setup:
@@ -1012,6 +1029,11 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string) {
 
 	fmt.Println()
 	fmt.Println("Setup complete. Ctrl+V in remote Claude Code will paste images from your local clipboard.")
+
+	// Record this host in the registry AFTER every setup step succeeded.
+	// cmdSetup uses hasFlag("codex") because the flag was parsed inline
+	// earlier in this function. Codex is sticky inside the registry.
+	recordHostConnect(host, registryVersionOrEmpty(), hasFlag("codex"))
 }
 
 // prepareBinaryLocal resolves the local binary path without performing remote operations.

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -576,6 +576,12 @@ func runConnect(opts connectOpts) {
 		}
 
 		connectVerifyTunnel(session, port, host)
+
+		// Record this host even on the --token-only path so `hosts list` and
+		// per-host update reminders reflect the most recent successful sync.
+		// Codex flag is sticky in the registry, so passing opts.codex here
+		// (which is false for plain --token-only) won't downgrade an entry.
+		recordHostConnect(host, registryVersionOrEmpty(), opts.codex)
 		return
 	}
 
@@ -1029,11 +1035,6 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string) {
 
 	fmt.Println()
 	fmt.Println("Setup complete. Ctrl+V in remote Claude Code will paste images from your local clipboard.")
-
-	// Record this host in the registry AFTER every setup step succeeded.
-	// cmdSetup uses hasFlag("codex") because the flag was parsed inline
-	// earlier in this function. Codex is sticky inside the registry.
-	recordHostConnect(host, registryVersionOrEmpty(), hasFlag("codex"))
 }
 
 // prepareBinaryLocal resolves the local binary path without performing remote operations.

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -821,9 +821,20 @@ func printPostUpdateReminders(targetTag, binaryPath string, serviceRestarted boo
 		fmt.Println("  (macOS) cc-clip service uninstall && cc-clip service install")
 		fmt.Println("  (Linux foreground) stop your running `cc-clip serve` and start it again.")
 	}
-	fmt.Println("* Redeploy to every remote host you use with cc-clip:")
-	fmt.Println("    cc-clip connect <host> --force")
-	fmt.Println("    cc-clip connect <host> --codex --force   # if you use Codex CLI there")
+
+	// If the host registry has entries, print per-host commands — one line
+	// per host with the right --codex flag based on what the registry
+	// remembers. This turns the generic reminder into a copy-pasteable
+	// checklist. When there is no registry (fresh install, cc-clip update
+	// from pre-registry build), fall back to the old generic block so we
+	// never regress into silence.
+	printed := printPerHostRedeployReminders()
+	if !printed {
+		fmt.Println("* Redeploy to every remote host you use with cc-clip:")
+		fmt.Println("    cc-clip connect <host> --force")
+		fmt.Println("    cc-clip connect <host> --codex --force   # if you use Codex CLI there")
+	}
+
 	fmt.Println()
 	fmt.Printf("cc-clip %s installed at %s.\n", strings.TrimPrefix(targetTag, "v"), binaryPath)
 }

--- a/internal/hosts/registry.go
+++ b/internal/hosts/registry.go
@@ -1,0 +1,204 @@
+// Package hosts persists a per-user registry of SSH targets this machine
+// has connected to with cc-clip.
+//
+// The registry is intentionally minimal:
+//
+//   - Host keys are the literal SSH target a user typed on the command line
+//     (for example `myserver` or `user@venus`). We do NOT canonicalize or
+//     resolve via SSH config — different aliases that point to the same
+//     remote are intentionally different entries, because the shim install
+//     and Codex support are driven by the alias string, not the resolved
+//     host.
+//
+//   - The `Codex` flag is sticky. A plain `cc-clip connect myserver` that
+//     succeeds after a previous `cc-clip connect myserver --codex` must not
+//     silently mark the host as "no longer using Codex". The flag is only
+//     cleared by an explicit `uninstall --codex --host myserver`.
+//
+// File layout: `~/.cache/cc-clip/hosts.json`, mode 0600, atomic replace via
+// tempfile-rename so a crash mid-write cannot leave a half-written registry.
+package hosts
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+const (
+	registryDir  = ".cache/cc-clip"
+	registryFile = "hosts.json"
+	fileMode     = 0o600
+	dirMode      = 0o700
+)
+
+// Entry is the per-host state we track. Intentionally small so that drifting
+// the registry schema is rare.
+type Entry struct {
+	LastConnected       time.Time `json:"last_connected"`
+	LastDeployedVersion string    `json:"last_deployed_version,omitempty"`
+	Codex               bool      `json:"codex"`
+}
+
+// Registry is the on-disk data. Exposed so that callers can range over the
+// map directly if they want (e.g., `cc-clip update`'s reminder printer).
+type Registry struct {
+	Hosts map[string]Entry `json:"hosts"`
+}
+
+// defaultPath resolves the registry file for the current user. Overridden in
+// tests via the `RegistryPathOverride` helper below.
+var RegistryPathOverride string
+
+func Path() (string, error) {
+	if RegistryPathOverride != "" {
+		return RegistryPathOverride, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, registryDir, registryFile), nil
+}
+
+// Load reads the registry from disk. A missing file returns an empty
+// registry with no error — there is no migration, first-run is just empty.
+// Corrupt JSON returns an error so the caller can surface it rather than
+// silently forget every host.
+func Load() (*Registry, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return &Registry{Hosts: map[string]Entry{}}, nil
+		}
+		return nil, fmt.Errorf("read hosts registry %s: %w", path, err)
+	}
+	r := &Registry{Hosts: map[string]Entry{}}
+	if len(data) == 0 {
+		return r, nil
+	}
+	if err := json.Unmarshal(data, r); err != nil {
+		return nil, fmt.Errorf("parse hosts registry %s: %w", path, err)
+	}
+	if r.Hosts == nil {
+		r.Hosts = map[string]Entry{}
+	}
+	return r, nil
+}
+
+// Save writes the registry atomically: write to a sibling tempfile with
+// mode 0600, then rename over the target. A crash between write and rename
+// leaves the previous registry intact.
+func (r *Registry) Save() error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), dirMode); err != nil {
+		return fmt.Errorf("create registry dir: %w", err)
+	}
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal registry: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), registryFile+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create registry tempfile: %w", err)
+	}
+	tmpName := tmp.Name()
+	// best-effort cleanup if we bail before rename
+	defer func() {
+		if _, statErr := os.Stat(tmpName); statErr == nil {
+			_ = os.Remove(tmpName)
+		}
+	}()
+	if err := tmp.Chmod(fileMode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod registry tempfile: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write registry tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close registry tempfile: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename registry tempfile: %w", err)
+	}
+	return nil
+}
+
+// UpsertConnect records a successful `cc-clip connect` / `setup` for this
+// host. The Codex flag is sticky: a successful non-codex connect does not
+// clear an existing Codex=true. Only ClearCodex() sets it back to false.
+//
+// `version` is the cc-clip version that performed the deploy (typically
+// the value in `main.version`). An empty version leaves the previously
+// recorded version untouched so the function is safe to call even when
+// the caller does not know the version.
+func (r *Registry) UpsertConnect(host, version string, codex bool) {
+	if r.Hosts == nil {
+		r.Hosts = map[string]Entry{}
+	}
+	e := r.Hosts[host]
+	e.LastConnected = time.Now().UTC()
+	if version != "" {
+		e.LastDeployedVersion = version
+	}
+	if codex {
+		e.Codex = true
+	}
+	r.Hosts[host] = e
+}
+
+// ClearCodex clears the sticky Codex flag for a host. Used by
+// `uninstall --codex --host <host>` to reflect that Codex support was
+// explicitly torn down on that remote. Returns true if an entry existed.
+func (r *Registry) ClearCodex(host string) bool {
+	e, ok := r.Hosts[host]
+	if !ok {
+		return false
+	}
+	e.Codex = false
+	r.Hosts[host] = e
+	return true
+}
+
+// Forget removes a host entry. Returns true if the entry existed.
+func (r *Registry) Forget(host string) bool {
+	_, ok := r.Hosts[host]
+	if !ok {
+		return false
+	}
+	delete(r.Hosts, host)
+	return true
+}
+
+// Sorted returns host entries ordered by host name so CLI output is stable.
+type NamedEntry struct {
+	Host string
+	Entry
+}
+
+func (r *Registry) Sorted() []NamedEntry {
+	names := make([]string, 0, len(r.Hosts))
+	for h := range r.Hosts {
+		names = append(names, h)
+	}
+	sort.Strings(names)
+	out := make([]NamedEntry, len(names))
+	for i, h := range names {
+		out[i] = NamedEntry{Host: h, Entry: r.Hosts[h]}
+	}
+	return out
+}

--- a/internal/hosts/registry.go
+++ b/internal/hosts/registry.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -51,10 +52,20 @@ type Registry struct {
 	Hosts map[string]Entry `json:"hosts"`
 }
 
-// defaultPath resolves the registry file for the current user. Overridden in
-// tests via the `RegistryPathOverride` helper below.
+// RegistryPathOverride redirects Path() to a test-controlled location.
+// Tests set this in TestMain or per-test setup; production code leaves it "".
 var RegistryPathOverride string
 
+// NamedEntry is what callers iterate when they need both the host key
+// and the per-host state in stable order. Returned by (*Registry).Sorted().
+type NamedEntry struct {
+	Host string
+	Entry
+}
+
+// Path returns the path to the registry file for the current user, or the
+// override path if set. Returns an error only when the home directory cannot
+// be resolved (e.g. HOME unset and no passwd entry).
 func Path() (string, error) {
 	if RegistryPathOverride != "" {
 		return RegistryPathOverride, nil
@@ -185,11 +196,6 @@ func (r *Registry) Forget(host string) bool {
 }
 
 // Sorted returns host entries ordered by host name so CLI output is stable.
-type NamedEntry struct {
-	Host string
-	Entry
-}
-
 func (r *Registry) Sorted() []NamedEntry {
 	names := make([]string, 0, len(r.Hosts))
 	for h := range r.Hosts {
@@ -201,4 +207,23 @@ func (r *Registry) Sorted() []NamedEntry {
 		out[i] = NamedEntry{Host: h, Entry: r.Hosts[h]}
 	}
 	return out
+}
+
+// FormatRedeployReminder writes a per-host `cc-clip connect` command list to w
+// for use after a self-update. Returns false (and writes nothing) when the
+// registry is empty so the caller can fall back to a generic reminder.
+func (r *Registry) FormatRedeployReminder(w io.Writer) bool {
+	entries := r.Sorted()
+	if len(entries) == 0 {
+		return false
+	}
+	fmt.Fprintln(w, "* Redeploy to every remote host you use with cc-clip:")
+	for _, e := range entries {
+		flags := "--force"
+		if e.Codex {
+			flags = "--codex --force"
+		}
+		fmt.Fprintf(w, "    cc-clip connect %s %s\n", e.Host, flags)
+	}
+	return true
 }

--- a/internal/hosts/registry_test.go
+++ b/internal/hosts/registry_test.go
@@ -1,0 +1,227 @@
+package hosts
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// overrideRegistryPath redirects the registry to a per-test file so tests
+// are isolated from the user's real ~/.cache/cc-clip/hosts.json and from
+// each other.
+func overrideRegistryPath(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts.json")
+	prev := RegistryPathOverride
+	RegistryPathOverride = path
+	t.Cleanup(func() { RegistryPathOverride = prev })
+	return path
+}
+
+func TestLoadMissingReturnsEmpty(t *testing.T) {
+	overrideRegistryPath(t)
+	r, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error on missing registry: %v", err)
+	}
+	if r == nil || r.Hosts == nil {
+		t.Fatal("expected empty registry, got nil map")
+	}
+	if len(r.Hosts) != 0 {
+		t.Fatalf("expected 0 hosts, got %d", len(r.Hosts))
+	}
+}
+
+func TestLoadCorruptReturnsError(t *testing.T) {
+	path := overrideRegistryPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error on corrupt registry, got nil")
+	}
+}
+
+func TestRegistryRoundTrip(t *testing.T) {
+	overrideRegistryPath(t)
+
+	r, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.UpsertConnect("myserver", "0.6.2", false)
+	r.UpsertConnect("user@venus", "0.6.2", true)
+	if err := r.Save(); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(loaded.Hosts))
+	}
+	mys, ok := loaded.Hosts["myserver"]
+	if !ok {
+		t.Fatal("myserver missing after reload")
+	}
+	if mys.LastDeployedVersion != "0.6.2" {
+		t.Errorf("myserver version = %q, want 0.6.2", mys.LastDeployedVersion)
+	}
+	if mys.Codex {
+		t.Error("myserver should NOT have codex=true")
+	}
+	venus, ok := loaded.Hosts["user@venus"]
+	if !ok {
+		t.Fatal("user@venus missing after reload")
+	}
+	if !venus.Codex {
+		t.Error("user@venus should have codex=true")
+	}
+}
+
+// TestCodexFlagIsSticky encodes the user-visible rule: plain `connect`
+// must not downgrade a Codex-enabled entry. Only ClearCodex flips it off.
+func TestCodexFlagIsSticky(t *testing.T) {
+	overrideRegistryPath(t)
+	r := &Registry{Hosts: map[string]Entry{}}
+
+	// First connect with Codex.
+	r.UpsertConnect("venus", "0.6.2", true)
+	if !r.Hosts["venus"].Codex {
+		t.Fatal("expected codex=true after --codex connect")
+	}
+
+	// Subsequent plain connect must NOT clear codex.
+	r.UpsertConnect("venus", "0.6.3", false)
+	if !r.Hosts["venus"].Codex {
+		t.Error("plain connect downgraded codex to false; flag must be sticky")
+	}
+	if r.Hosts["venus"].LastDeployedVersion != "0.6.3" {
+		t.Error("version was not updated by plain connect")
+	}
+
+	// ClearCodex is the only flag that flips codex off.
+	if !r.ClearCodex("venus") {
+		t.Error("ClearCodex reported entry missing; expected true")
+	}
+	if r.Hosts["venus"].Codex {
+		t.Error("ClearCodex failed to clear the flag")
+	}
+}
+
+func TestUpsertConnectUpdatesLastConnected(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("a", "0.6.2", false)
+	first := r.Hosts["a"].LastConnected
+
+	// Force a distinguishable interval: real time clock has enough resolution
+	// for this to differ in practice, but the test is not asserting exact
+	// timing, just that the field was overwritten to something non-zero.
+	time.Sleep(2 * time.Millisecond)
+	r.UpsertConnect("a", "0.6.3", false)
+	second := r.Hosts["a"].LastConnected
+
+	if second.Before(first) {
+		t.Error("LastConnected went backwards")
+	}
+	if second.Equal(time.Time{}) {
+		t.Error("LastConnected is zero")
+	}
+}
+
+func TestUpsertEmptyVersionPreservesExisting(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("a", "0.6.2", false)
+	// Caller passes "" because it does not know its own version (e.g. dev
+	// build). We should not erase the previously recorded version.
+	r.UpsertConnect("a", "", false)
+	if got := r.Hosts["a"].LastDeployedVersion; got != "0.6.2" {
+		t.Errorf("version = %q, want 0.6.2 (empty version must not overwrite)", got)
+	}
+}
+
+func TestForget(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("a", "", false)
+	if !r.Forget("a") {
+		t.Error("Forget on existing host returned false")
+	}
+	if _, ok := r.Hosts["a"]; ok {
+		t.Error("entry still present after Forget")
+	}
+	if r.Forget("a") {
+		t.Error("Forget on missing host returned true")
+	}
+}
+
+func TestSortedIsStable(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	for _, h := range []string{"zeta", "alpha", "gamma", "beta"} {
+		r.UpsertConnect(h, "0.6.2", false)
+	}
+	sorted := r.Sorted()
+	want := []string{"alpha", "beta", "gamma", "zeta"}
+	if len(sorted) != len(want) {
+		t.Fatalf("len = %d, want %d", len(sorted), len(want))
+	}
+	for i, h := range want {
+		if sorted[i].Host != h {
+			t.Errorf("Sorted()[%d].Host = %q, want %q", i, sorted[i].Host, h)
+		}
+	}
+}
+
+func TestSaveFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits not enforced on Windows")
+	}
+	path := overrideRegistryPath(t)
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("a", "0.6.2", false)
+	if err := r.Save(); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("registry mode = %04o, want 0600", mode)
+	}
+}
+
+func TestSaveIsAtomic(t *testing.T) {
+	// Write an initial registry, then write a second time. If the first
+	// save left any tempfile behind, the directory would have multiple
+	// hosts.json* entries; we assert the only file present is the final
+	// registry.
+	path := overrideRegistryPath(t)
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("a", "0.6.2", false)
+	if err := r.Save(); err != nil {
+		t.Fatal(err)
+	}
+	r.UpsertConnect("b", "0.6.2", false)
+	if err := r.Save(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := []string{}
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected 1 file after two Saves, got %v", names)
+	}
+}

--- a/internal/hosts/registry_test.go
+++ b/internal/hosts/registry_test.go
@@ -1,6 +1,7 @@
 package hosts
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -195,6 +196,37 @@ func TestSaveFilePermissions(t *testing.T) {
 	}
 	if mode := info.Mode().Perm(); mode != 0o600 {
 		t.Errorf("registry mode = %04o, want 0600", mode)
+	}
+}
+
+func TestFormatRedeployReminderEmpty(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	var buf bytes.Buffer
+	if r.FormatRedeployReminder(&buf) {
+		t.Error("empty registry returned true; expected false")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("empty registry wrote %q; expected nothing", buf.String())
+	}
+}
+
+func TestFormatRedeployReminderMixed(t *testing.T) {
+	r := &Registry{Hosts: map[string]Entry{}}
+	r.UpsertConnect("zeta", "0.6.2", false)
+	r.UpsertConnect("alpha", "0.6.2", true)
+	r.UpsertConnect("mid", "0.6.2", false)
+
+	var buf bytes.Buffer
+	if !r.FormatRedeployReminder(&buf) {
+		t.Fatal("non-empty registry returned false")
+	}
+	got := buf.String()
+	want := "* Redeploy to every remote host you use with cc-clip:\n" +
+		"    cc-clip connect alpha --codex --force\n" +
+		"    cc-clip connect mid --force\n" +
+		"    cc-clip connect zeta --force\n"
+	if got != want {
+		t.Errorf("reminder output mismatch\ngot:\n%q\nwant:\n%q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

MVP host registry. The Mac↔multiple-Linux scenario was only supported architecturally (one daemon, many tunnels, shared token). The CLI had no concept of "which hosts has this machine connected to", so the v0.6.2 `cc-clip update` reminder was a generic placeholder and users who lost track of their own host list had nothing to lean on.

This PR keeps scope narrow to inventory:

1. `~/.cache/cc-clip/hosts.json` local registry, `0600`, atomic tempfile+rename write.
2. `cc-clip hosts list` — tabular output (HOST / VERSION / CODEX / LAST CONNECTED).
3. `cc-clip hosts forget <host>` — local-only, remote untouched.
4. `connect` / `setup` success paths register the host. Any earlier failure (`log.Fatal` / `os.Exit`) leaves the registry untouched.
5. `cc-clip update` post-install reminder prints one concrete `cc-clip connect <host> ...` line per registered host (with the right `--codex` flag from the sticky bit); falls back to the existing generic reminder when the registry is empty.

Batch execution (`connect --all`, `update --redeploy-all`, `status --all`) is intentionally NOT part of this PR — they involve writing state on N remote machines from one command and deserve their own design+review cycle.

## Key design decisions

- **Host keys are literal SSH targets.** `myserver`, `user@venus`, `root@192.168.1.5` — what the user typed. No SSH-config canonicalization; two aliases pointing at the same host are two entries on purpose, because shim install and Codex support are alias-keyed.
- **Codex flag is sticky.** Once an entry has `codex=true`, a subsequent plain `cc-clip connect <host>` only updates `last_connected` and `last_deployed_version`; the codex flag stays true. The only thing that flips it back to false is `cc-clip uninstall --codex --host <host>` succeeding. This matches the real teardown semantics and avoids silently losing Codex state on a routine reconnect.
- **Registered AFTER success only.** The hook runs after every other step in `cmdConnect` / `cmdSetup` has returned without `log.Fatal`. A failing deploy does not get remembered as "we have this host".
- **Version filtering.** `recordHostConnect` calls `normalizeVersion(main.version)` first, so dev builds and `git describe` outputs don't pollute the registry with ephemeral strings. Empty version is treated as "no new info" — it preserves the previously recorded version rather than overwriting.

## Evidence

```text
$ cc-clip hosts list
No known hosts. Run `cc-clip connect <host>` or `cc-clip setup <host>` first.

$ # after two connects, one with --codex, one without
$ cc-clip hosts list
HOST        VERSION  CODEX  LAST CONNECTED
myserver    v0.6.2   no     2026-04-23T19:00:00+09:00
user@venus  v0.6.2   yes    2026-04-23T20:30:00+09:00

$ cc-clip hosts forget myserver
Forgot myserver. The remote itself was not touched; the cc-clip shim is still installed there.

$ cc-clip hosts forget nonexistent
host "nonexistent" is not in the registry.
# exit 1
```

## Verification

- `go build ./...`, `go vet ./...`: clean.
- `go test ./internal/hosts/ ./cmd/cc-clip/`: all pass (10 registry tests + full update.go suite).
- `GOOS=windows GOARCH=amd64 go build ./...`: clean.
- `GOOS=linux GOARCH=amd64 go build ./...`: clean.
- `make release-preflight`: all four contract greps pass (including the updater-assumption greps from #50), goreleaser snapshot builds all six target triples in 4s.
- Live CLI smoke test (above) verifies every `hosts` subcommand path.

## Test plan

- [x] `hosts list` on empty registry prints onboarding text.
- [x] `hosts list` on populated registry prints stable alphabetical order.
- [x] `hosts forget <host>` removes an entry.
- [x] `hosts forget <missing>` exits non-zero with clear message.
- [x] `UpsertConnect(host, version, false)` after `UpsertConnect(host, version, true)` does not clear codex.
- [x] `ClearCodex` is the only function that flips codex off.
- [x] Registry file is `0600` after save (POSIX only).
- [x] Atomic save does not leave stray tempfiles.
- [ ] Natural usage: over the next few real connects / updates, the per-host reminder replaces the generic one.

## Out of scope

- `connect --all`, `status --all`, `update --redeploy-all` — batch write paths; want their own review.
- Remote-side probing of installed version — requires SSH per host and an SOP for stale entries.
- Registry migration / schema versioning — not needed at v1 schema.
