### PR TITLE
chore: ignore local build artifacts, tool caches, and planning scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Go
 .gocache/
 /cc-clip
+/cc-clip-dev
 *.exe
+*.test
 
 # Go telemetry / sandbox artifacts
 .home/
@@ -14,3 +16,12 @@
 .vscode/
 dist/
 AGENTS.md
+
+# Local tool artifacts (per-machine, not part of the repo)
+.claude/
+.playwright-mcp/
+
+# Local planning scratch files (use docs/ for anything worth keeping)
+/findings.md
+/progress.md
+/task_plan.md


### PR DESCRIPTION
## Summary

Clean up `git status` noise after the host-registry work. The repo currently shows ~10 untracked files on every session — per-machine build outputs, tool caches, and planning scratch — which makes accidental `git add .` riskier than it needs to be.

## Scope

**Ignored (per-machine, not part of the repo):**
- `/cc-clip-dev` and `*.test` — local `go build` / `go test -c` artifacts (covers `cc-clip.test`, `x11bridge.test`, `xvfb.test`)
- `.claude/`, `.playwright-mcp/` — per-machine tool caches
- `/findings.md`, `/progress.md`, `/task_plan.md` — planning scratch at repo root only

**Deliberately NOT ignored:**
- `docs/marketing/`, `docs/plans/`, `docs/superpowers/` — these contain product/design assets in flight. Owner decides whether each new doc becomes a tracked docs PR or gets deleted; the repo should not silently hide them.

## Test plan
- [x] `git status` after change shows only `docs/marketing/`, `docs/plans/`, `docs/superpowers/` as untracked (verified locally)
- [x] No tracked files affected (`.gitignore` is the only change)
- [x] `go test ./... -count=1` and `go vet ./...` both green on `main` (no behavior change in this PR, but confirms baseline)