### PR TITLE
chore(ci): bump release workflow actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 
@@ -40,7 +40,7 @@ jobs:
           grep -Fq 'formats: [tar.gz]' .goreleaser.yaml
           grep -Fq 'formats: [zip]' .goreleaser.yaml
 
-      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+      - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Summary

GitHub deprecated Node 20 actions on 2025-09-19. Runners switch the Node 24 default on 2026-06-02 and remove Node 20 entirely on 2026-09-16. Our release workflow pinned three actions still on Node 20, so v0.7.0 emitted a deprecation warning during release.

This PR upgrades all three to their current Node 24 capable major version, keeping the project's existing convention of pinning to commit SHAs for supply-chain safety.

## Bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` (`34e1148…`) | **v6.0.2** (`de0fac2…`) |
| `actions/setup-go` | `v5` (`40f1582…`) | **v6.4.0** (`4a36011…`) |
| `goreleaser/goreleaser-action` | `v6` (`e435ccd…`) | **v7.2.1** (`1a80836…`) |

## What does NOT change

- GoReleaser line still uses `version: "~> v2"`, so the release contract on archive naming, install.sh format, and zip/tar.gz output stays identical.
- Release contract grep checks (`name_template`, `install.sh format`, `formats: [tar.gz]`, `formats: [zip]`) all still match against the unchanged `.goreleaser.yaml` and `scripts/install.sh`.
- No new permissions, no new secrets, no new build steps.

## Test plan

- [x] YAML parses (ruby psych safe_load)
- [x] All four release-contract grep checks still match (verified locally)
- [x] Diff is exactly three pinned-SHA replacements + their `# vX.Y.Z` comments
- [ ] Real-world verification: next tag push (e.g. v0.7.1 patch) will exercise the upgraded actions; until then PR merge is the gate.

## Why pin SHAs and not tags

Existing repo convention. Tag refs can be moved by upstream maintainers; commit SHAs cannot. The `# vX.Y.Z` comment captures the human-friendly version label so reviewers can tell at a glance which release is pinned.

## References

- GitHub Changelog (Node 20 deprecation): https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- GoReleaser Action docs: https://goreleaser.com/ci/actions/