### PR TITLE
fix(installer): claude wrapper symlink-safe install + v0.7.0 corruption recovery (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,18 @@ cc-clip works with **any coding agent that reads the clipboard via `xclip` or `w
 cc-clip doctor --host myserver
 ```
 
+### `cc-clip: real claude binary not found in PATH` after running v0.7.0
+
+If you installed cc-clip v0.7.0 against a remote whose `claude` was installed via Anthropic's Native Installer (`curl https://claude.ai/install.sh`), v0.7.0 had a bug ([#55](https://github.com/ShunmeiCho/cc-clip/issues/55)) that overwrote the real claude binary at the symlink target. To recover:
+
+```
+cc-clip setup <host> --auto-recover
+```
+
+This detects the corrupted state, migrates the original binary back from `~/.local/bin/claude.cc-clip-bak`, and installs the (fixed) v0.7.1+ wrapper. The `--auto-recover` flag is mutually exclusive with `--token-only` — they describe different intents.
+
+If `~/.local/bin/claude.cc-clip-bak` is missing on the remote, the binary cannot be recovered automatically. Reinstall Claude Code via `curl https://claude.ai/install.sh` and re-run `cc-clip setup`.
+
 <details>
 <summary><b>"zsh: killed" after installation</b></summary>
 

--- a/cmd/cc-clip/cli_flag_test.go
+++ b/cmd/cc-clip/cli_flag_test.go
@@ -41,4 +41,3 @@ func TestCLIMutex(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/cc-clip/cli_flag_test.go
+++ b/cmd/cc-clip/cli_flag_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCLIMutex_AutoRecoverWithTokenOnly(t *testing.T) {
+	cmd := exec.Command("go", "run", ".", "connect", "fakehost.invalid", "--auto-recover", "--token-only")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit on flag conflict")
+	}
+	if !strings.Contains(stderr.String(), "--auto-recover cannot be combined with --token-only") {
+		t.Fatalf("missing mutex error in stderr: %s", stderr.String())
+	}
+}

--- a/cmd/cc-clip/cli_flag_test.go
+++ b/cmd/cc-clip/cli_flag_test.go
@@ -7,15 +7,38 @@ import (
 	"testing"
 )
 
-func TestCLIMutex_AutoRecoverWithTokenOnly(t *testing.T) {
-	cmd := exec.Command("go", "run", ".", "connect", "fakehost.invalid", "--auto-recover", "--token-only")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err == nil {
-		t.Fatal("expected non-zero exit on flag conflict")
+// TestCLIMutex covers spec scenarios 22-style flag-parse rejections.
+// Both `connect` and `setup` must fail-fast at the validation gate
+// before any SSH activity — verified by stderr containing the mutex
+// message rather than an SSH connection failure for the fake host.
+func TestCLIMutex(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "connect_auto_recover_with_token_only",
+			args: []string{"connect", "fakehost.invalid", "--auto-recover", "--token-only"},
+		},
+		{
+			name: "setup_auto_recover_with_token_only",
+			args: []string{"setup", "fakehost.invalid", "--auto-recover", "--token-only"},
+		},
 	}
-	if !strings.Contains(stderr.String(), "--auto-recover cannot be combined with --token-only") {
-		t.Fatalf("missing mutex error in stderr: %s", stderr.String())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"run", "."}, tc.args...)
+			cmd := exec.Command("go", args...)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+			if err == nil {
+				t.Fatal("expected non-zero exit on flag conflict")
+			}
+			if !strings.Contains(stderr.String(), "--auto-recover cannot be combined with --token-only") {
+				t.Fatalf("missing mutex error in stderr: %s", stderr.String())
+			}
+		})
 	}
 }
+

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -505,12 +505,13 @@ func cmdUninstallCodexLocal() {
 }
 
 type connectOpts struct {
-	host      string
-	port      int
-	force     bool
-	tokenOnly bool
-	codex     bool
-	noNotify  bool
+	host        string
+	port        int
+	force       bool
+	tokenOnly   bool
+	codex       bool
+	noNotify    bool
+	autoRecover bool
 }
 
 func cmdConnect() {
@@ -530,14 +531,14 @@ func cmdConnect() {
            cc-clip connect <host> --token-only`)
 		os.Exit(2)
 	}
-	_ = autoRecover // consumed in T16 (N0 wiring)
 	runConnect(connectOpts{
-		host:      os.Args[2],
-		port:      getPort(),
-		force:     hasFlag("force"),
-		tokenOnly: tokenOnly,
-		codex:     hasFlag("codex"),
-		noNotify:  hasFlag("no-notify"),
+		host:        os.Args[2],
+		port:        getPort(),
+		force:       hasFlag("force"),
+		tokenOnly:   tokenOnly,
+		codex:       hasFlag("codex"),
+		noNotify:    hasFlag("no-notify"),
+		autoRecover: autoRecover,
 	})
 }
 
@@ -570,6 +571,44 @@ func runConnect(opts connectOpts) {
 	}
 	defer session.Close()
 	fmt.Println("      SSH master connected")
+
+	// N0: Pre-deploy v0.7.0 corruption detection. Runs before any other
+	// remote write (including --token-only token sync) so a corrupted remote
+	// either aborts cleanly or recovers in one step.
+	fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
+	corrupted, err := shim.DetectV070Corruption(session)
+	if err != nil {
+		log.Fatalf("      N0 detection failed: %v", err)
+	}
+	if corrupted {
+		if !opts.autoRecover {
+			fmt.Fprintf(os.Stderr, `
+error: detected v0.7.0 corruption on remote: ~/.local/bin/claude is a symlink
+       to a file that is now a cc-clip wrapper, with the real binary backed up
+       at ~/.local/bin/claude.cc-clip-bak.
+
+To recover, either re-run with --auto-recover:
+
+    cc-clip connect %s --auto-recover
+
+Or fix manually:
+
+    ssh %s 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+    cc-clip connect %s
+
+If ~/.local/bin/claude.cc-clip-bak is missing on the remote, reinstall Claude
+Code via 'curl https://claude.ai/install.sh' and re-run cc-clip connect.
+`, host, host, host)
+			os.Exit(3)
+		}
+		fmt.Println("      v0.7.0 corruption detected; running recovery...")
+		if err := shim.RecoverV070Corruption(session); err != nil {
+			log.Fatalf("      recovery failed: %v", err)
+		}
+		fmt.Println("      backup migrated to versions store; continuing install")
+	} else {
+		fmt.Println("      no corruption detected")
+	}
 
 	// --token-only: skip binary/shim, just sync token and verify tunnel
 	if tokenOnly {
@@ -1007,9 +1046,10 @@ func cmdSetup() {
 	// Step 4: Deploy to remote
 	fmt.Printf("\n[4/4] Deploying to %s...\n", host)
 	runConnect(connectOpts{
-		host:  host,
-		port:  port,
-		codex: hasFlag("codex"),
+		host:        host,
+		port:        port,
+		codex:       hasFlag("codex"),
+		autoRecover: hasFlag("auto-recover"),
 	})
 }
 

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -517,11 +517,25 @@ func cmdConnect() {
 	if len(os.Args) < 3 {
 		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify]")
 	}
+	autoRecover := hasFlag("auto-recover")
+	tokenOnly := hasFlag("token-only")
+	if autoRecover && tokenOnly {
+		fmt.Fprintln(os.Stderr, `error: --auto-recover cannot be combined with --token-only
+       --auto-recover performs recovery and full reinstall.
+       Re-run without --token-only:
+           cc-clip connect <host> --auto-recover
+       Or, if you only want to recover the binary without reinstalling the
+       wrapper, run the manual recovery and then cc-clip connect --token-only:
+           ssh <host> 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+           cc-clip connect <host> --token-only`)
+		os.Exit(2)
+	}
+	_ = autoRecover // consumed in T16 (N0 wiring)
 	runConnect(connectOpts{
 		host:      os.Args[2],
 		port:      getPort(),
 		force:     hasFlag("force"),
-		tokenOnly: hasFlag("token-only"),
+		tokenOnly: tokenOnly,
 		codex:     hasFlag("codex"),
 		noNotify:  hasFlag("no-notify"),
 	})

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -104,7 +104,7 @@ Remote:
     --target         auto|xclip|wl-paste (default: auto)
     --path           Install directory (default: ~/.local/bin)
   uninstall          Remove shim
-    --host           Also clean up PATH marker on remote host
+    --host           Also clean up remote: claude wrapper restore + PATH marker
   paste              Fetch clipboard image and output path
     --out-dir        Output directory (env: CC_CLIP_OUT_DIR)
   send [<host>] [<file>]
@@ -126,6 +126,7 @@ Remote:
 One-command setup:
   setup <host>       Full setup: deps, SSH config, daemon, deploy
     --port           Tunnel port (default: 18339)
+    --auto-recover   Recover from v0.7.0 wrapper corruption (mutex with --token-only)
 
 Known hosts (per-user registry):
   hosts list         Show hosts this machine has connected to (version, codex, last seen)
@@ -144,6 +145,7 @@ Deploy (local -> remote):
     --local-bin      Path to pre-downloaded remote binary
     --force          Ignore remote state, full redeploy
     --token-only     Only sync token, skip binary/shim deploy
+    --auto-recover   Recover from v0.7.0 wrapper corruption (mutex with --token-only)
 
 Codex support (extends connect/setup/uninstall):
   connect <host> --codex   Deploy with Codex support (Xvfb + x11-bridge)

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -397,12 +397,28 @@ func cmdUninstall() {
 	}
 
 	if err := shim.Uninstall(target, installPath); err != nil {
-		log.Fatalf("uninstall failed: %v", err)
+		if host == "" {
+			log.Fatalf("uninstall failed: %v", err)
+		}
+		fmt.Fprintf(os.Stderr, "warning: local shim uninstall failed (continuing because --host was set): %v\n", err)
+	} else {
+		fmt.Println("Shim removed successfully.")
 	}
 
-	fmt.Println("Shim removed successfully.")
-
 	if host != "" {
+		fmt.Printf("Restoring claude wrapper on remote %s...\n", host)
+		session, err := shim.NewSSHSession(host)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to open SSH session for wrapper restore: %v\n", err)
+		} else {
+			defer session.Close()
+			if err := shim.UninstallRemoteClaudeWrapper(session); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to restore claude wrapper: %v\n", err)
+			} else {
+				fmt.Println("      claude wrapper removed; original entry restored from sidecar")
+			}
+		}
+
 		fmt.Printf("Removing PATH marker from remote %s...\n", host)
 		if err := shim.RemoveRemotePath(host); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: failed to remove PATH marker: %v\n", err)

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -532,23 +532,36 @@ type connectOpts struct {
 	autoRecover bool
 }
 
+// rejectAutoRecoverWithTokenOnly enforces the spec-mandated mutual
+// exclusion between --auto-recover and --token-only at flag-parse time,
+// before any SSH activity. Shared by cmdConnect and cmdSetup so the
+// error message stays identical regardless of entrypoint.
+//
+// Returns silently when the combination is safe. Exits 2 with stderr
+// guidance when the flags conflict.
+func rejectAutoRecoverWithTokenOnly(cmdName string, autoRecover, tokenOnly bool) {
+	if !autoRecover || !tokenOnly {
+		return
+	}
+	fmt.Fprintf(os.Stderr, `error: --auto-recover cannot be combined with --token-only
+       --auto-recover performs recovery and full reinstall.
+       Re-run without --token-only:
+           cc-clip %s <host> --auto-recover
+       Or, if you only want to recover the binary without reinstalling the
+       wrapper, run the manual recovery and then cc-clip connect --token-only:
+           ssh <host> 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+           cc-clip connect <host> --token-only
+`, cmdName)
+	os.Exit(2)
+}
+
 func cmdConnect() {
 	if len(os.Args) < 3 {
 		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify]")
 	}
 	autoRecover := hasFlag("auto-recover")
 	tokenOnly := hasFlag("token-only")
-	if autoRecover && tokenOnly {
-		fmt.Fprintln(os.Stderr, `error: --auto-recover cannot be combined with --token-only
-       --auto-recover performs recovery and full reinstall.
-       Re-run without --token-only:
-           cc-clip connect <host> --auto-recover
-       Or, if you only want to recover the binary without reinstalling the
-       wrapper, run the manual recovery and then cc-clip connect --token-only:
-           ssh <host> 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
-           cc-clip connect <host> --token-only`)
-		os.Exit(2)
-	}
+	rejectAutoRecoverWithTokenOnly("connect", autoRecover, tokenOnly)
 	runConnect(connectOpts{
 		host:        os.Args[2],
 		port:        getPort(),
@@ -593,12 +606,20 @@ func runConnect(opts connectOpts) {
 	// N0: Pre-deploy v0.7.0 corruption detection. Runs before any other
 	// remote write (including --token-only token sync) so a corrupted remote
 	// either aborts cleanly or recovers in one step.
+	//
+	// Tri-state gate: NotCorrupted continues, Recoverable either aborts
+	// with a hint or auto-recovers depending on --auto-recover, and
+	// NonRecoverable always aborts (the real claude binary is lost; only
+	// the operator can fix it by reinstalling via curl https://claude.ai/install.sh).
 	fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
-	corrupted, err := shim.DetectV070Corruption(session)
+	state, diag, err := shim.DetectV070State(session)
 	if err != nil {
 		log.Fatalf("      N0 detection failed: %v", err)
 	}
-	if corrupted {
+	switch state {
+	case shim.V070NotCorrupted:
+		fmt.Printf("      no corruption detected (%s)\n", diag)
+	case shim.V070Recoverable:
 		if !opts.autoRecover {
 			fmt.Fprintf(os.Stderr, `
 error: detected v0.7.0 corruption on remote: ~/.local/bin/claude is a symlink
@@ -613,9 +634,6 @@ Or fix manually:
 
     ssh %s 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
     cc-clip connect %s
-
-If ~/.local/bin/claude.cc-clip-bak is missing on the remote, reinstall Claude
-Code via 'curl https://claude.ai/install.sh' and re-run cc-clip connect.
 `, host, host, host)
 			os.Exit(3)
 		}
@@ -624,8 +642,33 @@ Code via 'curl https://claude.ai/install.sh' and re-run cc-clip connect.
 			log.Fatalf("      recovery failed: %v", err)
 		}
 		fmt.Println("      backup migrated to versions store; continuing install")
-	} else {
-		fmt.Println("      no corruption detected")
+	case shim.V070NonRecoverable:
+		// Fail-closed: do NOT continue, even with --auto-recover. The
+		// recovery path requires a non-wrapper backup, which by definition
+		// does not exist in this state. Proceeding would layer a fresh
+		// wrapper on top of a half-broken Native Installer layout.
+		fmt.Fprintf(os.Stderr, `
+error: detected non-recoverable v0.7.0 corruption on remote (%s).
+       ~/.local/bin/claude is a symlink whose target is a cc-clip wrapper,
+       but the real-binary backup at ~/.local/bin/claude.cc-clip-bak is
+       missing, too small, or itself a wrapper — auto-recovery cannot
+       restore the original Claude Code binary.
+
+Manual recovery required:
+
+    1. Reinstall Claude Code on %s:
+
+       ssh %s 'curl -fsSL https://claude.ai/install.sh | bash'
+
+    2. After Claude Code is reinstalled, retry cc-clip:
+
+       cc-clip connect %s
+
+The --auto-recover flag does NOT help here because there is no usable
+backup to migrate. cc-clip will refuse to write any wrapper until the
+remote has a valid claude binary installed.
+`, diag, host, host, host)
+		os.Exit(3)
 	}
 
 	// --token-only: skip binary/shim, just sync token and verify tunnel
@@ -1008,6 +1051,13 @@ func cmdSetup() {
 	host := os.Args[2]
 	port := getPort()
 
+	// Reject conflicting flag combinations at parse time, before any
+	// dependency check or remote activity. Spec scenario 22 requires
+	// setup to fail-fast just like connect does.
+	autoRecover := hasFlag("auto-recover")
+	tokenOnly := hasFlag("token-only")
+	rejectAutoRecoverWithTokenOnly("setup", autoRecover, tokenOnly)
+
 	// Step 1: Dependencies
 	fmt.Println("[1/4] Checking local dependencies...")
 	if runtime.GOOS == "darwin" {
@@ -1067,7 +1117,7 @@ func cmdSetup() {
 		host:        host,
 		port:        port,
 		codex:       hasFlag("codex"),
-		autoRecover: hasFlag("auto-recover"),
+		autoRecover: autoRecover,
 	})
 }
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,8 +21,11 @@ Complete cc-clip command reference. For the 10 most common commands, see the [Co
 | `cc-clip connect <host>` | Deploy to remote (incremental) |
 | `cc-clip connect <host> --codex` | Deploy with Codex support (Xvfb + x11-bridge) |
 | `cc-clip connect <host> --token-only` | Sync token only (fast) |
+| `cc-clip connect <host> --auto-recover` | Recover from v0.7.0 wrapper corruption + reinstall (mutex with --token-only) |
+| `cc-clip setup <host> --auto-recover` | Same recovery flow via setup path |
 | `cc-clip connect <host> --force` | Full redeploy ignoring cache |
-| `cc-clip uninstall` | Remove xclip shim from remote |
+| `cc-clip uninstall` | Remove local xclip shim only |
+| `cc-clip uninstall --host <host>` | Remove from remote: claude wrapper, PATH marker (local shim best-effort) |
 | `cc-clip uninstall --codex` | Remove Codex support (local) |
 | `cc-clip uninstall --codex --host <host>` | Remove Codex support from remote |
 

--- a/docs/superpowers/plans/2026-05-07-issue-55-claude-wrapper-symlink-fix-plan.md
+++ b/docs/superpowers/plans/2026-05-07-issue-55-claude-wrapper-symlink-fix-plan.md
@@ -1,0 +1,2154 @@
+# Issue #55 Claude Wrapper Symlink-Safe Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `cc-clip setup`/`connect` install the claude wrapper without overwriting the real claude binary on Native Installer layouts (issue #55), with opt-in recovery for v0.7.0 victims via `--auto-recover`.
+
+**Architecture:** Approach B from spec — symlink-safe install topology using mv-only (never `cp`/`>` against possibly-symlink paths), explicit `~/.local/bin/claude.cc-clip-real` sidecar holding the original entry, sidecar-first wrapper exec with PATH-discovery fallback, plus default-fail-closed v0.7.0 corruption detection (5-condition check) and opt-in recovery via `--auto-recover` flag.
+
+**Tech Stack:** Go 1.22+, bash 4+ on remote, OpenSSH ControlMaster (Linux/macOS) or independent ssh (Windows), `go test` with `t.TempDir()`-based fakes, no new dependencies.
+
+**Spec:** [`docs/superpowers/specs/2026-05-07-issue-55-claude-wrapper-symlink-fix-design.md`](../specs/2026-05-07-issue-55-claude-wrapper-symlink-fix-design.md)
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `internal/shim/ssh.go` | Modify | Add `SessionExecutor` interface, `(*SSHSession).ExecWithStdin`, rewrite `InstallRemoteClaudeWrapper`, new functions `UninstallRemoteClaudeWrapper`, `DetectV070Corruption`, `RecoverV070Corruption`, helper `classifyClaudeBin` |
+| `internal/shim/claude_wrapper.go` | Modify | Update `claudeWrapperTemplate` to sidecar-first exec branch with PATH-fallback |
+| `internal/shim/deploy.go` | Modify | Add `ClaudeWrapperState` sub-struct + `ClaudeWrapper` field on `DeployState` |
+| `internal/shim/local_session_test.go` | Create | `localSession` test stub implementing `SessionExecutor` against `t.TempDir()` |
+| `internal/shim/claude_wrapper_install_test.go` | Create | All 22 spec test scenarios for install/uninstall/detect/recover/wrapper-exec |
+| `cmd/cc-clip/main.go` | Modify | Add `--auto-recover` flag with mutex check, insert N0 detection in `cmdConnect`/`cmdSetup` (between line 558 and 561), modify `cmdUninstall` for `--host` best-effort + wrapper restore wiring, update `printUsage` |
+| `docs/commands.md` | Modify | Document `--auto-recover` flag and new uninstall semantics |
+| `README.md` | Modify | One-line note about `--auto-recover` for v0.7.0 victims |
+
+---
+
+## Build Order Rationale
+
+Phase 1 (T1-T3): Test seam + data structures. No production behavior change. Lets every later task be unit-testable.
+
+Phase 2 (T4): Wrapper template. Independent of Layer 1 logic but required for Layer 1 sidecar-exec tests.
+
+Phase 3 (T5-T11): `InstallRemoteClaudeWrapper` rebuild from classify → branches → guards → atomic write + rollback. Each branch a separate task to keep failure modes isolated.
+
+Phase 4 (T12-T13): Detect + recover.
+
+Phase 5 (T14): Uninstall.
+
+Phase 6 (T15-T17): CLI wiring in main.go. Done last so all shim functions are already proven.
+
+Phase 7 (T18): Docs.
+
+Run `go test ./internal/shim -count=1 -race` after every task. Run `go vet ./...` before each commit.
+
+---
+
+## Task 1: SessionExecutor interface + ExecWithStdin method
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Test: `internal/shim/ssh_test.go` (add to existing file)
+
+**Why:** Without an interface, no install/uninstall function is unit-testable. This task introduces the seam.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/shim/ssh_test.go`:
+
+```go
+func TestSessionExecutorInterface_StaticConformance(t *testing.T) {
+    // Compile-time assertion: *SSHSession implements SessionExecutor.
+    var _ SessionExecutor = (*SSHSession)(nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestSessionExecutorInterface -count=1`
+Expected: compile error like `undefined: SessionExecutor`.
+
+- [ ] **Step 3: Add SessionExecutor interface to ssh.go**
+
+Add `"io"` to the imports of `internal/shim/ssh.go`. Then append (after the import block, before `type SSHSession`):
+
+```go
+// SessionExecutor abstracts a remote SSH session for install/uninstall/
+// detect/recover testing. *SSHSession satisfies this interface; tests use
+// a localSession stub that runs commands locally against a temp $HOME.
+type SessionExecutor interface {
+    // Exec runs a remote shell command and returns STDOUT only.
+    // Stderr is intentionally discarded to match the existing semantics of
+    // (*SSHSession).Exec — SSH multiplex chatter (control socket noise,
+    // mux_client_forward, etc.) lands on stderr and would otherwise pollute
+    // callers that grep the output for content markers.
+    Exec(cmd string) (stdout string, err error)
+
+    // ExecWithStdin runs a remote shell command with the provided stdin
+    // and returns COMBINED stdout+stderr. Combined output is appropriate
+    // here because this method is used during install/uninstall where
+    // stderr diagnostics (e.g. "mv: cannot create regular file: Permission
+    // denied") are required for actionable error messages.
+    ExecWithStdin(cmd string, stdin io.Reader) (combinedOutput string, err error)
+}
+```
+
+- [ ] **Step 4: Add ExecWithStdin method to *SSHSession**
+
+Append to `internal/shim/ssh.go` (after the existing `Upload` method):
+
+```go
+// ExecWithStdin runs a remote shell command with the provided stdin via
+// the SSH master connection. Returns combined stdout+stderr output for
+// install/uninstall error diagnostics.
+func (s *SSHSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+    args := append(s.connArgs(), s.host, cmd)
+    c := exec.Command("ssh", args...)
+    c.Stdin = stdin
+    out, err := c.CombinedOutput()
+    return string(out), err
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestSessionExecutorInterface -count=1`
+Expected: PASS.
+
+Run: `go vet ./...`
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/ssh_test.go
+git commit -m "refactor(shim): introduce SessionExecutor interface and ExecWithStdin"
+```
+
+---
+
+## Task 2: localSession test stub
+
+**Files:**
+- Create: `internal/shim/local_session_test.go`
+
+**Why:** All install/uninstall/detect/recover tests need a `SessionExecutor` impl that runs against `t.TempDir()` instead of a real SSH host.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/shim/local_session_test.go`:
+
+```go
+package shim
+
+import (
+    "io"
+    "os/exec"
+    "strings"
+    "testing"
+)
+
+// localSession is a SessionExecutor that runs commands locally via bash -c
+// against a configured $HOME (a t.TempDir() in tests). $HOME is set per
+// command so the bash `~` expansion lands in the fake home.
+type localSession struct {
+    home string
+}
+
+func (l *localSession) Exec(cmd string) (string, error) {
+    c := exec.Command("bash", "-c", cmd)
+    c.Env = append(c.Env, "HOME="+l.home, "PATH=/usr/bin:/bin")
+    out, err := c.Output() // stdout only, matches *SSHSession.Exec semantics
+    return strings.TrimSpace(string(out)), err
+}
+
+func (l *localSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+    c := exec.Command("bash", "-c", cmd)
+    c.Env = append(c.Env, "HOME="+l.home, "PATH=/usr/bin:/bin")
+    c.Stdin = stdin
+    out, err := c.CombinedOutput() // combined, matches *SSHSession.ExecWithStdin
+    return string(out), err
+}
+
+func TestLocalSession_ExecStdoutOnly(t *testing.T) {
+    s := &localSession{home: t.TempDir()}
+    out, err := s.Exec("echo out; echo err >&2")
+    if err != nil {
+        t.Fatalf("Exec failed: %v", err)
+    }
+    if out != "out" {
+        t.Fatalf("expected stdout %q, got %q (stderr should be discarded)", "out", out)
+    }
+}
+
+func TestLocalSession_ExecWithStdinCombined(t *testing.T) {
+    s := &localSession{home: t.TempDir()}
+    out, err := s.ExecWithStdin("echo out; echo err >&2", strings.NewReader(""))
+    if err != nil {
+        t.Fatalf("ExecWithStdin failed: %v", err)
+    }
+    if !strings.Contains(out, "out") || !strings.Contains(out, "err") {
+        t.Fatalf("expected combined output containing both 'out' and 'err', got %q", out)
+    }
+}
+
+func TestLocalSession_ImplementsSessionExecutor(t *testing.T) {
+    var _ SessionExecutor = (*localSession)(nil)
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestLocalSession -count=1 -v`
+Expected: 3 PASS lines.
+
+This locks Spec scenario 21 (test stub semantic alignment).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/shim/local_session_test.go
+git commit -m "test(shim): add localSession stub for SessionExecutor"
+```
+
+---
+
+## Task 3: DeployState ClaudeWrapper field
+
+**Files:**
+- Modify: `internal/shim/deploy.go`
+- Test: `internal/shim/deploy_test.go` (add to existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/shim/deploy_test.go` (add `"encoding/json"` and `"strings"` to imports if absent):
+
+```go
+func TestDeployState_ClaudeWrapperRoundtrip(t *testing.T) {
+    in := &DeployState{
+        BinaryHash:    "sha256:abc",
+        BinaryVersion: "v0.7.1-test",
+        ShimInstalled: true,
+        ShimTarget:    "xclip",
+        ClaudeWrapper: &ClaudeWrapperState{
+            Installed:    true,
+            OriginKind:   "symlink",
+            OriginTarget: "/home/u/.local/share/claude/versions/2.1.132",
+        },
+    }
+    data, err := json.Marshal(in)
+    if err != nil {
+        t.Fatalf("marshal: %v", err)
+    }
+    var out DeployState
+    if err := json.Unmarshal(data, &out); err != nil {
+        t.Fatalf("unmarshal: %v", err)
+    }
+    if out.ClaudeWrapper == nil {
+        t.Fatal("ClaudeWrapper missing after roundtrip")
+    }
+    if out.ClaudeWrapper.OriginKind != "symlink" {
+        t.Fatalf("OriginKind: got %q, want symlink", out.ClaudeWrapper.OriginKind)
+    }
+}
+
+func TestDeployState_ClaudeWrapperOmitemptyWhenNil(t *testing.T) {
+    in := &DeployState{BinaryHash: "x"}
+    data, err := json.Marshal(in)
+    if err != nil {
+        t.Fatalf("marshal: %v", err)
+    }
+    if strings.Contains(string(data), "claude_wrapper") {
+        t.Fatalf("nil ClaudeWrapper should be omitted, got: %s", data)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestDeployState_ClaudeWrapper -count=1`
+Expected: compile error — `undefined: ClaudeWrapperState`.
+
+- [ ] **Step 3: Add ClaudeWrapperState struct and field**
+
+Edit `internal/shim/deploy.go`. Add after the existing `NotifyDeployState` definition (around line 27):
+
+```go
+// ClaudeWrapperState records what InstallRemoteClaudeWrapper replaced at
+// ~/.local/bin/claude. Used by uninstall and future doctor commands; the
+// wrapper bash script itself does NOT read this — it only checks file
+// existence/executability of the sidecar.
+type ClaudeWrapperState struct {
+    Installed    bool   `json:"installed"`
+    OriginKind   string `json:"origin_kind"`             // "none" | "regular" | "symlink"
+    OriginTarget string `json:"origin_target,omitempty"` // resolved path when OriginKind=="symlink"
+}
+```
+
+Add field to `DeployState` struct (around line 31-39):
+
+```go
+type DeployState struct {
+    BinaryHash    string              `json:"binary_hash"`
+    BinaryVersion string              `json:"binary_version"`
+    ShimInstalled bool                `json:"shim_installed"`
+    ShimTarget    string              `json:"shim_target"`
+    PathFixed     bool                `json:"path_fixed"`
+    Notify        *NotifyDeployState  `json:"notify,omitempty"`
+    Codex         *CodexDeployState   `json:"codex,omitempty"`
+    ClaudeWrapper *ClaudeWrapperState `json:"claude_wrapper,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestDeployState -count=1 -v`
+Expected: PASS for all `TestDeployState_*` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/deploy.go internal/shim/deploy_test.go
+git commit -m "feat(shim): add ClaudeWrapperState to DeployState for diagnostics"
+```
+
+---
+
+## Task 4: Wrapper template — sidecar-first exec
+
+**Files:**
+- Modify: `internal/shim/claude_wrapper.go`
+- Test: `internal/shim/claude_wrapper_test.go` (add to existing)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/shim/claude_wrapper_test.go`:
+
+```go
+func TestClaudeWrapperScript_PrefersSidecar(t *testing.T) {
+    script := ClaudeWrapperScript(18339)
+    if !strings.Contains(script, "claude.cc-clip-real") {
+        t.Fatal("wrapper does not reference sidecar path")
+    }
+    // Sidecar branch must precede PATH-discovery fallback.
+    sidecarIdx := strings.Index(script, "claude.cc-clip-real")
+    pathDiscoveryIdx := strings.Index(script, "_PATH_DIRS")
+    if sidecarIdx == -1 || pathDiscoveryIdx == -1 {
+        t.Fatal("wrapper missing one of: sidecar branch, PATH-discovery fallback")
+    }
+    if sidecarIdx >= pathDiscoveryIdx {
+        t.Fatal("sidecar branch must precede PATH-discovery fallback")
+    }
+}
+
+func TestClaudeWrapperScript_KeepsPathFallback(t *testing.T) {
+    // PATH-discovery must remain for backward compat with legacy installs
+    // that have no sidecar.
+    script := ClaudeWrapperScript(18339)
+    if !strings.Contains(script, "_PATH_DIRS") || !strings.Contains(script, "_SELF_DIR") {
+        t.Fatal("wrapper missing PATH-discovery fallback")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestClaudeWrapperScript_PrefersSidecar -count=1`
+Expected: FAIL — `wrapper does not reference sidecar path`.
+
+- [ ] **Step 3: Update the wrapper template**
+
+Edit `internal/shim/claude_wrapper.go`. Replace `claudeWrapperTemplate` with:
+
+```go
+const claudeWrapperTemplate = `#!/usr/bin/env bash
+# cc-clip claude wrapper — auto-inject notification hooks
+# Installed by: cc-clip connect
+# Remove with:  cc-clip uninstall --host <this-host>
+
+# Find the real claude binary.
+# Priority 1: ~/.local/bin/claude.cc-clip-real (the sidecar set by install).
+# Priority 2: walk $PATH skipping our own directory (legacy install fallback).
+_REAL_CLAUDE=""
+_SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+_SIDECAR="$_SELF_DIR/claude.cc-clip-real"
+
+if [ -x "$_SIDECAR" ]; then
+    _REAL_CLAUDE="$_SIDECAR"
+else
+    IFS=: read -ra _PATH_DIRS <<< "$PATH"
+    for _dir in "${_PATH_DIRS[@]}"; do
+        [ "$_dir" = "$_SELF_DIR" ] && continue
+        [ -x "$_dir/claude" ] && _REAL_CLAUDE="$_dir/claude" && break
+    done
+fi
+
+if [ -z "$_REAL_CLAUDE" ]; then
+    echo "cc-clip: real claude binary not found (no sidecar at $_SIDECAR and no claude on PATH outside $_SELF_DIR)" >&2
+    exit 1
+fi
+
+# Only inject hooks if cc-clip tunnel is alive
+if curl -sf --connect-timeout 1 --max-time 2 "http://127.0.0.1:${CC_CLIP_PORT:-%d}/health" >/dev/null 2>&1; then
+    exec "$_REAL_CLAUDE" --settings '{
+  "hooks": {
+    "Stop": [{"type":"command","command":"cc-clip-hook"}],
+    "Notification": [{"type":"command","command":"cc-clip-hook"}]
+  }
+}' "$@"
+else
+    # Tunnel not available — run claude without hook injection
+    exec "$_REAL_CLAUDE" "$@"
+fi
+`
+```
+
+- [ ] **Step 4: Run all wrapper tests**
+
+Run: `go test ./internal/shim -run TestClaudeWrapperScript -count=1 -v`
+Expected: all PASS, including the new sidecar-first tests and any pre-existing port-substitution tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/claude_wrapper.go internal/shim/claude_wrapper_test.go
+git commit -m "feat(shim): wrapper exec sidecar-first with PATH-discovery fallback"
+```
+
+---
+
+## Task 5: classifyClaudeBin helper
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Create: `internal/shim/claude_wrapper_install_test.go`
+
+**Why:** Layer 1 install branches on classification. Centralizing detection lets us test all states once.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+package shim
+
+import (
+    "os"
+    "path/filepath"
+    "runtime"
+    "testing"
+)
+
+// setupFakeHome creates a t.TempDir() with .local/bin/ subdir and returns
+// the bin dir path. Tests use this as a fake remote $HOME root.
+func setupFakeHome(t *testing.T) (home, binDir string) {
+    t.Helper()
+    home = t.TempDir()
+    binDir = filepath.Join(home, ".local", "bin")
+    if err := os.MkdirAll(binDir, 0755); err != nil {
+        t.Fatalf("setup binDir: %v", err)
+    }
+    return home, binDir
+}
+
+func TestClassifyClaudeBin_None(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash not reliably available on Windows runner")
+    }
+    home, _ := setupFakeHome(t)
+    s := &localSession{home: home}
+    kind, err := classifyClaudeBin(s)
+    if err != nil {
+        t.Fatalf("classify: %v", err)
+    }
+    if kind != "none" {
+        t.Fatalf("got %q, want none", kind)
+    }
+}
+
+func TestClassifyClaudeBin_RegularNonWrapper(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash not reliably available on Windows runner")
+    }
+    home, binDir := setupFakeHome(t)
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("\x7fELF... fake"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+    kind, err := classifyClaudeBin(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if kind != "regular" {
+        t.Fatalf("got %q, want regular", kind)
+    }
+}
+
+func TestClassifyClaudeBin_CcWrapper(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash not reliably available on Windows runner")
+    }
+    home, binDir := setupFakeHome(t)
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+    kind, err := classifyClaudeBin(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if kind != "cc_wrapper" {
+        t.Fatalf("got %q, want cc_wrapper", kind)
+    }
+}
+
+func TestClassifyClaudeBin_Symlink(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    target := filepath.Join(home, ".local", "share", "claude", "versions", "2.1.132")
+    if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.WriteFile(target, []byte("\x7fELF... real binary content"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+    kind, err := classifyClaudeBin(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if kind != "symlink" {
+        t.Fatalf("got %q, want symlink", kind)
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestClassifyClaudeBin -count=1`
+Expected: compile error — `undefined: classifyClaudeBin`.
+
+- [ ] **Step 3: Implement classifyClaudeBin**
+
+Append to `internal/shim/ssh.go`:
+
+```go
+// classifyClaudeBin inspects ~/.local/bin/claude on the remote and returns
+// one of: "none", "cc_wrapper", "symlink", "regular", "other".
+//
+// "cc_wrapper" means a regular file whose first 256 bytes contain the
+// cc-clip wrapper marker — i.e. our previous install. Used to skip the
+// sidecar staging step on re-install (we just overwrite our own wrapper).
+//
+// Inspection is read-only; nothing is modified.
+func classifyClaudeBin(s SessionExecutor) (string, error) {
+    out, err := s.Exec(`p="$HOME/.local/bin/claude"
+if [ ! -e "$p" ] && [ ! -L "$p" ]; then echo none; exit 0; fi
+if [ -L "$p" ]; then echo symlink; exit 0; fi
+if [ -f "$p" ]; then
+    if head -c 256 "$p" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+        echo cc_wrapper
+    else
+        echo regular
+    fi
+    exit 0
+fi
+echo other`)
+    if err != nil {
+        return "", fmt.Errorf("classify ~/.local/bin/claude: %w", err)
+    }
+    return strings.TrimSpace(out), nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestClassifyClaudeBin -count=1 -v`
+Expected: 4 PASS lines (none, regular, cc_wrapper, symlink).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): classifyClaudeBin helper for install branch dispatch"
+```
+
+---
+
+## Task 6: InstallRemoteClaudeWrapper rewrite — `none` case (Spec scenario 3)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/shim/claude_wrapper_install_test.go` (add `"strings"` to imports if absent):
+
+```go
+func TestInstall_NoPriorInstall(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    s := &localSession{home: home}
+
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatalf("install: %v", err)
+    }
+
+    // Wrapper should now exist as a regular file at ~/.local/bin/claude.
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatalf("claude not installed: %v", err)
+    }
+    if info.Mode()&os.ModeSymlink != 0 {
+        t.Fatal("claude should be a regular file, got symlink")
+    }
+    if info.Mode().Perm()&0111 == 0 {
+        t.Fatal("claude should be executable")
+    }
+
+    // No sidecar should have been created (no origin to displace).
+    if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+        t.Fatalf("sidecar should not exist on first install of 'none' case, got: %v", err)
+    }
+
+    // Content must be the wrapper script.
+    data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(string(data), "# cc-clip claude wrapper") {
+        t.Fatal("installed file is not the cc-clip wrapper")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestInstall_NoPriorInstall -count=1`
+Expected: FAIL — the existing `InstallRemoteClaudeWrapper` takes `*SSHSession`, not `SessionExecutor`. Compile error.
+
+- [ ] **Step 3: Rewrite InstallRemoteClaudeWrapper signature + minimal implementation**
+
+Replace the existing `InstallRemoteClaudeWrapper` in `internal/shim/ssh.go` (line 263-279) with:
+
+```go
+// InstallRemoteClaudeWrapper installs the claude wrapper to ~/.local/bin/claude
+// on the remote, using a symlink-safe topology that never overwrites the real
+// claude binary even when ~/.local/bin/claude is a symlink to a versions store
+// (Anthropic Native Installer layout).
+//
+// Topology:
+//   - The original entry (regular file or symlink) is renamed to
+//     ~/.local/bin/claude.cc-clip-real.
+//   - The wrapper script is written via mktemp + chmod + atomic mv.
+//   - On re-install over an existing cc-clip wrapper, the wrapper file is
+//     replaced atomically; the existing sidecar is left untouched.
+func InstallRemoteClaudeWrapper(s SessionExecutor, port int) error {
+    kind, err := classifyClaudeBin(s)
+    if err != nil {
+        return fmt.Errorf("install: classify failed: %w", err)
+    }
+    switch kind {
+    case "none":
+        return installWrapperNoOrigin(s, port)
+    default:
+        return fmt.Errorf("install: unsupported origin kind %q (more branches added in later tasks)", kind)
+    }
+}
+
+// installWrapperNoOrigin writes the wrapper to a fresh ~/.local/bin/claude
+// when no prior file exists. No sidecar is created.
+func installWrapperNoOrigin(s SessionExecutor, port int) error {
+    script := ClaudeWrapperScript(port)
+    cmd := `mkdir -p "$HOME/.local/bin" && \
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX") && \
+cat > "$tmp" && \
+chmod +x "$tmp" && \
+mv "$tmp" "$HOME/.local/bin/claude"`
+    out, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+    if err != nil {
+        return fmt.Errorf("install (none): %s: %w", strings.TrimSpace(out), err)
+    }
+    return nil
+}
+```
+
+The existing call site in `cmd/cc-clip/main.go:813` continues to compile because `*SSHSession` satisfies `SessionExecutor`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_NoPriorInstall -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the rest of the package still compiles**
+
+Run: `go build ./...`
+Expected: no errors.
+
+Run: `go test ./internal/shim -count=1`
+Expected: pre-existing tests still pass; only the partially-implemented branches will fail with the explicit "unsupported origin kind" error in tests we haven't written yet.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): rewrite InstallRemoteClaudeWrapper with classify-dispatch (none branch)"
+```
+
+---
+
+## Task 7: Install — regular file branch (Spec scenario 2)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestInstall_RegularFileOrigin(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    originalContent := []byte("\x7fELF... pretend this is the real 250MB claude binary")
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), originalContent, 0755); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatalf("install: %v", err)
+    }
+
+    // Sidecar must hold the original (verbatim).
+    sidecar, err := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-real"))
+    if err != nil {
+        t.Fatalf("sidecar missing: %v", err)
+    }
+    if string(sidecar) != string(originalContent) {
+        t.Fatal("sidecar does not contain original content (mv may have leaked or content was rewritten)")
+    }
+
+    // claude must now be the wrapper.
+    data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(string(data), "# cc-clip claude wrapper") {
+        t.Fatal("claude is not the cc-clip wrapper after install")
+    }
+
+    // claude must be a regular file (not a symlink).
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if info.Mode()&os.ModeSymlink != 0 {
+        t.Fatal("claude should be a regular file after install")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestInstall_RegularFileOrigin -count=1`
+Expected: FAIL — `unsupported origin kind "regular"`.
+
+- [ ] **Step 3: Add regular branch**
+
+In `internal/shim/ssh.go`, extend the `switch kind` in `InstallRemoteClaudeWrapper`:
+
+```go
+    switch kind {
+    case "none":
+        return installWrapperNoOrigin(s, port)
+    case "regular", "symlink":
+        return installWrapperWithSidecar(s, port)
+    default:
+        return fmt.Errorf("install: unsupported origin kind %q", kind)
+    }
+```
+
+Add the new function:
+
+```go
+// installWrapperWithSidecar handles the regular and symlink origin kinds:
+// stage the origin to ~/.local/bin/claude.cc-clip-real, then commit the
+// wrapper. Uses prepare-then-commit ordering so failures before the final
+// mv leave the user's claude untouched, and failures after staging trigger
+// a best-effort rollback.
+func installWrapperWithSidecar(s SessionExecutor, port int) error {
+    script := ClaudeWrapperScript(port)
+    // Pre-flight: refuse if sidecar already exists (we don't know if it's
+    // stale or load-bearing). User can `rm` it and re-run.
+    out, _ := s.Exec(`if test -e "$HOME/.local/bin/claude.cc-clip-real" || test -L "$HOME/.local/bin/claude.cc-clip-real"; then echo conflict; fi`)
+    if strings.TrimSpace(out) == "conflict" {
+        return fmt.Errorf("install: ~/.local/bin/claude.cc-clip-real already exists; remove it manually and re-run")
+    }
+
+    cmd := `set -e
+mkdir -p "$HOME/.local/bin"
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp"
+chmod +x "$tmp"
+# Stage origin to sidecar (mv on a symlink renames the link itself,
+# never reads/writes through it).
+mv "$HOME/.local/bin/claude" "$HOME/.local/bin/claude.cc-clip-real"
+# Commit wrapper.
+if ! mv "$tmp" "$HOME/.local/bin/claude"; then
+    # Best-effort rollback: restore origin so user's claude keeps working.
+    mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude" 2>/dev/null || true
+    exit 1
+fi
+trap - EXIT  # tmp now consumed by the mv`
+    outErr, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+    if err != nil {
+        return fmt.Errorf("install (with-sidecar): %s: %w", strings.TrimSpace(outErr), err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_RegularFileOrigin -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run all install tests**
+
+Run: `go test ./internal/shim -run TestInstall_ -count=1 -v`
+Expected: existing none + new regular both PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): install regular-file origin via mv-only sidecar staging"
+```
+
+---
+
+## Task 8: Install — symlink branch (Spec scenario 1, the issue #55 regression test)
+
+**Files:**
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+The `installWrapperWithSidecar` from Task 7 already handles symlink because `mv` on a symlink renames the link itself. We just need a test to lock that behavior and explicitly assert the issue #55 regression is closed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+
+    // Build Native Installer layout:
+    //   ~/.local/bin/claude -> ~/.local/share/claude/versions/2.1.132
+    //   ~/.local/share/claude/versions/2.1.132 = real binary (5MB random)
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    realBinary := make([]byte, 5*1024*1024)
+    for i := range realBinary {
+        realBinary[i] = byte(i % 251) // pseudo-random; large enough to be distinguishable
+    }
+    if err := os.WriteFile(target, realBinary, 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+
+    // Snapshot the real binary content before install.
+    pre, err := os.ReadFile(target)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatalf("install: %v", err)
+    }
+
+    // CRITICAL: real binary in versions store must be byte-identical to before.
+    post, err := os.ReadFile(target)
+    if err != nil {
+        t.Fatalf("real binary disappeared: %v", err)
+    }
+    if string(pre) != string(post) {
+        t.Fatal("REGRESSION: real claude binary was modified during install (issue #55 root bug)")
+    }
+
+    // Sidecar must be the symlink itself, still pointing at versions/2.1.132.
+    sidecar := filepath.Join(binDir, "claude.cc-clip-real")
+    info, err := os.Lstat(sidecar)
+    if err != nil {
+        t.Fatalf("sidecar missing: %v", err)
+    }
+    if info.Mode()&os.ModeSymlink == 0 {
+        t.Fatal("sidecar should be a symlink (origin was a symlink)")
+    }
+    resolved, err := os.Readlink(sidecar)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if resolved != target {
+        t.Fatalf("sidecar target: got %q, want %q", resolved, target)
+    }
+
+    // Wrapper must be a regular file.
+    wrapperInfo, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if wrapperInfo.Mode()&os.ModeSymlink != 0 {
+        t.Fatal("claude should be a regular file after install (the wrapper)")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_SymlinkOrigin -count=1 -v`
+Expected: PASS (the implementation in Task 7 already supports this).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/shim/claude_wrapper_install_test.go
+git commit -m "test(shim): lock issue #55 regression — symlink install does not corrupt target"
+```
+
+---
+
+## Task 9: Install — cc_wrapper re-install branch (Spec scenario 4)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestInstall_ReinstallOverCcWrapper(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+
+    // Existing cc-clip wrapper at claude (port 18339).
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+        t.Fatal(err)
+    }
+    // Existing sidecar from prior install.
+    sidecarContent := []byte("PRIOR-SIDECAR-CONTENT")
+    if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-real"), sidecarContent, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    if err := InstallRemoteClaudeWrapper(s, 19999); err != nil {
+        t.Fatalf("re-install: %v", err)
+    }
+
+    // Wrapper must be updated (port baked in is 19999 now).
+    data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !strings.Contains(string(data), "19999") {
+        t.Fatal("wrapper port was not updated")
+    }
+    if strings.Contains(string(data), "18339") {
+        t.Fatal("wrapper still contains old port")
+    }
+
+    // Sidecar must be untouched (we don't displace re-install over our own wrapper).
+    sidecarPost, err := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-real"))
+    if err != nil {
+        t.Fatalf("sidecar missing after re-install: %v", err)
+    }
+    if string(sidecarPost) != string(sidecarContent) {
+        t.Fatal("sidecar was modified during re-install (must be untouched)")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestInstall_ReinstallOverCcWrapper -count=1`
+Expected: FAIL — `unsupported origin kind "cc_wrapper"`.
+
+- [ ] **Step 3: Add cc_wrapper branch**
+
+Edit `internal/shim/ssh.go`. Update the switch:
+
+```go
+    switch kind {
+    case "none":
+        return installWrapperNoOrigin(s, port)
+    case "cc_wrapper":
+        return installWrapperOverwriteSelf(s, port)
+    case "regular", "symlink":
+        return installWrapperWithSidecar(s, port)
+    default:
+        return fmt.Errorf("install: unsupported origin kind %q", kind)
+    }
+```
+
+Add new function:
+
+```go
+// installWrapperOverwriteSelf replaces our own previous wrapper at
+// ~/.local/bin/claude via mktemp + atomic mv. The sidecar is left untouched
+// because we already own the claude path (it's our wrapper, not user state).
+func installWrapperOverwriteSelf(s SessionExecutor, port int) error {
+    script := ClaudeWrapperScript(port)
+    cmd := `set -e
+mkdir -p "$HOME/.local/bin"
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp"
+chmod +x "$tmp"
+mv "$tmp" "$HOME/.local/bin/claude"
+trap - EXIT`
+    out, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+    if err != nil {
+        return fmt.Errorf("install (cc_wrapper overwrite): %s: %w", strings.TrimSpace(out), err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_ReinstallOverCcWrapper -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): atomic re-install over existing cc-clip wrapper"
+```
+
+---
+
+## Task 10: Install — sidecar collision guard (Spec scenarios 18, 19)
+
+**Files:**
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+The collision guard pre-flight is already in `installWrapperWithSidecar`. This task adds tests to lock the behavior.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestInstall_SidecarCollision_RegularFile(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+
+    // Native installer layout (symlink origin).
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    if err := os.WriteFile(target, []byte("real binary"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+
+    // Stale sidecar from a prior half-install.
+    sidecar := filepath.Join(binDir, "claude.cc-clip-real")
+    if err := os.WriteFile(sidecar, []byte("STALE"), 0644); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    err := InstallRemoteClaudeWrapper(s, 18339)
+    if err == nil {
+        t.Fatal("expected install to refuse with collision; got nil")
+    }
+    if !strings.Contains(err.Error(), "claude.cc-clip-real already exists") {
+        t.Fatalf("unexpected error: %v", err)
+    }
+
+    // Origin must be untouched.
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if info.Mode()&os.ModeSymlink == 0 {
+        t.Fatal("origin symlink was disturbed despite collision refusal")
+    }
+}
+
+func TestInstall_SidecarCollision_Directory(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    // Sidecar PATH is a directory — would have been the silent-corruption footgun.
+    sidecarDir := filepath.Join(binDir, "claude.cc-clip-real")
+    if err := os.Mkdir(sidecarDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    err := InstallRemoteClaudeWrapper(s, 18339)
+    if err == nil {
+        t.Fatal("expected install to refuse on directory at sidecar path")
+    }
+    // CRITICAL: origin must NOT have been moved into the directory.
+    if _, statErr := os.Stat(filepath.Join(sidecarDir, "claude")); statErr == nil {
+        t.Fatal("FOOTGUN: claude was moved into the directory; collision guard failed")
+    }
+    // Origin must still be at the original location.
+    if _, err := os.Lstat(filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal("origin claude is missing; collision guard failed to short-circuit")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `go test ./internal/shim -run TestInstall_SidecarCollision -count=1 -v`
+Expected: both PASS (the guard already exists in Task 7 implementation).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/shim/claude_wrapper_install_test.go
+git commit -m "test(shim): lock sidecar collision guard for regular and directory paths"
+```
+
+---
+
+## Task 11: Install — staging mv failure rollback + mktemp guard (Spec scenarios 16, 17)
+
+**Files:**
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+The mktemp + rollback logic is already in Task 7's `installWrapperWithSidecar`. This task adds verification tests.
+
+- [ ] **Step 1: Write the rollback test**
+
+Append to `internal/shim/claude_wrapper_install_test.go` (add `"io"` to imports if absent):
+
+```go
+// rollbackInjectingSession wraps localSession and rewrites the install
+// command to force the final mv to fail, simulating a filesystem error
+// after the staging mv has already moved origin to the sidecar.
+type rollbackInjectingSession struct {
+    *localSession
+    binDir   string
+    injected bool
+}
+
+func (r *rollbackInjectingSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+    if !r.injected && strings.Contains(cmd, "claude.cc-clip-real") {
+        r.injected = true
+        // Replace the final mv guard with a forced failure so the rollback
+        // branch (mv sidecar back to claude) is exercised.
+        cmd = strings.Replace(cmd,
+            `if ! mv "$tmp" "$HOME/.local/bin/claude"; then`,
+            `if ! false; then`, 1)
+    }
+    return r.localSession.ExecWithStdin(cmd, stdin)
+}
+
+func TestInstall_RollbackOnFinalMvFailure(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    originalContent := []byte("ORIGINAL-CLAUDE-BINARY-MUST-BE-RESTORED")
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), originalContent, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &rollbackInjectingSession{localSession: &localSession{home: home}, binDir: binDir}
+    err := InstallRemoteClaudeWrapper(s, 18339)
+    if err == nil {
+        t.Fatal("expected install to fail (we injected final-mv failure)")
+    }
+
+    // Origin must be restored at ~/.local/bin/claude.
+    restored, err := os.ReadFile(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatalf("origin not restored: %v", err)
+    }
+    if string(restored) != string(originalContent) {
+        t.Fatal("origin content corrupted; rollback failed")
+    }
+
+    // Sidecar must NOT exist after rollback.
+    if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+        t.Fatal("sidecar lingered after rollback")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_RollbackOnFinalMvFailure -count=1 -v`
+Expected: PASS (rollback logic is in Task 7's implementation).
+
+- [ ] **Step 3: Write mktemp anti-symlink-follow test**
+
+Append:
+
+```go
+func TestInstall_MktempDoesNotFollowSymlinks(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular origin"), 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    // Plant a sensitive file outside binDir; install must not touch it.
+    // mktemp uses XXXXXX (random suffix), so collision probability is ~1/(62^6).
+    // This test confirms install succeeds and the sensitive file is unchanged,
+    // verifying mktemp is in use rather than a predictable name like $$.
+    sensitive := filepath.Join(home, "sensitive-file.txt")
+    if err := os.WriteFile(sensitive, []byte("DO NOT TOUCH"), 0644); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatalf("install: %v", err)
+    }
+
+    // Sensitive file must be unchanged.
+    pre, _ := os.ReadFile(sensitive)
+    if string(pre) != "DO NOT TOUCH" {
+        t.Fatal("sensitive file was modified — mktemp may not be in use")
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim -run TestInstall_MktempDoesNotFollowSymlinks -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/claude_wrapper_install_test.go
+git commit -m "test(shim): lock install rollback on final-mv failure and mktemp safety"
+```
+
+---
+
+## Task 12: DetectV070Corruption (Spec scenarios 10, 12, 13, 14, 15)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+// makeV070Corruption sets up the exact filesystem state issue #55 describes:
+// symlink at ~/.local/bin/claude points at versions/X.Y.Z, that file is now
+// a cc-clip wrapper, and ~/.local/bin/claude.cc-clip-bak holds the real binary.
+func makeV070Corruption(t *testing.T, home string) {
+    t.Helper()
+    binDir := filepath.Join(home, ".local", "bin")
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    // versions/X.Y.Z is a cc-clip wrapper (the bug).
+    if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+        t.Fatal(err)
+    }
+    // claude is the symlink, untouched.
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+    // .cc-clip-bak holds the original 5MB ELF.
+    realBinary := make([]byte, 5*1024*1024)
+    for i := range realBinary {
+        realBinary[i] = byte(i % 251)
+    }
+    if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), realBinary, 0755); err != nil {
+        t.Fatal(err)
+    }
+}
+
+func TestDetectV070_CorruptedState(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, _ := setupFakeHome(t)
+    makeV070Corruption(t, home)
+
+    s := &localSession{home: home}
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        t.Fatalf("detect: %v", err)
+    }
+    if !corrupted {
+        t.Fatal("expected corrupted=true on canonical v0.7.0 state")
+    }
+}
+
+func TestDetectV070_NotSymlinkOrigin(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    // Even with a .cc-clip-bak, C1 fails (not symlink).
+    if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), make([]byte, 5*1024*1024), 0755); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if corrupted {
+        t.Fatal("expected corrupted=false when origin is regular file (C1 must fail)")
+    }
+}
+
+func TestDetectV070_BackupMissing(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+    // No .cc-clip-bak.
+    s := &localSession{home: home}
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if corrupted {
+        t.Fatal("expected corrupted=false when backup is missing (C3 must fail)")
+    }
+}
+
+func TestDetectV070_BackupIsAlsoWrapper(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+    // Backup is also a wrapper. Pad to >1MB so C4 passes.
+    bakContent := append([]byte(ClaudeWrapperScript(18339)), make([]byte, 2*1024*1024)...)
+    if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), bakContent, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if corrupted {
+        t.Fatal("expected corrupted=false when backup itself is a wrapper (C5 must fail)")
+    }
+}
+
+func TestDetectV070_SymlinkTargetNotWrapper(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    if err := os.WriteFile(target, []byte("\x7fELF... regular real binary"), 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+    s := &localSession{home: home}
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if corrupted {
+        t.Fatal("expected corrupted=false when symlink target is a real binary (C2 must fail)")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/shim -run TestDetectV070 -count=1`
+Expected: compile error — `undefined: DetectV070Corruption`.
+
+- [ ] **Step 3: Implement DetectV070Corruption**
+
+Append to `internal/shim/ssh.go`:
+
+```go
+// DetectV070Corruption returns true when the remote exhibits the exact
+// filesystem state produced by v0.7.0's buggy InstallRemoteClaudeWrapper:
+//
+//   C1: ~/.local/bin/claude is a symlink.
+//   C2: The symlink target's first 256 bytes contain the cc-clip wrapper marker.
+//   C3: ~/.local/bin/claude.cc-clip-bak exists as a regular file.
+//   C4: That backup is larger than 1 MiB.
+//   C5: That backup is NOT itself a cc-clip wrapper (guards against a double-
+//       install pathology where both target and backup are wrappers).
+//
+// All five conditions must be true to return corrupted=true. The check is
+// strictly read-only — nothing is modified.
+func DetectV070Corruption(s SessionExecutor) (bool, error) {
+    out, err := s.Exec(`set -e
+claude="$HOME/.local/bin/claude"
+bak="$HOME/.local/bin/claude.cc-clip-bak"
+# C1: claude is a symlink.
+[ -L "$claude" ] || { echo notcorrupted; exit 0; }
+# C2: target contains wrapper marker.
+target=$(readlink -f "$claude") || { echo notcorrupted; exit 0; }
+[ -f "$target" ] || { echo notcorrupted; exit 0; }
+head -c 256 "$target" 2>/dev/null | grep -qF "# cc-clip claude wrapper" || { echo notcorrupted; exit 0; }
+# C3: backup is a regular file.
+[ -f "$bak" ] || { echo notcorrupted; exit 0; }
+# C4: backup > 1 MiB.
+size=$(wc -c < "$bak" | tr -d ' ')
+[ "$size" -gt 1048576 ] || { echo notcorrupted; exit 0; }
+# C5: backup is NOT a wrapper.
+if head -c 256 "$bak" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+    echo notcorrupted
+    exit 0
+fi
+echo corrupted`)
+    if err != nil {
+        return false, fmt.Errorf("detect v0.7.0 corruption: %w", err)
+    }
+    return strings.TrimSpace(out) == "corrupted", nil
+}
+```
+
+- [ ] **Step 4: Run all detection tests**
+
+Run: `go test ./internal/shim -run TestDetectV070 -count=1 -v`
+Expected: 5 PASS lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): DetectV070Corruption with five-condition gate"
+```
+
+---
+
+## Task 13: RecoverV070Corruption (Spec scenario 11)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestRecoverV070_HappyPath(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    makeV070Corruption(t, home)
+
+    target := filepath.Join(home, ".local", "share", "claude", "versions", "2.1.132")
+    bakBefore, _ := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-bak"))
+
+    s := &localSession{home: home}
+    if err := RecoverV070Corruption(s); err != nil {
+        t.Fatalf("recover: %v", err)
+    }
+
+    // After recovery: target file content == backup content (real binary restored).
+    targetAfter, err := os.ReadFile(target)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if string(targetAfter) != string(bakBefore) {
+        t.Fatal("target content does not match backup; recovery failed")
+    }
+
+    // Backup file must be gone (mv consumed it).
+    if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-bak")); !os.IsNotExist(err) {
+        t.Fatal("backup file lingered after recovery")
+    }
+
+    // Symlink must still exist and still point at target.
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if info.Mode()&os.ModeSymlink == 0 {
+        t.Fatal("claude is no longer a symlink after recovery")
+    }
+}
+
+func TestRecoverV070_RefusesIfNotCorrupted(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    err := RecoverV070Corruption(s)
+    if err == nil {
+        t.Fatal("expected recovery to refuse when no corruption is detected")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim -run TestRecoverV070 -count=1`
+Expected: compile error — `undefined: RecoverV070Corruption`.
+
+- [ ] **Step 3: Implement RecoverV070Corruption**
+
+Append to `internal/shim/ssh.go`:
+
+```go
+// RecoverV070Corruption migrates the v0.7.0 backup file (which contains the
+// real claude binary) back to the symlink's target path, restoring the
+// original Native Installer layout. After this call, the caller is expected
+// to re-run InstallRemoteClaudeWrapper to install a v0.7.1+ wrapper safely.
+//
+// This function re-verifies all five corruption conditions inside the same
+// SSH session before doing anything destructive (TOCTOU guard).
+func RecoverV070Corruption(s SessionExecutor) error {
+    corrupted, err := DetectV070Corruption(s)
+    if err != nil {
+        return fmt.Errorf("recover: re-detection failed: %w", err)
+    }
+    if !corrupted {
+        return fmt.Errorf("recover: corruption no longer detected; refusing to migrate backup")
+    }
+    out, err := s.Exec(`set -e
+target=$(readlink -f "$HOME/.local/bin/claude")
+mv "$HOME/.local/bin/claude.cc-clip-bak" "$target"`)
+    if err != nil {
+        return fmt.Errorf("recover: migrate backup: %s: %w", strings.TrimSpace(out), err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run all recovery tests**
+
+Run: `go test ./internal/shim -run TestRecoverV070 -count=1 -v`
+Expected: 2 PASS.
+
+- [ ] **Step 5: Run full install + detect + recover suite**
+
+Run: `go test ./internal/shim -count=1 -race`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): RecoverV070Corruption migrates backup to symlink target"
+```
+
+---
+
+## Task 14: UninstallRemoteClaudeWrapper (Spec scenarios 7, 8, 9)
+
+**Files:**
+- Modify: `internal/shim/ssh.go`
+- Modify: `internal/shim/claude_wrapper_install_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/shim/claude_wrapper_install_test.go`:
+
+```go
+func TestUninstall_SymlinkOrigin(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("symlink semantics differ on Windows")
+    }
+    home, binDir := setupFakeHome(t)
+    versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+    if err := os.MkdirAll(versionsDir, 0755); err != nil {
+        t.Fatal(err)
+    }
+    target := filepath.Join(versionsDir, "2.1.132")
+    realBinary := []byte("real claude binary content, ~5MB pretend")
+    if err := os.WriteFile(target, realBinary, 0755); err != nil {
+        t.Fatal(err)
+    }
+    if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatalf("install: %v", err)
+    }
+    if err := UninstallRemoteClaudeWrapper(s); err != nil {
+        t.Fatalf("uninstall: %v", err)
+    }
+
+    // claude must be a symlink again, pointing at the original target.
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if info.Mode()&os.ModeSymlink == 0 {
+        t.Fatal("claude is not a symlink after uninstall")
+    }
+    resolved, err := os.Readlink(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if resolved != target {
+        t.Fatalf("symlink target: got %q, want %q", resolved, target)
+    }
+    // Real binary intact (was never touched).
+    pre, _ := os.ReadFile(target)
+    if string(pre) != string(realBinary) {
+        t.Fatal("real binary corrupted")
+    }
+    // Sidecar must be gone.
+    if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+        t.Fatal("sidecar lingered after uninstall")
+    }
+}
+
+func TestUninstall_RegularFileOrigin(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    original := []byte("ORIGINAL")
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), original, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+        t.Fatal(err)
+    }
+    if err := UninstallRemoteClaudeWrapper(s); err != nil {
+        t.Fatal(err)
+    }
+
+    // claude must be the original regular file again.
+    info, err := os.Lstat(filepath.Join(binDir, "claude"))
+    if err != nil {
+        t.Fatal(err)
+    }
+    if info.Mode()&os.ModeSymlink != 0 {
+        t.Fatal("claude is a symlink after uninstall (should be regular)")
+    }
+    data, _ := os.ReadFile(filepath.Join(binDir, "claude"))
+    if string(data) != string(original) {
+        t.Fatal("origin content not restored")
+    }
+}
+
+func TestUninstall_RefusesForeignFile(t *testing.T) {
+    if runtime.GOOS == "windows" {
+        t.Skip("bash-based install path is Linux-only")
+    }
+    home, binDir := setupFakeHome(t)
+    foreign := []byte("#!/bin/bash\n# user's own custom claude wrapper, not ours\n")
+    if err := os.WriteFile(filepath.Join(binDir, "claude"), foreign, 0755); err != nil {
+        t.Fatal(err)
+    }
+
+    s := &localSession{home: home}
+    err := UninstallRemoteClaudeWrapper(s)
+    if err == nil {
+        t.Fatal("expected uninstall to refuse foreign file")
+    }
+    if !strings.Contains(err.Error(), "not a cc-clip wrapper") {
+        t.Fatalf("unexpected uninstall error: %v", err)
+    }
+    // Foreign file must be untouched.
+    data, _ := os.ReadFile(filepath.Join(binDir, "claude"))
+    if string(data) != string(foreign) {
+        t.Fatal("foreign file was modified")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/shim -run TestUninstall_ -count=1`
+Expected: compile error — `undefined: UninstallRemoteClaudeWrapper`.
+
+- [ ] **Step 3: Implement UninstallRemoteClaudeWrapper**
+
+Append to `internal/shim/ssh.go`:
+
+```go
+// UninstallRemoteClaudeWrapper removes the cc-clip claude wrapper from
+// ~/.local/bin/claude and restores the origin from ~/.local/bin/claude.cc-clip-real.
+//
+// Safety: refuses if ~/.local/bin/claude is not a cc-clip wrapper (i.e. the
+// user replaced it with their own file). In that case, returns an error
+// without touching anything.
+//
+// If a v0.7.0-era ~/.local/bin/claude.cc-clip-bak file exists, it is left
+// in place — recovery of that backup is the user's call (see
+// RecoverV070Corruption + --auto-recover).
+func UninstallRemoteClaudeWrapper(s SessionExecutor) error {
+    // Verify file at claude is a cc-clip wrapper (and exists).
+    out, err := s.Exec(`p="$HOME/.local/bin/claude"
+if [ ! -e "$p" ] && [ ! -L "$p" ]; then echo absent; exit 0; fi
+if [ -L "$p" ] || [ ! -f "$p" ]; then echo notwrapper; exit 0; fi
+if head -c 256 "$p" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+    echo wrapper
+else
+    echo notwrapper
+fi`)
+    if err != nil {
+        return fmt.Errorf("uninstall: classify failed: %w", err)
+    }
+    switch strings.TrimSpace(out) {
+    case "absent":
+        return nil
+    case "notwrapper":
+        return fmt.Errorf("uninstall: ~/.local/bin/claude is not a cc-clip wrapper; refusing to remove")
+    case "wrapper":
+        // proceed
+    default:
+        return fmt.Errorf("uninstall: unexpected classify output %q", strings.TrimSpace(out))
+    }
+
+    // Remove wrapper, restore origin from sidecar if present.
+    cmd := `set -e
+rm "$HOME/.local/bin/claude"
+if [ -e "$HOME/.local/bin/claude.cc-clip-real" ] || [ -L "$HOME/.local/bin/claude.cc-clip-real" ]; then
+    mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude"
+fi`
+    outErr, err := s.Exec(cmd)
+    if err != nil {
+        return fmt.Errorf("uninstall: %s: %w", strings.TrimSpace(outErr), err)
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Run uninstall tests**
+
+Run: `go test ./internal/shim -run TestUninstall_ -count=1 -v`
+Expected: 3 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/shim/ssh.go internal/shim/claude_wrapper_install_test.go
+git commit -m "feat(shim): UninstallRemoteClaudeWrapper restores origin via sidecar"
+```
+
+---
+
+## Task 15: CLI — `--auto-recover` flag + mutex check (Spec scenario 22)
+
+**Files:**
+- Modify: `cmd/cc-clip/main.go`
+- Create: `cmd/cc-clip/cli_flag_test.go`
+
+- [ ] **Step 1: Locate flag-parsing entry points**
+
+Run: `grep -n 'tokenOnly\|getFlag\|hasFlag' cmd/cc-clip/main.go | head -20`
+Expected: shows lines where `--token-only` and `--codex` are read in `cmdConnect`/`cmdSetup`.
+
+- [ ] **Step 2: Add `--auto-recover` flag read + mutex check**
+
+In `cmdConnect`, immediately after the existing `tokenOnly := hasFlag("token-only")` line and BEFORE any SSH setup or `connectVerifyTunnel` call (i.e. before line 552 where SSH session setup begins), insert:
+
+```go
+    autoRecover := hasFlag("auto-recover")
+    if autoRecover && tokenOnly {
+        fmt.Fprintln(os.Stderr, `error: --auto-recover cannot be combined with --token-only
+       --auto-recover performs recovery and full reinstall.
+       Re-run without --token-only:
+           cc-clip connect <host> --auto-recover
+       Or, if you only want to recover the binary without reinstalling the
+       wrapper, run the manual recovery and then cc-clip connect --token-only:
+           ssh <host> 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+           cc-clip connect <host> --token-only`)
+        os.Exit(2)
+    }
+    _ = autoRecover // consumed in Task 16 (N0 wiring)
+```
+
+Mirror the same block at the equivalent location in `cmdSetup`. (If `cmdSetup` delegates to `cmdConnect`, the block lives only at the entry point that's reached first.)
+
+- [ ] **Step 3: Add an automated test for the mutex**
+
+Create `cmd/cc-clip/cli_flag_test.go`:
+
+```go
+package main
+
+import (
+    "bytes"
+    "os/exec"
+    "strings"
+    "testing"
+)
+
+func TestCLIMutex_AutoRecoverWithTokenOnly(t *testing.T) {
+    cmd := exec.Command("go", "run", ".", "connect", "fakehost.invalid", "--auto-recover", "--token-only")
+    var stderr bytes.Buffer
+    cmd.Stderr = &stderr
+    err := cmd.Run()
+    if err == nil {
+        t.Fatal("expected non-zero exit on flag conflict")
+    }
+    if !strings.Contains(stderr.String(), "--auto-recover cannot be combined with --token-only") {
+        t.Fatalf("missing mutex error in stderr: %s", stderr.String())
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./cmd/cc-clip -run TestCLIMutex -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cc-clip/main.go cmd/cc-clip/cli_flag_test.go
+git commit -m "feat(cli): --auto-recover flag with --token-only mutex"
+```
+
+---
+
+## Task 16: CLI — N0 detection wiring in cmdConnect/cmdSetup (Spec scenarios 10, 11, 20)
+
+**Files:**
+- Modify: `cmd/cc-clip/main.go`
+
+- [ ] **Step 1: Insert N0 step between SSH session and --token-only branch**
+
+In `cmdConnect`, right after line 558 (`fmt.Println("      SSH master connected")`) and before line 561 (`if tokenOnly {`), insert:
+
+```go
+    // N0: Pre-deploy v0.7.0 corruption detection. Runs before any other
+    // remote write (including --token-only token sync) so a corrupted remote
+    // either aborts cleanly or recovers in one step.
+    fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
+    corrupted, err := shim.DetectV070Corruption(session)
+    if err != nil {
+        log.Fatalf("      N0 detection failed: %v", err)
+    }
+    if corrupted {
+        if !autoRecover {
+            fmt.Fprintf(os.Stderr, `
+error: detected v0.7.0 corruption on remote: ~/.local/bin/claude is a symlink
+       to a file that is now a cc-clip wrapper, with the real binary backed up
+       at ~/.local/bin/claude.cc-clip-bak.
+
+To recover, either re-run with --auto-recover:
+
+    cc-clip connect %s --auto-recover
+
+Or fix manually:
+
+    ssh %s 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+    cc-clip connect %s
+
+If ~/.local/bin/claude.cc-clip-bak is missing on the remote, reinstall Claude
+Code via 'curl https://claude.ai/install.sh' and re-run cc-clip connect.
+`, host, host, host)
+            os.Exit(3)
+        }
+        fmt.Println("      v0.7.0 corruption detected; running recovery...")
+        if err := shim.RecoverV070Corruption(session); err != nil {
+            log.Fatalf("      recovery failed: %v", err)
+        }
+        fmt.Println("      backup migrated to versions store; continuing install")
+    } else {
+        fmt.Println("      no corruption detected")
+    }
+```
+
+Replace the earlier `_ = autoRecover` placeholder line from Task 15 (the variable is now used).
+
+Apply the same block at the equivalent position in `cmdSetup` if it has its own SSH session setup. If `cmdSetup` delegates to `cmdConnect`, the block lives only once.
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 3: Note on testing**
+
+End-to-end testing of `cmdConnect` requires a real or mocked SSH layer. Layer 3 logic (`DetectV070Corruption` + `RecoverV070Corruption`) is unit-tested in tasks 12-13; this step is purely wiring. Manual smoke per spec §5 covers the integrated path.
+
+- [ ] **Step 4: Run full test suite to confirm no regressions**
+
+Run: `go test ./... -count=1 -race`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cc-clip/main.go
+git commit -m "feat(cli): N0 v0.7.0 corruption detection in cmdConnect/cmdSetup
+
+Inserts detection between SSH session establishment and the --token-only
+branch so all deploy paths share fail-closed semantics. Unit tests for
+DetectV070Corruption and RecoverV070Corruption cover the logic; CLI wiring
+verified via manual smoke per spec section 5."
+```
+
+---
+
+## Task 17: CLI — cmdUninstall --host best-effort + wrapper restore (Spec scenarios 7, 8, 9 wiring)
+
+**Files:**
+- Modify: `cmd/cc-clip/main.go`
+
+- [ ] **Step 1: Modify the local-uninstall block to be best-effort when --host is set**
+
+In `cmd/cc-clip/main.go:399-403`, replace:
+
+```go
+    if err := shim.Uninstall(target, installPath); err != nil {
+        log.Fatalf("uninstall failed: %v", err)
+    }
+
+    fmt.Println("Shim removed successfully.")
+```
+
+With:
+
+```go
+    if err := shim.Uninstall(target, installPath); err != nil {
+        if host == "" {
+            log.Fatalf("uninstall failed: %v", err)
+        }
+        fmt.Fprintf(os.Stderr, "warning: local shim uninstall failed (continuing because --host was set): %v\n", err)
+    } else {
+        fmt.Println("Shim removed successfully.")
+    }
+```
+
+- [ ] **Step 2: Add wrapper restore step inside the `--host` branch**
+
+In the `if host != ""` block (currently line 405-412), insert wrapper restore BEFORE the existing PATH marker cleanup:
+
+```go
+    if host != "" {
+        fmt.Printf("Restoring claude wrapper on remote %s...\n", host)
+        session, err := shim.NewSSHSession(host)
+        if err != nil {
+            fmt.Fprintf(os.Stderr, "warning: failed to open SSH session for wrapper restore: %v\n", err)
+        } else {
+            defer session.Close()
+            if err := shim.UninstallRemoteClaudeWrapper(session); err != nil {
+                fmt.Fprintf(os.Stderr, "warning: failed to restore claude wrapper: %v\n", err)
+            } else {
+                fmt.Println("      claude wrapper removed; original entry restored from sidecar")
+            }
+        }
+
+        fmt.Printf("Removing PATH marker from remote %s...\n", host)
+        if err := shim.RemoveRemotePath(host); err != nil {
+            fmt.Fprintf(os.Stderr, "warning: failed to remove PATH marker: %v\n", err)
+        } else {
+            fmt.Println("PATH marker removed from remote shell rc file.")
+        }
+    }
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/cc-clip/main.go
+git commit -m "feat(cli): cmdUninstall --host best-effort local + remote wrapper restore"
+```
+
+---
+
+## Task 18: Docs — printUsage + commands.md + README
+
+**Files:**
+- Modify: `cmd/cc-clip/main.go` (printUsage)
+- Modify: `docs/commands.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Update printUsage**
+
+In `cmd/cc-clip/main.go` around line 99-152, locate the `setup` and `connect` flag documentation. Add `--auto-recover` to both sections so users discover it at `cc-clip --help`:
+
+```
+  setup <host> [--codex] [--token-only] [--auto-recover]
+  connect <host> [--codex] [--token-only] [--auto-recover]
+
+Flags:
+  --auto-recover   Recover from v0.7.0 wrapper corruption (cannot combine with --token-only)
+```
+
+Update the `uninstall --host` doc line:
+
+```
+  uninstall --host <host>   Remove cc-clip from remote: claude wrapper, PATH marker, hook script
+```
+
+- [ ] **Step 2: Update docs/commands.md**
+
+Open `docs/commands.md`. For the `setup` and `connect` rows, add an `--auto-recover` row underneath each:
+
+```markdown
+| `--auto-recover` | Recover from v0.7.0 claude wrapper corruption (mutually exclusive with `--token-only`). |
+```
+
+Add a new section after install/setup commands titled "Symlink-safe install" with one paragraph: "cc-clip's claude wrapper at `~/.local/bin/claude` preserves the original entry by renaming it to `~/.local/bin/claude.cc-clip-real` (the sidecar). The wrapper exec's the sidecar first, falling back to PATH discovery for backward compatibility. See `docs/superpowers/specs/2026-05-07-issue-55-claude-wrapper-symlink-fix-design.md` for full background."
+
+- [ ] **Step 3: Update README.md**
+
+Locate the FAQ / Q&A section in README.md (around line 149). Add one Q&A entry:
+
+```markdown
+**Q: I see `cc-clip: real claude binary not found in PATH` after running cc-clip v0.7.0. What now?**
+
+A: Run `cc-clip setup <host> --auto-recover` (or `cc-clip connect <host> --auto-recover`). It detects the v0.7.0 corruption and migrates your real claude binary back into place before installing the (fixed) wrapper.
+```
+
+- [ ] **Step 4: Verify nothing else broke**
+
+Run: `go test ./... -count=1 -race`
+Expected: all PASS.
+
+Run: `go vet ./...`
+Expected: no output.
+
+Run: `make build`
+Expected: success.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/cc-clip/main.go docs/commands.md README.md
+git commit -m "docs: --auto-recover flag and uninstall --host wrapper restore semantics"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the full test suite**
+
+```bash
+go test ./... -count=1 -race
+go vet ./...
+make build
+```
+
+Expected: all tests pass, vet clean, binary builds.
+
+- [ ] **Optional: manual smoke (per spec §5)**
+
+If a Linux VM with Anthropic Native Installer is available:
+
+1. `cc-clip setup <host>` against a fresh Native Installer install. Verify symlink intact, real binary intact, `claude --version` works.
+2. `cc-clip uninstall --host <host>`. Verify symlink restored, real binary intact.
+3. Construct v0.7.0 corruption by hand on a second VM. `cc-clip setup <host>` → expect abort. `cc-clip setup <host> --auto-recover` → expect clean install + working `claude`.
+
+- [ ] **Optional: ready for PR**
+
+```bash
+git log --oneline 2e81fa9..HEAD
+```
+
+Expected: ~18 commits forming the implementation. Push and open a PR referencing issue #55.
+
+---
+
+## Self-Review Checklist (run before handing off)
+
+- [x] Spec coverage: every test scenario 1-22 maps to a task. (1, 2, 3 → T6, T7, T8; 4 → T9; 5, 6 → T4; 7, 8, 9 → T14; 10, 12, 13, 14, 15 → T12; 11 → T13; 16, 17 → T11; 18, 19 → T10; 20 → T16; 21 → T2; 22 → T15.)
+- [x] Placeholder scan: no "TBD"; every code block has real Go/bash content.
+- [x] Type consistency: `SessionExecutor`, `ClaudeWrapperState`, `InstallRemoteClaudeWrapper(s SessionExecutor, port int) error`, `UninstallRemoteClaudeWrapper(s SessionExecutor) error`, `DetectV070Corruption(s SessionExecutor) (bool, error)`, `RecoverV070Corruption(s SessionExecutor) error`, `classifyClaudeBin(s SessionExecutor) (string, error)` — used consistently across all tasks.
+- [x] Build order respects dependencies: T1 (interface) → T2 (stub) → T3 (data) → T4 (template) → T5 (classify) → T6-T11 (install branches) → T12 (detect) → T13 (recover) → T14 (uninstall) → T15-T17 (CLI) → T18 (docs).
+- [x] Each task has explicit Run / Expected pairs for tests.
+- [x] All commits use Conventional Commits prefix (feat/fix/refactor/test/docs).

--- a/docs/superpowers/specs/2026-05-07-issue-55-claude-wrapper-symlink-fix-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-55-claude-wrapper-symlink-fix-design.md
@@ -1,0 +1,529 @@
+# Issue #55 — Claude Wrapper Symlink-Safe Install Fix
+
+**Date:** 2026-05-07
+**Issue:** [#55](https://github.com/ShunmeiCho/cc-clip/issues/55) — Setup overwrites claude binary at symlink target instead of replacing the symlink
+**Affected version:** v0.7.0
+**Target release:** v0.7.1
+
+---
+
+## 1. Problem
+
+### 1.1 Reported symptom
+
+On remotes where Claude Code is installed via Anthropic's official Native Installer (`curl https://claude.ai/install.sh`), the layout is:
+
+```
+~/.local/bin/claude                       -> ~/.local/share/claude/versions/X.Y.Z   (symlink)
+~/.local/share/claude/versions/X.Y.Z      (250MB ELF binary, the real claude)
+```
+
+After `cc-clip setup myhost` (or `cc-clip connect myhost`) completes:
+
+```
+~/.local/bin/claude                       -> ~/.local/share/claude/versions/X.Y.Z   (symlink unchanged)
+~/.local/share/claude/versions/X.Y.Z      (1017-byte cc-clip wrapper bash script)   ← CORRUPTED
+~/.local/bin/claude.cc-clip-bak           (the original 250MB binary)
+```
+
+Subsequent `claude` invocation:
+
+```
+$ claude --resume
+cc-clip: real claude binary not found in PATH
+```
+
+### 1.2 Root cause — two symlink-follow defects in `InstallRemoteClaudeWrapper`
+
+Code reference: `internal/shim/ssh.go:263-278`.
+
+| Step | Command on remote | Behavior on a symlink |
+|---|---|---|
+| 1. Detect existing wrapper | `head -5 ~/.local/bin/claude` | Follows symlink → reads first 5 lines of 250MB ELF (binary garbage). String `cc-clip claude wrapper` is absent → "needs backup" branch is taken. |
+| 2. Backup | `cp ~/.local/bin/claude ~/.local/bin/claude.cc-clip-bak` | `cp` without `-d`/`-P` follows the symlink at the source, so the 250MB binary content is copied into `claude.cc-clip-bak`. |
+| 3. **Write wrapper (CRITICAL)** | `cat > ~/.local/bin/claude` | Shell `>` is `open(O_WRONLY\|O_CREAT\|O_TRUNC)` — it **follows the symlink** and truncates/writes to `~/.local/share/claude/versions/X.Y.Z`. Wrapper script (1017 bytes) lands inside the versions store, overwriting the real binary. |
+| 4. Permissions | `chmod +x ~/.local/bin/claude` | Follows symlink (no-op; the file was already +x). |
+
+### 1.3 Why the wrapper's PATH-discovery fallback fails
+
+`internal/shim/claude_wrapper.go:14-17` iterates `$PATH` looking for `claude` and skips its own directory. Under Native Installer layout there is **no second `claude`** elsewhere on PATH — `~/.local/bin` is the only entry that holds it. The wrapper exits 1 with "real claude binary not found in PATH".
+
+### 1.4 Blast radius
+
+- **Severity:** HIGH. Silently corrupts a 250MB user-owned binary.
+- **Affected users:** Every cc-clip user whose remote uses Anthropic's recommended Native Installer (the most common path).
+- **Detectability:** None at install time. Only surfaces when the user runs `claude` after `cc-clip setup`.
+- **Recoverability:** Manual `mv` of the backup; documented as the issue's workaround.
+- **Compounding risk:** Anthropic's installer self-update may `ln -sf ~/.local/bin/claude → versions/X.Y.Z+1`, replacing whatever lives at `~/.local/bin/claude`. **Any** wrapper-at-symlink-path strategy must accept "user re-runs `cc-clip setup` after Claude Code upgrade" as the recovery contract; this is unavoidable and orthogonal to the bug being fixed here.
+
+---
+
+## 2. Solution overview — Approach B (symlink-safe with explicit sidecar + opt-in v0.7.0 recovery)
+
+The fix has six layers, applied together: install topology, wrapper exec topology, corruption detection + recovery, symmetric uninstall, DeployState integration, and a test seam for unit-testability.
+
+### Layer 1 — Symlink-safe install topology
+
+Replace the install sequence in `InstallRemoteClaudeWrapper` with a state-aware flow that uses **`mv` only** (never `cp`/`>` against a path that may be a symlink):
+
+```text
+Install algorithm (prepare-then-commit, with rollback)
+──────────────────────────────────────────────────────
+1.  Classify ~/.local/bin/claude (read-only inspection, no writes):
+      - none        : path does not exist
+      - cc_wrapper  : test -f && ! test -L, AND head -c 256 contains
+                      "# cc-clip claude wrapper" (the marker)
+      - symlink     : test -L returns 0
+      - regular     : test -f returns 0, ! test -L, and not cc_wrapper
+      - other       : refuse to install (e.g. directory, device, socket)
+
+2.  Prepare wrapper tmp file FIRST (before touching the origin):
+      a. mkdir -p ~/.local/bin
+      b. tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
+         WHY mktemp: it uses O_CREAT|O_EXCL with a random suffix, so it
+         CANNOT follow a pre-existing symlink — even if an attacker or a
+         botched prior install left a symlink at any predictable tmp path,
+         mktemp would fail rather than write through. Predictable names
+         like ".cc-clip-tmp.$$" do NOT have this guarantee.
+         WHY leading dot: hides the tmp from `which claude` PATH-discovery
+         during the brief window it lives next to the real claude.
+      c. cat > "$tmp"                  (safe: $tmp is a fresh regular file
+                                        with no symlink semantics possible)
+      d. chmod +x "$tmp"
+
+      On any failure in steps 2a-d:
+          rm -f "$tmp"; return error.
+          The origin is still in place; no user-visible change.
+
+3.  Stage origin and commit wrapper, branch by classification:
+
+      Case "none":
+        mv "$tmp" ~/.local/bin/claude
+        # No sidecar to create.
+
+      Case "cc_wrapper" (re-install over our own previous wrapper):
+        mv "$tmp" ~/.local/bin/claude
+        # Existing sidecar (if any) is left untouched.
+
+      Case "symlink" or "regular":
+        # Pre-flight: sidecar collision guard.
+        # If ~/.local/bin/claude.cc-clip-real already exists, we don't know whether
+        # it is stale state from a prior cc-clip install (e.g. user manually
+        # removed the wrapper but left the sidecar) or genuinely-needed state.
+        # Refuse rather than overwrite — user can `rm` the sidecar and re-run.
+        # Critically: if it's a directory, `mv claude .cc-clip-real` would move
+        # claude INTO the directory rather than rename to it, silently breaking
+        # wrapper exec. Refusing here avoids that footgun.
+        if test -e ~/.local/bin/claude.cc-clip-real || test -L ~/.local/bin/claude.cc-clip-real; then
+            rm -f "$tmp"
+            return error with diagnostic explaining the conflict and suggesting
+            `rm ~/.local/bin/claude.cc-clip-real` to proceed.
+        fi
+
+        # Stage origin to sidecar:
+        if ! mv ~/.local/bin/claude ~/.local/bin/claude.cc-clip-real; then
+            # Origin was never moved. Just clean up tmp and exit.
+            rm -f "$tmp"
+            return error (origin unchanged; user's claude still works).
+        fi
+
+        # Commit wrapper:
+        if ! mv "$tmp" ~/.local/bin/claude; then
+            # Best-effort rollback to leave user with working claude:
+            mv ~/.local/bin/claude.cc-clip-real ~/.local/bin/claude
+            rm -f "$tmp"
+            return error
+        fi
+        # On success: origin lives at sidecar, wrapper lives at claude.
+
+      Case "other":
+        rm -f "$tmp"
+        return error with diagnostic.
+
+Hard invariants enforced by this ordering:
+  - `cat >` is only ever applied to a freshly-created mktemp regular file.
+    It is NEVER applied to a path that may be a user-owned symlink.
+  - The window during which `~/.local/bin/claude` is missing is bounded to
+    one mv between staging the origin and committing the wrapper.
+  - On failure inside the symlink/regular branch AFTER staging, rollback
+    restores the origin so the user's `claude` keeps working — even if
+    cc-clip wrapper installation did not succeed.
+  - On failure BEFORE staging (steps 2a-d), the origin was never touched.
+```
+
+Key invariant: **`>` redirection is only ever applied to a freshly-created mktemp regular file or to a path we have just verified is a cc-clip-owned regular file (cc_wrapper re-install). It is NEVER applied to a path that might be a user symlink, and the tmp path is never predictable.**
+
+### Layer 2 — Wrapper exec topology (sidecar-first)
+
+Update `claudeWrapperTemplate` so the bash wrapper resolves the real claude binary in this priority:
+
+```text
+1. If `~/.local/bin/claude.cc-clip-real` is executable (regular file or working symlink):
+       _REAL_CLAUDE=~/.local/bin/claude.cc-clip-real
+2. Else fall back to current PATH-discovery (skip self_dir, walk $PATH):
+       _REAL_CLAUDE=$(first claude on PATH outside self_dir)
+3. Else exit 1 with diagnostic.
+```
+
+The fallback preserves backward compatibility for users who installed under earlier cc-clip versions where there is no sidecar. Wrapper still does **not** parse JSON or read deploy state — it only checks file existence/executability.
+
+### Layer 3 — v0.7.0 corruption: detect, default fail-closed, opt-in recovery
+
+`setup` and `connect` invoke a new `DetectV070Corruption(session)` step **immediately after SSH session establishment, before any other remote write** (we call this step **N0**). Concretely: it runs after `EnsureSession`/SSH master setup but before binary upload (`cmd/cc-clip/main.go` ~line 570), shim install (~line 660), token sync, hook script install, and wrapper install (line 811-824).
+
+The reason for placing detection at N0: the corruption recovery default is **fail closed**. Running detection at N4 (the wrapper-install step) would leave a half-deployed remote on abort: binary uploaded, xclip shim installed, hook script installed, but wrapper aborted. Placing it at N0 guarantees that **fail-closed leaves zero new state on the remote** — the existing v0.7.0 corruption is also untouched. On `--auto-recover`, recovery runs at N0, then the normal deploy flow proceeds end-to-end without any awkward mid-flow branch.
+
+The detection requires **all five** conditions to be true to flag a remote as "v0.7.0 corrupted":
+
+```text
+C1. test -L ~/.local/bin/claude                     (claude is a symlink)
+C2. resolved = $(readlink -f ~/.local/bin/claude)
+    head -c 256 "$resolved" | grep -q "# cc-clip claude wrapper"
+                                                    (symlink target IS a cc-clip wrapper)
+C3. test -f ~/.local/bin/claude.cc-clip-bak         (backup exists, regular file)
+C4. size of claude.cc-clip-bak > 1048576 (1 MiB)    (backup is plausibly a real binary)
+C5. ! head -c 256 ~/.local/bin/claude.cc-clip-bak | grep -qF "# cc-clip claude wrapper"
+                                                    (backup is NOT itself a wrapper —
+                                                     guards against double-install corruption.
+
+                                                     IMPORTANT: use `! ... | grep -qF MARKER`
+                                                     to negate the entire search. `grep -qv`
+                                                     is WRONG here: even a real wrapper has
+                                                     lines (e.g. the shebang) that do not
+                                                     contain the marker, so `grep -qv MARKER`
+                                                     would exit 0 and falsely pass C5,
+                                                     allowing --auto-recover to mv a wrapper
+                                                     back into the versions store.)
+```
+
+#### Default behavior (no `--auto-recover` flag)
+
+- Print a diagnostic block listing C1..C5 with check/cross marks per condition.
+- Print a copy-paste recovery command and exit non-zero **before** writing any new wrapper or sidecar:
+
+  ```bash
+  mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"
+  cc-clip setup <host>      # then re-run setup
+  ```
+
+- Wrapper install does NOT proceed. The user is explicitly choosing what to do with their Claude binary.
+
+#### `--auto-recover` flag behavior
+
+When the user passes `--auto-recover` to `setup` or `connect`:
+
+1. Re-verify all five conditions (recheck inside the same SSH session — guard against TOCTOU).
+2. Execute on remote, in order:
+   ```bash
+   target=$(readlink -f ~/.local/bin/claude) && \
+   mv ~/.local/bin/claude.cc-clip-bak "$target"
+   ```
+3. Proceed into Layer-1 symlink-safe install (which will then `mv` the symlink itself to `.cc-clip-real` and write a fresh wrapper).
+
+If any of C1..C5 fails, `--auto-recover` does **not** silently install a new wrapper. It aborts with a diagnostic explaining which condition failed and recommends manual recovery (or, for irrecoverable cases like missing backup, recommends reinstalling Claude Code).
+
+#### Flag combination: `--auto-recover` × `--token-only` is mutually exclusive
+
+`--auto-recover` is contractually "recovery + reinstall in one step" (per §6 release notes and §7 decisions log). `--token-only` is contractually "skip binary/shim/wrapper install, just sync the token". These two modes **conflict**: passing both leaves an undefined third mode where backup is migrated but no wrapper is reinstalled — the remote ends up with a working `claude` binary but no notification hooks, with no clear reason for the user to know they're in this state.
+
+Behavior: when both `--auto-recover` and `--token-only` are passed, `setup`/`connect` fail fast at flag-parse time (before SSH session setup, before N0 detection) with:
+
+```
+error: --auto-recover cannot be combined with --token-only
+       --auto-recover performs recovery and full reinstall.
+       Re-run without --token-only:
+           cc-clip setup <host> --auto-recover
+       Or, if you only want to recover the binary without reinstalling the
+       wrapper, run the manual recovery and then `cc-clip setup --token-only`:
+           ssh <host> 'mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"'
+           cc-clip setup <host> --token-only
+```
+
+Exit code: non-zero (e.g. exit 2 for usage errors, matching Go convention).
+
+### Layer 4 — Symmetric uninstall
+
+New function `UninstallRemoteClaudeWrapper(session)`:
+
+```text
+1. If ~/.local/bin/claude does not exist: nothing to do.
+2. If it is NOT a cc-clip wrapper (head -c 256 lacks the marker): refuse.
+   Print a warning. The user has a foreign file there; we won't touch it.
+3. If it IS a cc-clip wrapper:
+   a. rm ~/.local/bin/claude
+   b. If ~/.local/bin/claude.cc-clip-real exists:
+        mv ~/.local/bin/claude.cc-clip-real ~/.local/bin/claude
+      (This restores the original symlink or regular file as it was before install.)
+   c. If ~/.local/bin/claude.cc-clip-bak exists from a v0.7.0 install:
+        Print informational note about the legacy backup; do NOT auto-move it.
+        (The user's real binary is at the symlink target now if recovery happened;
+         if it didn't, the user has a manual decision to make.)
+```
+
+Wired into the existing `cmdUninstall --host <host>` branch in `cmd/cc-clip/main.go:371-413`.
+
+CLI surface decision: we extend the existing `cc-clip uninstall --host <host>` flag to also remove the wrapper and restore origin. We do NOT introduce a new positional `cc-clip uninstall <host>` form in v0.7.1 — that would be a CLI-surface expansion beyond the bug fix. Existing semantics of `cc-clip uninstall` (local-only) and `cc-clip uninstall --codex` are unchanged. Only the `--host <host>` branch gains the wrapper-restore step.
+
+#### Required fix to existing cmdUninstall control flow
+
+The current implementation at `cmd/cc-clip/main.go:399` calls `shim.Uninstall(...)` and `log.Fatalf` on error **before** entering the `--host` branch at line 405. This means `cc-clip uninstall --host <host>` on a machine where the local shim is absent (e.g. uninstalled previously, or never installed because the user only used cc-clip from another box) will fatal **before** any remote cleanup runs. Remote wrapper restore would never trigger.
+
+Fix: when `--host != ""`, downgrade the local uninstall from fatal to best-effort. Concretely, replace lines 399-403:
+
+```go
+// Before (current):
+if err := shim.Uninstall(target, installPath); err != nil {
+    log.Fatalf("uninstall failed: %v", err)
+}
+fmt.Println("Shim removed successfully.")
+
+// After:
+if err := shim.Uninstall(target, installPath); err != nil {
+    if host == "" {
+        log.Fatalf("uninstall failed: %v", err)
+    }
+    fmt.Fprintf(os.Stderr, "warning: local shim uninstall failed (continuing because --host was set): %v\n", err)
+} else {
+    fmt.Println("Shim removed successfully.")
+}
+```
+
+Then in the `--host` branch (line 405-412), add the wrapper restore step before the existing PATH marker cleanup:
+
+```go
+if host != "" {
+    fmt.Printf("Restoring claude wrapper on remote %s...\n", host)
+    session, err := shim.NewSSHSession(host)
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "warning: failed to open SSH session for wrapper restore: %v\n", err)
+    } else {
+        defer session.Close()
+        if err := shim.UninstallRemoteClaudeWrapper(session); err != nil {
+            fmt.Fprintf(os.Stderr, "warning: failed to restore claude wrapper: %v\n", err)
+        }
+    }
+    // Existing PATH marker cleanup follows.
+    fmt.Printf("Removing PATH marker from remote %s...\n", host)
+    // ... (unchanged)
+}
+```
+
+Net behavioral change:
+- `cc-clip uninstall` (no `--host`): unchanged — still fatal on local error.
+- `cc-clip uninstall --host <host>`: local error becomes a warning; remote wrapper restore + PATH marker cleanup always run.
+
+### Layer 5 — DeployState integration
+
+Extend `internal/shim/deploy.go:DeployState` with a new sub-struct:
+
+```go
+type ClaudeWrapperState struct {
+    Installed    bool   `json:"installed"`
+    OriginKind   string `json:"origin_kind"`   // "none" | "regular" | "symlink"
+    OriginTarget string `json:"origin_target,omitempty"` // resolved path when OriginKind=="symlink"
+}
+
+type DeployState struct {
+    // ... existing fields ...
+    ClaudeWrapper *ClaudeWrapperState `json:"claude_wrapper,omitempty"`
+}
+```
+
+Synthetic example of the new field on disk:
+
+```json
+{
+  "claude_wrapper": {
+    "installed": true,
+    "origin_kind": "symlink",
+    "origin_target": "~/.local/share/claude/versions/X.Y.Z"
+  }
+}
+```
+
+Used by:
+- `setup`/`connect` to record what the wrapper replaced (for diagnostics + future doctor command).
+- `uninstall` informational output (e.g. "this wrapper originally replaced a symlink → versions/X.Y.Z").
+- **Wrapper runtime does NOT read this file.** Wrapper only does file-existence checks (per Layer 2 hard rule).
+
+### Layer 6 — Test seam (SessionExecutor interface)
+
+`*SSHSession` is currently a concrete struct in `internal/shim/ssh.go`, so functions taking `*SSHSession` cannot be unit-tested with a stub against a temp `$HOME` directory. We introduce a small interface in `internal/shim/`:
+
+```go
+// SessionExecutor abstracts a remote SSH session for the purpose of
+// install/uninstall/detect/recover testing. *SSHSession satisfies this
+// interface; tests use a localSession stub that runs commands locally.
+type SessionExecutor interface {
+    // Exec runs a remote shell command and returns STDOUT only.
+    // Stderr is intentionally discarded to match the existing semantics of
+    // (*SSHSession).Exec at internal/shim/ssh.go:99 — SSH multiplex chatter
+    // (control socket noise, etc.) lands on stderr and would otherwise
+    // pollute callers that grep the output for content markers.
+    Exec(cmd string) (stdout string, err error)
+
+    // ExecWithStdin runs a remote shell command with the provided stdin and
+    // returns COMBINED stdout+stderr. Combined output is appropriate here
+    // because this method is used during install/uninstall where stderr
+    // diagnostics (e.g. "mv: cannot create regular file: Permission denied")
+    // are required for actionable error messages.
+    ExecWithStdin(cmd string, stdin io.Reader) (combinedOutput string, err error)
+}
+```
+
+Test stubs MUST honor these distinct semantics: a `localSession.Exec` stub that returns combined output by accident would diverge from production behavior and let regressions slip past unit tests.
+
+Changes required to honor this seam:
+
+- Add a new method `(*SSHSession).ExecWithStdin(cmd string, stdin io.Reader) (string, error)` that wraps the existing inline `exec.Command("ssh", ...)+Stdin` pattern (currently duplicated in `InstallRemoteClaudeWrapper` and `WriteRemoteState`).
+- New functions `InstallRemoteClaudeWrapper`, `UninstallRemoteClaudeWrapper`, `DetectV070Corruption`, `RecoverV070Corruption` accept `SessionExecutor` instead of `*SSHSession`.
+- Existing call sites in `cmd/cc-clip/main.go` keep passing `*SSHSession`, which satisfies the interface — no source-level break for callers.
+- Tests use a `localSession` stub in `internal/shim/local_session_test.go` (or similar) that implements the interface by running commands via `bash -c` against a `t.TempDir()`-backed fake `$HOME`.
+
+This is the test-seam compromise: minimal interface, narrow scope, only the four new install-side functions take the interface; the rest of the package keeps using `*SSHSession` directly. We do NOT introduce a wide refactor in v0.7.1.
+
+---
+
+## 3. Files modified
+
+| File | Change |
+|---|---|
+| `internal/shim/claude_wrapper.go` | Wrapper template: add sidecar-first branch ahead of PATH-discovery. |
+| `internal/shim/ssh.go` | Rewrite `InstallRemoteClaudeWrapper` (state-classify + mv-only + tmp-write+mv). New: `UninstallRemoteClaudeWrapper`, `DetectV070Corruption`, `RecoverV070Corruption`. |
+| `internal/shim/deploy.go` | Add `ClaudeWrapperState` and `ClaudeWrapper` field on `DeployState`. |
+| `cmd/cc-clip/main.go` | Add `--auto-recover` flag to `setup` + `connect`. Reject `--auto-recover --token-only` combination at flag-parse time (before any SSH session setup or network call) per §2 Layer 3 mutual-exclusion rule; exit non-zero with the diagnostic message defined there. Insert new pre-deploy step **N0** between line 558 (`fmt.Println("      SSH master connected")`) and line 561 (the `if tokenOnly` branch). This placement guarantees N0 runs on BOTH the full-deploy path AND the `--token-only` path: on `--token-only`, a corrupted remote still aborts because the user's claude is broken and a token sync would mask that. Action on detect: `corrupted` && no `--auto-recover` → print diagnostic and abort non-zero before any remote write (no binary upload at ~line 588+, no shim install at ~line 660, no token sync at line 567, no wrapper install at line 813). `corrupted` && `--auto-recover` → call `RecoverV070Corruption`, then proceed into the existing path. Existing `InstallRemoteClaudeWrapper` call at line 813 is unchanged in caller (the function itself is rewritten per Layer 1). Modify `cmdUninstall` (~line 399-403) to make local shim uninstall best-effort (warn-only) when `--host` is set; in the `--host` branch (~line 405-412), call `UninstallRemoteClaudeWrapper` BEFORE the existing PATH-marker cleanup. Update `printUsage` (~line 99-152) to document `--auto-recover` flag and the new wrapper-restore semantics of `uninstall --host`. |
+| `internal/shim/ssh_test.go` (or new `claude_wrapper_install_test.go`) | All test scenarios in §4. |
+| `docs/commands.md` | Add `--auto-recover` flag to the `setup` and `connect` command tables. Add a "Symlink-safe install" note explaining the `.cc-clip-real` sidecar artifact. Update `uninstall --host` row to mention wrapper restore. |
+| `README.md` | Update the command-reference snippets (~line 24, 133, 149-162) and the `setup` vs `connect` section (~line 232) only if they currently document install/uninstall semantics that change. Specifically: add a one-line note that `--auto-recover` exists for users hitting the v0.7.0 corruption recovery path. Do NOT expand the README into full v0.7.1 release notes; keep that in the GitHub release body. |
+
+No changes to: `internal/shim/hook_template.go`, `internal/shim/pathfix.go`, `internal/shim/connect.go`, daemon/notify code paths, `docs/notifications.md`, `docs/release.md`.
+
+---
+
+## 4. Test matrix
+
+All tests run against a temp HOME directory simulating remote `~`. Use real `mv`, `ln -s`, `head` etc. on the local filesystem; mock the SSH session to execute commands locally.
+
+| # | Scenario | Setup | Action | Expectation |
+|---|---|---|---|---|
+| 1 | Native installer layout, fresh install | `~/.local/bin/claude → versions/X.Y.Z` (symlink to fake 5KB ELF) | `InstallRemoteClaudeWrapper` | symlink moved to `.cc-clip-real` (still symlink, target unchanged); `claude` is regular file = wrapper script; fake ELF in versions store untouched |
+| 2 | Regular file layout, fresh install | `~/.local/bin/claude` is a regular file (fake ELF) | `InstallRemoteClaudeWrapper` | file moved to `.cc-clip-real` (regular file); `claude` is wrapper |
+| 3 | No prior install | `~/.local/bin/claude` does not exist | `InstallRemoteClaudeWrapper` | wrapper written; no sidecar created |
+| 4 | Re-install (already cc-clip wrapper) | wrapper at `claude`, sidecar exists | `InstallRemoteClaudeWrapper` | wrapper rewritten via tmp+mv; sidecar untouched |
+| 5 | Wrapper exec via sidecar | install scenario 1 + place fake `claude` shell script at sidecar target that `echo`s a token | run wrapper with no tunnel | wrapper exec's sidecar, token observed on stdout |
+| 6 | Wrapper PATH-fallback (no sidecar, legacy install) | wrapper at `claude`, no sidecar, fake claude on `$PATH` outside self_dir | run wrapper | wrapper falls back to PATH-discovery, fake claude executed |
+| 7 | Uninstall - symlink origin | install scenario 1, then uninstall | `UninstallRemoteClaudeWrapper` | wrapper deleted; `.cc-clip-real` mv'd back to `claude`; symlink restored, target unchanged |
+| 8 | Uninstall - regular file origin | install scenario 2, then uninstall | `UninstallRemoteClaudeWrapper` | wrapper deleted; `.cc-clip-real` mv'd back as regular file |
+| 9 | Uninstall refuses foreign file | place a non-cc-clip script at `claude` | `UninstallRemoteClaudeWrapper` | refused with warning; foreign file untouched |
+| 10 | v0.7.0 corruption detected, no flag | construct exact corrupted state (symlink → wrapper, `.cc-clip-bak` is 5MB fake ELF) | `setup` (no flag) | `DetectV070Corruption` returns true; setup aborts non-zero with full diagnostic; no wrapper write occurs; corrupted state untouched |
+| 11 | v0.7.0 corruption + `--auto-recover` | same as 10 | `setup --auto-recover` | backup mv'd back to versions target; symlink mv'd to `.cc-clip-real`; new wrapper installed; exec chain works |
+| 12 | Corruption-like but backup missing | symlink + target is wrapper, no `.cc-clip-bak` | `setup --auto-recover` | C3 fails; abort with "backup absent — reinstall Claude Code" diagnostic; nothing modified |
+| 13 | Corruption-like but backup is itself a wrapper | symlink + target is wrapper + `.cc-clip-bak` is also a wrapper (double-install pathology) | `setup --auto-recover` | C5 fails; abort with diagnostic; nothing modified |
+| 14 | False-positive guard | regular file install + `.cc-clip-bak` happens to exist (large file from unrelated reason) | `setup` | C1 fails (not symlink) → `DetectV070Corruption` returns false → install proceeds normally |
+| 15 | Symlink target is unrelated file (not wrapper) | `~/.local/bin/claude → some-other-binary` | `setup` | C2 fails → no corruption flag → standard install (mv symlink to sidecar) |
+| 16 | Install rollback - regular file origin | regular file at `claude`; inject failure of the final `mv tmp → claude` step (e.g. delete `~/.local/bin` between staging mv and final mv via `localSession` hook) | `InstallRemoteClaudeWrapper` | error returned; sidecar `.cc-clip-real` was mv'd back to `claude` (best-effort rollback); tmp file removed; original regular file content unchanged |
+| 17 | mktemp pre-existing-symlink guard | place `~/.local/bin/.claude.cc-clip-tmp.AAAAAA` as a symlink to a sensitive file; force `mktemp`'s random suffix to AAAAAA via test seam | `InstallRemoteClaudeWrapper` | mktemp returns failure (or generates a different suffix); the planted symlink target is NOT written to; install either retries with a different suffix or aborts cleanly |
+| 18 | Sidecar collision - regular file already at sidecar path | symlink at `claude` + a stale regular file at `claude.cc-clip-real` (e.g. from a half-completed prior install) | `InstallRemoteClaudeWrapper` | install aborts pre-stage with diagnostic suggesting `rm ~/.local/bin/claude.cc-clip-real`; symlink at `claude` is untouched; tmp removed; user's claude still works |
+| 19 | Sidecar collision - directory at sidecar path | regular file at `claude` + a directory at `claude.cc-clip-real` (the silent-corruption footgun case) | `InstallRemoteClaudeWrapper` | install aborts pre-stage with diagnostic; verify origin was NOT moved into the directory (that would be the bug we're guarding against); user's claude still works |
+| 20 | N0 detection on `--token-only` path | constructed v0.7.0 corrupted remote | `cc-clip connect <host> --token-only` (no `--auto-recover`) | N0 detection fires; setup aborts non-zero with diagnostic; token sync at line 567 NEVER runs; remote token file unchanged |
+| 21 | Test stub Exec/ExecWithStdin semantics | localSession stub returns "out\n" on stdout and "err\n" on stderr for `echo out; echo err >&2` | call stub `Exec` and `ExecWithStdin` | `Exec` returns `"out\n"` only (stderr discarded). `ExecWithStdin` returns `"out\nerr\n"` (combined, order may vary by buffering). This locks the contract that production and stub stay aligned — the wrong stub semantics are exactly what would let MEDIUM 1 regress silently. |
+| 22 | Flag combination `--auto-recover --token-only` is rejected | (no remote needed) | `cc-clip setup <host> --auto-recover --token-only` | exit non-zero at flag-parse time, before SSH session setup; stderr contains the conflict-resolution message from §2 Layer 3; verify NO `NewSSHSession` call was made (use a test seam or a host that would fail to resolve to confirm we exit before networking) |
+
+Test helpers needed:
+- `t.TempDir()` based fake `$HOME` with `.local/bin/` and `.local/share/claude/versions/X.Y.Z/`.
+- `localSession` stub implementing the `SessionExecutor` interface (per §2 Layer 6), running commands via `bash -c` against the temp HOME. Critically: bash interprets `~` against `$HOME`, which the stub sets to `t.TempDir()`. Tests do NOT call the real `*SSHSession` constructor.
+- Fixture: a ≥5MB random file to play "real claude binary" (so C4 size threshold triggers naturally); the wrapper script content is the real `ClaudeWrapperScript(port)` output (so C2/C5 marker matching uses real bytes, not a hand-crafted near-miss).
+
+---
+
+## 5. Verification
+
+After implementation, before any commit/PR:
+
+```bash
+go test ./internal/shim -count=1 -race
+go test ./cmd/cc-clip ./internal/shim -count=1 -race
+go vet ./...
+make build
+```
+
+Before tagging v0.7.1:
+
+```bash
+make release-preflight   # if defined; otherwise the existing release-local + smoke check
+```
+
+Manual smoke (real remote):
+
+1. Set up a fresh Ubuntu 22.04 VM with Anthropic's Native Installer (`curl https://claude.ai/install.sh`).
+2. Run `cc-clip setup <host>` — verify symlink intact, real binary intact, `claude --version` works.
+3. SSH in, run `cc-clip-hook` smoke (existing notification probe in step N6 should still pass).
+4. Run `cc-clip uninstall --host <host>` — verify symlink restored to original target, no leftover `.cc-clip-real` (a `.cc-clip-bak` from a prior v0.7.0 install is preserved with an info message; new installs do not create one), real binary intact.
+5. Construct v0.7.0 corrupted state by hand on a second VM. Run `cc-clip setup <host>` → expect abort with diagnostic and zero remote writes. Run `cc-clip setup <host> --auto-recover` → expect clean install + working `claude`.
+
+---
+
+## 6. Release notes (v0.7.1 draft)
+
+```markdown
+## v0.7.1 — Fix: claude wrapper no longer corrupts the real binary on Native Installer layouts
+
+### Bug fix
+- `cc-clip setup` / `cc-clip connect` previously followed the symlink at
+  `~/.local/bin/claude` and overwrote the actual claude binary inside
+  `~/.local/share/claude/versions/X.Y.Z`. This affected every user installing
+  Claude Code via Anthropic's official Native Installer (`curl claude.ai/install.sh`).
+- The install path is now symlink-safe: the original entry (regular file or
+  symlink) is renamed to `~/.local/bin/claude.cc-clip-real`, and the wrapper is
+  written via tmp-file + atomic rename. The real claude binary is never touched.
+
+### Recovery for existing v0.7.0 victims
+On v0.7.1, running `cc-clip setup <host>` against a remote whose claude binary
+was corrupted by v0.7.0 will:
+
+1. Detect the corruption (five-condition check) and abort with a clear diagnostic.
+2. Show a copy-paste recovery command.
+3. Offer `cc-clip setup <host> --auto-recover` to perform recovery + reinstall in one step.
+
+If you prefer to recover manually:
+
+    ssh <host>
+    mv ~/.local/bin/claude.cc-clip-bak "$(readlink -f ~/.local/bin/claude)"
+
+Then re-run `cc-clip setup <host>` from your local machine.
+
+If `~/.local/bin/claude.cc-clip-bak` is missing on your remote, your real claude
+binary cannot be recovered automatically. Reinstall Claude Code via
+`curl https://claude.ai/install.sh` and then re-run `cc-clip setup`.
+
+### New: `cc-clip uninstall --host <host>` cleans up the claude wrapper
+The existing `cc-clip uninstall --host <host>` command now also removes the
+cc-clip claude wrapper from `~/.local/bin/claude` and restores the original
+file or symlink from the `~/.local/bin/claude.cc-clip-real` sidecar created
+during install. If the file at `~/.local/bin/claude` is not a cc-clip wrapper
+(e.g. user replaced it manually), it is left untouched and the command emits
+a warning.
+```
+
+---
+
+## 7. Decisions log (for reviewer reference)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Approach (A/B/C) | **B**: rename symlink + wrapper holds explicit sidecar | A leaves wrapper unable to find real claude under Native Installer layout; C downgrades semantics to interactive-shell-only |
+| Sidecar naming | `~/.local/bin/claude.cc-clip-real` (single name for all origin kinds) | Wrapper logic uniform; `.cc-clip-bak` reserved as a v0.7.0 historical artifact name we recognize but don't produce |
+| Write technique | tmp file + `chmod +x` + `mv` to final path | Atomic; guarantees we never `>` into a possibly-symlink path even defensively |
+| State storage | `DeployState.ClaudeWrapper` JSON sub-struct | Used for diagnostics/uninstall hints; **wrapper runtime does not parse JSON** |
+| v0.7.0 recovery default | **Fail closed** (abort + diagnostic) | A 250MB user binary move is not in the implicit authorization scope of `cc-clip setup`. Detection precision ≠ default-write authorization |
+| `--auto-recover` flag | Opt-in single-step recovery + reinstall | Same code path as default detection; just changes whether we proceed |
+| Recovery sub-command (`cc-clip recover-claude`) | **Not introduced** | Discovery rate too low; v0.7.1 victims will re-run `setup`, which is where the fix must surface |
+| Pre-existing `uninstall --codex` flow | Untouched | Out of scope; only the no-flag uninstall gains wrapper restoration |
+
+---
+
+## 8. Out of scope
+
+- Doctor / diagnostic sub-command. The `DeployState.ClaudeWrapper` field will support a future `cc-clip doctor` command but no command is added in v0.7.1.
+- Anthropic Claude Code self-update conflict handling. After Anthropic's installer overwrites `~/.local/bin/claude` during an upgrade, the user must re-run `cc-clip setup`. This is documented behavior and not a regression.
+- Behavior on platforms other than Linux remote. macOS-as-remote and Windows-as-remote are unchanged; the wrapper-on-remote concept is Linux-only by design.

--- a/internal/shim/claude_wrapper.go
+++ b/internal/shim/claude_wrapper.go
@@ -5,19 +5,27 @@ import "fmt"
 const claudeWrapperTemplate = `#!/usr/bin/env bash
 # cc-clip claude wrapper — auto-inject notification hooks
 # Installed by: cc-clip connect
-# Remove with:  rm ~/.local/bin/claude
+# Remove with:  cc-clip uninstall --host <this-host>
 
-# Find the real claude binary (skip our own directory)
+# Find the real claude binary.
+# Priority 1: ~/.local/bin/claude.cc-clip-real (the sidecar set by install).
+# Priority 2: walk $PATH skipping our own directory (legacy install fallback).
 _REAL_CLAUDE=""
 _SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
-IFS=: read -ra _PATH_DIRS <<< "$PATH"
-for _dir in "${_PATH_DIRS[@]}"; do
-    [ "$_dir" = "$_SELF_DIR" ] && continue
-    [ -x "$_dir/claude" ] && _REAL_CLAUDE="$_dir/claude" && break
-done
+_SIDECAR="$_SELF_DIR/claude.cc-clip-real"
+
+if [ -x "$_SIDECAR" ]; then
+    _REAL_CLAUDE="$_SIDECAR"
+else
+    IFS=: read -ra _PATH_DIRS <<< "$PATH"
+    for _dir in "${_PATH_DIRS[@]}"; do
+        [ "$_dir" = "$_SELF_DIR" ] && continue
+        [ -x "$_dir/claude" ] && _REAL_CLAUDE="$_dir/claude" && break
+    done
+fi
 
 if [ -z "$_REAL_CLAUDE" ]; then
-    echo "cc-clip: real claude binary not found in PATH" >&2
+    echo "cc-clip: real claude binary not found (no sidecar at $_SIDECAR and no claude on PATH outside $_SELF_DIR)" >&2
     exit 1
 fi
 

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -1,0 +1,96 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// setupFakeHome creates a t.TempDir() with .local/bin/ subdir and returns
+// the bin dir path. Tests use this as a fake remote $HOME root.
+func setupFakeHome(t *testing.T) (home, binDir string) {
+	t.Helper()
+	home = t.TempDir()
+	binDir = filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("setup binDir: %v", err)
+	}
+	return home, binDir
+}
+
+func TestClassifyClaudeBin_None(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not reliably available on Windows runner")
+	}
+	home, _ := setupFakeHome(t)
+	s := &localSession{home: home}
+	kind, err := classifyClaudeBin(s)
+	if err != nil {
+		t.Fatalf("classify: %v", err)
+	}
+	if kind != "none" {
+		t.Fatalf("got %q, want none", kind)
+	}
+}
+
+func TestClassifyClaudeBin_RegularNonWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not reliably available on Windows runner")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("\x7fELF... fake"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+	kind, err := classifyClaudeBin(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != "regular" {
+		t.Fatalf("got %q, want regular", kind)
+	}
+}
+
+func TestClassifyClaudeBin_CcWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash not reliably available on Windows runner")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+	kind, err := classifyClaudeBin(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != "cc_wrapper" {
+		t.Fatalf("got %q, want cc_wrapper", kind)
+	}
+}
+
+func TestClassifyClaudeBin_Symlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	target := filepath.Join(home, ".local", "share", "claude", "versions", "2.1.132")
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("\x7fELF... real binary content"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+	kind, err := classifyClaudeBin(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kind != "symlink" {
+		t.Fatalf("got %q, want symlink", kind)
+	}
+}

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -455,3 +455,156 @@ func TestInstall_MktempDoesNotFollowSymlinks(t *testing.T) {
 		t.Fatal("sensitive file was modified — mktemp may not be in use")
 	}
 }
+
+// makeV070Corruption sets up the exact filesystem state issue #55 describes:
+// symlink at ~/.local/bin/claude points at versions/X.Y.Z, that file is now
+// a cc-clip wrapper, and ~/.local/bin/claude.cc-clip-bak holds the real binary.
+func makeV070Corruption(t *testing.T, home string) {
+	t.Helper()
+	binDir := filepath.Join(home, ".local", "bin")
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	// versions/X.Y.Z is a cc-clip wrapper (the bug).
+	if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// claude is the symlink, untouched.
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	// .cc-clip-bak holds the original 5MB ELF.
+	realBinary := make([]byte, 5*1024*1024)
+	for i := range realBinary {
+		realBinary[i] = byte(i % 251)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), realBinary, 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectV070_CorruptedState(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, _ := setupFakeHome(t)
+	makeV070Corruption(t, home)
+
+	s := &localSession{home: home}
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if !corrupted {
+		t.Fatal("expected corrupted=true on canonical v0.7.0 state")
+	}
+}
+
+func TestDetectV070_NotSymlinkOrigin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Even with a .cc-clip-bak, C1 fails (not symlink).
+	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), make([]byte, 5*1024*1024), 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if corrupted {
+		t.Fatal("expected corrupted=false when origin is regular file (C1 must fail)")
+	}
+}
+
+func TestDetectV070_BackupMissing(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	// No .cc-clip-bak.
+	s := &localSession{home: home}
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if corrupted {
+		t.Fatal("expected corrupted=false when backup is missing (C3 must fail)")
+	}
+}
+
+func TestDetectV070_BackupIsAlsoWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	// Backup is also a wrapper. Pad to >1MB so C4 passes.
+	bakContent := append([]byte(ClaudeWrapperScript(18339)), make([]byte, 2*1024*1024)...)
+	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), bakContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if corrupted {
+		t.Fatal("expected corrupted=false when backup itself is a wrapper (C5 must fail)")
+	}
+}
+
+func TestDetectV070_SymlinkTargetNotWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	if err := os.WriteFile(target, []byte("\x7fELF... regular real binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if corrupted {
+		t.Fatal("expected corrupted=false when symlink target is a real binary (C2 must fail)")
+	}
+}

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -182,6 +182,49 @@ func TestInstall_NoPriorInstall(t *testing.T) {
 	}
 }
 
+func TestInstall_ReinstallOverCcWrapper(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+
+	// Existing cc-clip wrapper at claude (port 18339).
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Existing sidecar from prior install.
+	sidecarContent := []byte("PRIOR-SIDECAR-CONTENT")
+	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-real"), sidecarContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	if err := InstallRemoteClaudeWrapper(s, 19999); err != nil {
+		t.Fatalf("re-install: %v", err)
+	}
+
+	// Wrapper must be updated (port baked in is 19999 now).
+	data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "19999") {
+		t.Fatal("wrapper port was not updated")
+	}
+	if strings.Contains(string(data), "18339") {
+		t.Fatal("wrapper still contains old port")
+	}
+
+	// Sidecar must be untouched (we don't displace re-install over our own wrapper).
+	sidecarPost, err := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-real"))
+	if err != nil {
+		t.Fatalf("sidecar missing after re-install: %v", err)
+	}
+	if string(sidecarPost) != string(sidecarContent) {
+		t.Fatal("sidecar was modified during re-install (must be untouched)")
+	}
+}
+
 func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -225,6 +225,80 @@ func TestInstall_ReinstallOverCcWrapper(t *testing.T) {
 	}
 }
 
+func TestInstall_SidecarCollision_RegularFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+
+	// Native installer layout (symlink origin).
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	if err := os.WriteFile(target, []byte("real binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale sidecar from a prior half-install.
+	sidecar := filepath.Join(binDir, "claude.cc-clip-real")
+	if err := os.WriteFile(sidecar, []byte("STALE"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	err := InstallRemoteClaudeWrapper(s, 18339)
+	if err == nil {
+		t.Fatal("expected install to refuse with collision; got nil")
+	}
+	if !strings.Contains(err.Error(), "claude.cc-clip-real already exists") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Origin must be untouched.
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("origin symlink was disturbed despite collision refusal")
+	}
+}
+
+func TestInstall_SidecarCollision_Directory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Sidecar PATH is a directory — would have been the silent-corruption footgun.
+	sidecarDir := filepath.Join(binDir, "claude.cc-clip-real")
+	if err := os.Mkdir(sidecarDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	err := InstallRemoteClaudeWrapper(s, 18339)
+	if err == nil {
+		t.Fatal("expected install to refuse on directory at sidecar path")
+	}
+	// CRITICAL: origin must NOT have been moved into the directory.
+	if _, statErr := os.Stat(filepath.Join(sidecarDir, "claude")); statErr == nil {
+		t.Fatal("FOOTGUN: claude was moved into the directory; collision guard failed")
+	}
+	// Origin must still be at the original location.
+	if _, err := os.Lstat(filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal("origin claude is missing; collision guard failed to short-circuit")
+	}
+}
+
 func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -92,5 +93,43 @@ func TestClassifyClaudeBin_Symlink(t *testing.T) {
 	}
 	if kind != "symlink" {
 		t.Fatalf("got %q, want symlink", kind)
+	}
+}
+
+func TestInstall_NoPriorInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	s := &localSession{home: home}
+
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Wrapper should now exist as a regular file at ~/.local/bin/claude.
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatalf("claude not installed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("claude should be a regular file, got symlink")
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Fatal("claude should be executable")
+	}
+
+	// No sidecar should have been created (no origin to displace).
+	if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+		t.Fatalf("sidecar should not exist on first install of 'none' case, got: %v", err)
+	}
+
+	// Content must be the wrapper script.
+	data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "# cc-clip claude wrapper") {
+		t.Fatal("installed file is not the cc-clip wrapper")
 	}
 }

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -663,3 +663,112 @@ func TestRecoverV070_RefusesIfNotCorrupted(t *testing.T) {
 		t.Fatal("expected recovery to refuse when no corruption is detected")
 	}
 }
+
+func TestUninstall_SymlinkOrigin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	realBinary := []byte("real claude binary content, ~5MB pretend")
+	if err := os.WriteFile(target, realBinary, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if err := UninstallRemoteClaudeWrapper(s); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	// claude must be a symlink again, pointing at the original target.
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("claude is not a symlink after uninstall")
+	}
+	resolved, err := os.Readlink(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != target {
+		t.Fatalf("symlink target: got %q, want %q", resolved, target)
+	}
+	// Real binary intact (was never touched).
+	pre, _ := os.ReadFile(target)
+	if string(pre) != string(realBinary) {
+		t.Fatal("real binary corrupted")
+	}
+	// Sidecar must be gone.
+	if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+		t.Fatal("sidecar lingered after uninstall")
+	}
+}
+
+func TestUninstall_RegularFileOrigin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	original := []byte("ORIGINAL")
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), original, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatal(err)
+	}
+	if err := UninstallRemoteClaudeWrapper(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// claude must be the original regular file again.
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("claude is a symlink after uninstall (should be regular)")
+	}
+	data, _ := os.ReadFile(filepath.Join(binDir, "claude"))
+	if string(data) != string(original) {
+		t.Fatal("origin content not restored")
+	}
+}
+
+func TestUninstall_RefusesForeignFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	foreign := []byte("#!/bin/bash\n# user's own custom claude wrapper, not ours\n")
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), foreign, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	err := UninstallRemoteClaudeWrapper(s)
+	if err == nil {
+		t.Fatal("expected uninstall to refuse foreign file")
+	}
+	if !strings.Contains(err.Error(), "not a cc-clip wrapper") {
+		t.Fatalf("unexpected uninstall error: %v", err)
+	}
+	// Foreign file must be untouched.
+	data, _ := os.ReadFile(filepath.Join(binDir, "claude"))
+	if string(data) != string(foreign) {
+		t.Fatal("foreign file was modified")
+	}
+}

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -608,3 +608,58 @@ func TestDetectV070_SymlinkTargetNotWrapper(t *testing.T) {
 		t.Fatal("expected corrupted=false when symlink target is a real binary (C2 must fail)")
 	}
 }
+
+func TestRecoverV070_HappyPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+	makeV070Corruption(t, home)
+
+	target := filepath.Join(home, ".local", "share", "claude", "versions", "2.1.132")
+	bakBefore, _ := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-bak"))
+
+	s := &localSession{home: home}
+	if err := RecoverV070Corruption(s); err != nil {
+		t.Fatalf("recover: %v", err)
+	}
+
+	// After recovery: target file content == backup content (real binary restored).
+	targetAfter, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(targetAfter) != string(bakBefore) {
+		t.Fatal("target content does not match backup; recovery failed")
+	}
+
+	// Backup file must be gone (mv consumed it).
+	if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-bak")); !os.IsNotExist(err) {
+		t.Fatal("backup file lingered after recovery")
+	}
+
+	// Symlink must still exist and still point at target.
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("claude is no longer a symlink after recovery")
+	}
+}
+
+func TestRecoverV070_RefusesIfNotCorrupted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	err := RecoverV070Corruption(s)
+	if err == nil {
+		t.Fatal("expected recovery to refuse when no corruption is detected")
+	}
+}

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -181,3 +181,77 @@ func TestInstall_NoPriorInstall(t *testing.T) {
 		t.Fatal("installed file is not the cc-clip wrapper")
 	}
 }
+
+func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	home, binDir := setupFakeHome(t)
+
+	// Build Native Installer layout:
+	//   ~/.local/bin/claude -> ~/.local/share/claude/versions/2.1.132
+	//   ~/.local/share/claude/versions/2.1.132 = real binary (5MB random)
+	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+	if err := os.MkdirAll(versionsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(versionsDir, "2.1.132")
+	realBinary := make([]byte, 5*1024*1024)
+	for i := range realBinary {
+		realBinary[i] = byte(i % 251) // pseudo-random; large enough to be distinguishable
+	}
+	if err := os.WriteFile(target, realBinary, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Snapshot the real binary content before install.
+	pre, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// CRITICAL: real binary in versions store must be byte-identical to before.
+	// This is the issue #55 regression assertion — the original v0.7.0 bug had
+	// the wrapper written THROUGH the symlink to this very file.
+	post, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("real binary disappeared: %v", err)
+	}
+	if string(pre) != string(post) {
+		t.Fatal("REGRESSION: real claude binary was modified during install (issue #55 root bug)")
+	}
+
+	// Sidecar must be the symlink itself, still pointing at versions/2.1.132.
+	sidecar := filepath.Join(binDir, "claude.cc-clip-real")
+	info, err := os.Lstat(sidecar)
+	if err != nil {
+		t.Fatalf("sidecar missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatal("sidecar should be a symlink (origin was a symlink)")
+	}
+	resolved, err := os.Readlink(sidecar)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != target {
+		t.Fatalf("sidecar target: got %q, want %q", resolved, target)
+	}
+
+	// Wrapper must be a regular file at claude path.
+	wrapperInfo, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if wrapperInfo.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("claude should be a regular file after install (the wrapper)")
+	}
+}

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -485,50 +485,12 @@ func makeV070Corruption(t *testing.T, home string) {
 	}
 }
 
-func TestDetectV070_CorruptedState(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink semantics differ on Windows")
-	}
-	home, _ := setupFakeHome(t)
-	makeV070Corruption(t, home)
-
-	s := &localSession{home: home}
-	corrupted, err := DetectV070Corruption(s)
-	if err != nil {
-		t.Fatalf("detect: %v", err)
-	}
-	if !corrupted {
-		t.Fatal("expected corrupted=true on canonical v0.7.0 state")
-	}
-}
-
-func TestDetectV070_NotSymlinkOrigin(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("bash-based install path is Linux-only")
-	}
-	home, binDir := setupFakeHome(t)
-	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	// Even with a .cc-clip-bak, C1 fails (not symlink).
-	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), make([]byte, 5*1024*1024), 0755); err != nil {
-		t.Fatal(err)
-	}
-	s := &localSession{home: home}
-	corrupted, err := DetectV070Corruption(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if corrupted {
-		t.Fatal("expected corrupted=false when origin is regular file (C1 must fail)")
-	}
-}
-
-func TestDetectV070_BackupMissing(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlink semantics differ on Windows")
-	}
-	home, binDir := setupFakeHome(t)
+// makeSymlinkToWrapperOnly builds the "target is wrapper" half of the
+// v0.7.0 layout (C1+C2 hold) but leaves the .cc-clip-bak file to the caller
+// — so tests can craft any combination of C3/C4/C5 failures.
+func makeSymlinkToWrapperOnly(t *testing.T, home string) string {
+	t.Helper()
+	binDir := filepath.Join(home, ".local", "bin")
 	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
 	if err := os.MkdirAll(versionsDir, 0755); err != nil {
 		t.Fatal(err)
@@ -540,72 +502,172 @@ func TestDetectV070_BackupMissing(t *testing.T) {
 	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
 		t.Fatal(err)
 	}
-	// No .cc-clip-bak.
-	s := &localSession{home: home}
-	corrupted, err := DetectV070Corruption(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if corrupted {
-		t.Fatal("expected corrupted=false when backup is missing (C3 must fail)")
-	}
+	return filepath.Join(binDir, "claude.cc-clip-bak")
 }
 
-func TestDetectV070_BackupIsAlsoWrapper(t *testing.T) {
+// TestDetectV070State_TableDriven exhaustively covers the three-state
+// detector's decision boundary. Each row builds a specific filesystem
+// shape and asserts both the state classification AND the stable diag
+// token — diag tokens are part of the contract used by callers for
+// log messages and (importantly) for the manual-recovery hint at N0.
+func TestDetectV070State_TableDriven(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")
 	}
-	home, binDir := setupFakeHome(t)
-	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
-	if err := os.MkdirAll(versionsDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	target := filepath.Join(versionsDir, "2.1.132")
-	if err := os.WriteFile(target, []byte(ClaudeWrapperScript(18339)), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
-		t.Fatal(err)
-	}
-	// Backup is also a wrapper. Pad to >1MB so C4 passes.
-	bakContent := append([]byte(ClaudeWrapperScript(18339)), make([]byte, 2*1024*1024)...)
-	if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), bakContent, 0755); err != nil {
-		t.Fatal(err)
+
+	cases := []struct {
+		name      string
+		setup     func(t *testing.T, home string)
+		wantState V070State
+		wantDiag  string
+	}{
+		{
+			name:      "no_claude_at_all",
+			setup:     func(t *testing.T, home string) {},
+			wantState: V070NotCorrupted,
+			wantDiag:  "not_corrupted_C1_not_symlink",
+		},
+		{
+			name: "claude_is_regular_file_with_backup",
+			setup: func(t *testing.T, home string) {
+				binDir := filepath.Join(home, ".local", "bin")
+				if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				// Even with a .cc-clip-bak, C1 fails (not symlink).
+				if err := os.WriteFile(filepath.Join(binDir, "claude.cc-clip-bak"), make([]byte, 5*1024*1024), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantState: V070NotCorrupted,
+			wantDiag:  "not_corrupted_C1_not_symlink",
+		},
+		{
+			name: "symlink_target_not_wrapper",
+			setup: func(t *testing.T, home string) {
+				binDir := filepath.Join(home, ".local", "bin")
+				versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
+				if err := os.MkdirAll(versionsDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				target := filepath.Join(versionsDir, "2.1.132")
+				if err := os.WriteFile(target, []byte("\x7fELF... real binary"), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantState: V070NotCorrupted,
+			wantDiag:  "not_corrupted_C2_not_wrapper",
+		},
+		{
+			name: "canonical_v070_state_recoverable",
+			setup: func(t *testing.T, home string) {
+				makeV070Corruption(t, home)
+			},
+			wantState: V070Recoverable,
+			wantDiag:  "recoverable",
+		},
+		{
+			name: "wrapper_target_backup_missing",
+			setup: func(t *testing.T, home string) {
+				makeSymlinkToWrapperOnly(t, home)
+				// Intentionally no .cc-clip-bak: spec scenario 12.
+			},
+			wantState: V070NonRecoverable,
+			wantDiag:  "non_recoverable_C3_backup_missing",
+		},
+		{
+			name: "wrapper_target_backup_too_small",
+			setup: func(t *testing.T, home string) {
+				bakPath := makeSymlinkToWrapperOnly(t, home)
+				// Below 1 MiB threshold — cannot be a real claude binary.
+				if err := os.WriteFile(bakPath, make([]byte, 512*1024), 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantState: V070NonRecoverable,
+			wantDiag:  "non_recoverable_C4_backup_too_small",
+		},
+		{
+			name: "wrapper_target_backup_is_wrapper",
+			setup: func(t *testing.T, home string) {
+				bakPath := makeSymlinkToWrapperOnly(t, home)
+				// Backup is also a wrapper. Pad to >1MB so C4 passes
+				// and C5 is the deciding failure: spec scenario 13.
+				bakContent := append([]byte(ClaudeWrapperScript(18339)), make([]byte, 2*1024*1024)...)
+				if err := os.WriteFile(bakPath, bakContent, 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantState: V070NonRecoverable,
+			wantDiag:  "non_recoverable_C5_backup_is_wrapper",
+		},
 	}
 
-	s := &localSession{home: home}
-	corrupted, err := DetectV070Corruption(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if corrupted {
-		t.Fatal("expected corrupted=false when backup itself is a wrapper (C5 must fail)")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, _ := setupFakeHome(t)
+			tc.setup(t, home)
+			s := &localSession{home: home}
+			state, diag, err := DetectV070State(s)
+			if err != nil {
+				t.Fatalf("detect: %v", err)
+			}
+			if state != tc.wantState {
+				t.Errorf("state: got %v, want %v (diag=%q)", state, tc.wantState, diag)
+			}
+			if diag != tc.wantDiag {
+				t.Errorf("diag: got %q, want %q", diag, tc.wantDiag)
+			}
+		})
 	}
 }
 
-func TestDetectV070_SymlinkTargetNotWrapper(t *testing.T) {
+// TestDetectV070Corruption_BooleanCompat verifies the compat wrapper still
+// returns true ONLY for the recoverable case. Non-recoverable states must
+// collapse to false so RecoverV070Corruption's TOCTOU guard fails safe.
+func TestDetectV070Corruption_BooleanCompat(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink semantics differ on Windows")
 	}
-	home, binDir := setupFakeHome(t)
-	versionsDir := filepath.Join(home, ".local", "share", "claude", "versions")
-	if err := os.MkdirAll(versionsDir, 0755); err != nil {
-		t.Fatal(err)
+	cases := []struct {
+		name  string
+		setup func(t *testing.T, home string)
+		want  bool
+	}{
+		{
+			name:  "recoverable_yields_true",
+			setup: func(t *testing.T, home string) { makeV070Corruption(t, home) },
+			want:  true,
+		},
+		{
+			name: "non_recoverable_collapses_to_false",
+			setup: func(t *testing.T, home string) {
+				makeSymlinkToWrapperOnly(t, home) // C3 fails — non-recoverable
+			},
+			want: false,
+		},
+		{
+			name:  "not_corrupted_yields_false",
+			setup: func(t *testing.T, home string) {},
+			want:  false,
+		},
 	}
-	target := filepath.Join(versionsDir, "2.1.132")
-	if err := os.WriteFile(target, []byte("\x7fELF... regular real binary"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Symlink(target, filepath.Join(binDir, "claude")); err != nil {
-		t.Fatal(err)
-	}
-	s := &localSession{home: home}
-	corrupted, err := DetectV070Corruption(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if corrupted {
-		t.Fatal("expected corrupted=false when symlink target is a real binary (C2 must fail)")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home, _ := setupFakeHome(t)
+			tc.setup(t, home)
+			s := &localSession{home: home}
+			got, err := DetectV070Corruption(s)
+			if err != nil {
+				t.Fatalf("detect: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -370,5 +371,87 @@ func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
 	}
 	if wrapperInfo.Mode()&os.ModeSymlink != 0 {
 		t.Fatal("claude should be a regular file after install (the wrapper)")
+	}
+}
+
+// rollbackInjectingSession wraps localSession and rewrites the install
+// command to force the final mv to fail, simulating a filesystem error
+// after the staging mv has already moved origin to the sidecar.
+type rollbackInjectingSession struct {
+	*localSession
+	binDir   string
+	injected bool
+}
+
+func (r *rollbackInjectingSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+	if !r.injected && strings.Contains(cmd, "claude.cc-clip-real") {
+		r.injected = true
+		// Replace the final mv guard with a forced failure so the rollback
+		// branch (mv sidecar back to claude) is exercised.
+		cmd = strings.Replace(cmd,
+			`if ! mv "$tmp" "$HOME/.local/bin/claude"; then`,
+			`if ! false; then`, 1)
+	}
+	return r.localSession.ExecWithStdin(cmd, stdin)
+}
+
+func TestInstall_RollbackOnFinalMvFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	originalContent := []byte("ORIGINAL-CLAUDE-BINARY-MUST-BE-RESTORED")
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), originalContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &rollbackInjectingSession{localSession: &localSession{home: home}, binDir: binDir}
+	err := InstallRemoteClaudeWrapper(s, 18339)
+	if err == nil {
+		t.Fatal("expected install to fail (we injected final-mv failure)")
+	}
+
+	// Origin must be restored at ~/.local/bin/claude.
+	restored, err := os.ReadFile(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatalf("origin not restored: %v", err)
+	}
+	if string(restored) != string(originalContent) {
+		t.Fatal("origin content corrupted; rollback failed")
+	}
+
+	// Sidecar must NOT exist after rollback.
+	if _, err := os.Lstat(filepath.Join(binDir, "claude.cc-clip-real")); !os.IsNotExist(err) {
+		t.Fatal("sidecar lingered after rollback")
+	}
+}
+
+func TestInstall_MktempDoesNotFollowSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("regular origin"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Plant a sensitive file outside binDir; install must not touch it.
+	// mktemp uses XXXXXX (random suffix), so collision probability is ~1/(62^6).
+	// This test confirms install succeeds and the sensitive file is unchanged,
+	// verifying mktemp is in use rather than a predictable name like $$.
+	sensitive := filepath.Join(home, "sensitive-file.txt")
+	if err := os.WriteFile(sensitive, []byte("DO NOT TOUCH"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &localSession{home: home}
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Sensitive file must be unchanged.
+	pre, _ := os.ReadFile(sensitive)
+	if string(pre) != "DO NOT TOUCH" {
+		t.Fatal("sensitive file was modified — mktemp may not be in use")
 	}
 }

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -96,6 +96,54 @@ func TestClassifyClaudeBin_Symlink(t *testing.T) {
 	}
 }
 
+func TestInstall_RegularFileOrigin(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	originalContent := []byte("\x7fELF... pretend this is the real 250MB claude binary")
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), originalContent, 0755); err != nil {
+		t.Fatal(err)
+	}
+	s := &localSession{home: home}
+
+	if err := InstallRemoteClaudeWrapper(s, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	// Sidecar must hold the original (verbatim).
+	sidecar, err := os.ReadFile(filepath.Join(binDir, "claude.cc-clip-real"))
+	if err != nil {
+		t.Fatalf("sidecar missing: %v", err)
+	}
+	if string(sidecar) != string(originalContent) {
+		t.Fatal("sidecar does not contain original content (mv may have leaked or content was rewritten)")
+	}
+
+	// claude must now be the wrapper.
+	data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "# cc-clip claude wrapper") {
+		t.Fatal("claude is not the cc-clip wrapper after install")
+	}
+	// Port-substitution assertion (per T6 review note): wrapper must reference
+	// the port we passed to InstallRemoteClaudeWrapper.
+	if !strings.Contains(string(data), "18339") {
+		t.Fatal("installed wrapper does not contain expected port 18339")
+	}
+
+	// claude must be a regular file (not a symlink).
+	info, err := os.Lstat(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		t.Fatal("claude should be a regular file after install")
+	}
+}
+
 func TestInstall_NoPriorInstall(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash-based install path is Linux-only")

--- a/internal/shim/claude_wrapper_test.go
+++ b/internal/shim/claude_wrapper_test.go
@@ -64,3 +64,28 @@ func TestClaudeWrapperHasShebangAndHeader(t *testing.T) {
 		t.Error("expected header comment")
 	}
 }
+
+func TestClaudeWrapperScript_PrefersSidecar(t *testing.T) {
+	script := ClaudeWrapperScript(18339)
+	if !strings.Contains(script, "claude.cc-clip-real") {
+		t.Fatal("wrapper does not reference sidecar path")
+	}
+	// Sidecar branch must precede PATH-discovery fallback.
+	sidecarIdx := strings.Index(script, "claude.cc-clip-real")
+	pathDiscoveryIdx := strings.Index(script, "_PATH_DIRS")
+	if sidecarIdx == -1 || pathDiscoveryIdx == -1 {
+		t.Fatal("wrapper missing one of: sidecar branch, PATH-discovery fallback")
+	}
+	if sidecarIdx >= pathDiscoveryIdx {
+		t.Fatal("sidecar branch must precede PATH-discovery fallback")
+	}
+}
+
+func TestClaudeWrapperScript_KeepsPathFallback(t *testing.T) {
+	// PATH-discovery must remain for backward compat with legacy installs
+	// that have no sidecar.
+	script := ClaudeWrapperScript(18339)
+	if !strings.Contains(script, "_PATH_DIRS") || !strings.Contains(script, "_SELF_DIR") {
+		t.Fatal("wrapper missing PATH-discovery fallback")
+	}
+}

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -26,16 +26,27 @@ type NotifyDeployState struct {
 	HealthVerified bool `json:"health_verified"`
 }
 
+// ClaudeWrapperState records what InstallRemoteClaudeWrapper replaced at
+// ~/.local/bin/claude. Used by uninstall and future doctor commands; the
+// wrapper bash script itself does NOT read this — it only checks file
+// existence/executability of the sidecar.
+type ClaudeWrapperState struct {
+	Installed    bool   `json:"installed"`
+	OriginKind   string `json:"origin_kind"`             // "none" | "regular" | "symlink"
+	OriginTarget string `json:"origin_target,omitempty"` // resolved path when OriginKind=="symlink"
+}
+
 // DeployState represents the state of a cc-clip deployment on a remote host.
 // It is stored as ~/.cache/cc-clip/deploy.json on the remote.
 type DeployState struct {
-	BinaryHash    string             `json:"binary_hash"`
-	BinaryVersion string             `json:"binary_version"`
-	ShimInstalled bool               `json:"shim_installed"`
-	ShimTarget    string             `json:"shim_target"`
-	PathFixed     bool               `json:"path_fixed"`
-	Notify        *NotifyDeployState `json:"notify,omitempty"`
-	Codex         *CodexDeployState  `json:"codex,omitempty"`
+	BinaryHash    string              `json:"binary_hash"`
+	BinaryVersion string              `json:"binary_version"`
+	ShimInstalled bool                `json:"shim_installed"`
+	ShimTarget    string              `json:"shim_target"`
+	PathFixed     bool                `json:"path_fixed"`
+	Notify        *NotifyDeployState  `json:"notify,omitempty"`
+	Codex         *CodexDeployState   `json:"codex,omitempty"`
+	ClaudeWrapper *ClaudeWrapperState `json:"claude_wrapper,omitempty"`
 }
 
 const remoteDeployPath = "~/.cache/cc-clip/deploy.json"

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -512,3 +512,42 @@ func TestNeedsCodexSetup(t *testing.T) {
 		})
 	}
 }
+
+func TestDeployState_ClaudeWrapperRoundtrip(t *testing.T) {
+	in := &DeployState{
+		BinaryHash:    "sha256:abc",
+		BinaryVersion: "v0.7.1-test",
+		ShimInstalled: true,
+		ShimTarget:    "xclip",
+		ClaudeWrapper: &ClaudeWrapperState{
+			Installed:    true,
+			OriginKind:   "symlink",
+			OriginTarget: "/home/u/.local/share/claude/versions/2.1.132",
+		},
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out DeployState
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ClaudeWrapper == nil {
+		t.Fatal("ClaudeWrapper missing after roundtrip")
+	}
+	if out.ClaudeWrapper.OriginKind != "symlink" {
+		t.Fatalf("OriginKind: got %q, want symlink", out.ClaudeWrapper.OriginKind)
+	}
+}
+
+func TestDeployState_ClaudeWrapperOmitemptyWhenNil(t *testing.T) {
+	in := &DeployState{BinaryHash: "x"}
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "claude_wrapper") {
+		t.Fatalf("nil ClaudeWrapper should be omitted, got: %s", data)
+	}
+}

--- a/internal/shim/local_session_test.go
+++ b/internal/shim/local_session_test.go
@@ -1,0 +1,56 @@
+package shim
+
+import (
+	"io"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// localSession is a SessionExecutor that runs commands locally via bash -c
+// against a configured $HOME (a t.TempDir() in tests). $HOME is set per
+// command so the bash `~` expansion lands in the fake home.
+type localSession struct {
+	home string
+}
+
+func (l *localSession) Exec(cmd string) (string, error) {
+	c := exec.Command("bash", "-c", cmd)
+	c.Env = append(c.Env, "HOME="+l.home, "PATH=/usr/bin:/bin")
+	out, err := c.Output() // stdout only, matches *SSHSession.Exec semantics
+	return strings.TrimSpace(string(out)), err
+}
+
+func (l *localSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+	c := exec.Command("bash", "-c", cmd)
+	c.Env = append(c.Env, "HOME="+l.home, "PATH=/usr/bin:/bin")
+	c.Stdin = stdin
+	out, err := c.CombinedOutput() // combined, matches *SSHSession.ExecWithStdin
+	return string(out), err
+}
+
+func TestLocalSession_ExecStdoutOnly(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	out, err := s.Exec("echo out; echo err >&2")
+	if err != nil {
+		t.Fatalf("Exec failed: %v", err)
+	}
+	if out != "out" {
+		t.Fatalf("expected stdout %q, got %q (stderr should be discarded)", "out", out)
+	}
+}
+
+func TestLocalSession_ExecWithStdinCombined(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	out, err := s.ExecWithStdin("echo out; echo err >&2", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("ExecWithStdin failed: %v", err)
+	}
+	if !strings.Contains(out, "out") || !strings.Contains(out, "err") {
+		t.Fatalf("expected combined output containing both 'out' and 'err', got %q", out)
+	}
+}
+
+func TestLocalSession_ImplementsSessionExecutor(t *testing.T) {
+	var _ SessionExecutor = (*localSession)(nil)
+}

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -294,9 +294,6 @@ func InstallRemoteHookScript(session *SSHSession, port int) error {
 //   - The wrapper script is written via mktemp + chmod + atomic mv.
 //   - On re-install over an existing cc-clip wrapper, the wrapper file is
 //     replaced atomically; the existing sidecar is left untouched.
-//
-// This task implements only the "none" branch; other branches return a
-// placeholder error so subsequent tasks (T7-T9) can fill them in.
 func InstallRemoteClaudeWrapper(s SessionExecutor, port int) error {
 	kind, err := classifyClaudeBin(s)
 	if err != nil {
@@ -305,6 +302,8 @@ func InstallRemoteClaudeWrapper(s SessionExecutor, port int) error {
 	switch kind {
 	case claudeBinNone:
 		return installWrapperNoOrigin(s, port)
+	case claudeBinCcWrapper:
+		return installWrapperOverwriteSelf(s, port)
 	case claudeBinRegular, claudeBinSymlink:
 		return installWrapperWithSidecar(s, port)
 	default:
@@ -366,6 +365,26 @@ trap - EXIT  # tmp now consumed by the mv`
 	outErr, err := s.ExecWithStdin(cmd, strings.NewReader(script))
 	if err != nil {
 		return fmt.Errorf("install (with-sidecar): %s: %w", strings.TrimSpace(outErr), err)
+	}
+	return nil
+}
+
+// installWrapperOverwriteSelf replaces our own previous wrapper at
+// ~/.local/bin/claude via mktemp + atomic mv. The sidecar is left untouched
+// because we already own the claude path (it's our wrapper, not user state).
+func installWrapperOverwriteSelf(s SessionExecutor, port int) error {
+	script := ClaudeWrapperScript(port)
+	cmd := `set -e
+mkdir -p "$HOME/.local/bin"
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp"
+chmod +x "$tmp"
+mv "$tmp" "$HOME/.local/bin/claude"
+trap - EXIT`
+	out, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+	if err != nil {
+		return fmt.Errorf("install (cc_wrapper overwrite): %s: %w", strings.TrimSpace(out), err)
 	}
 	return nil
 }

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -522,6 +522,53 @@ mv "$HOME/.local/bin/claude.cc-clip-bak" "$target"`)
 	return nil
 }
 
+// UninstallRemoteClaudeWrapper removes the cc-clip claude wrapper from
+// ~/.local/bin/claude and restores the origin from ~/.local/bin/claude.cc-clip-real.
+//
+// Safety: refuses if ~/.local/bin/claude is not a cc-clip wrapper (i.e. the
+// user replaced it with their own file). In that case, returns an error
+// without touching anything.
+//
+// If a v0.7.0-era ~/.local/bin/claude.cc-clip-bak file exists, it is left
+// in place — recovery of that backup is the user's call (see
+// RecoverV070Corruption + --auto-recover).
+func UninstallRemoteClaudeWrapper(s SessionExecutor) error {
+	// Verify file at claude is a cc-clip wrapper (and exists).
+	out, err := s.Exec(`p="$HOME/.local/bin/claude"
+if [ ! -e "$p" ] && [ ! -L "$p" ]; then echo absent; exit 0; fi
+if [ -L "$p" ] || [ ! -f "$p" ]; then echo notwrapper; exit 0; fi
+if head -c 256 "$p" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+    echo wrapper
+else
+    echo notwrapper
+fi`)
+	if err != nil {
+		return fmt.Errorf("uninstall: classify failed: %w", err)
+	}
+	switch strings.TrimSpace(out) {
+	case "absent":
+		return nil
+	case "notwrapper":
+		return fmt.Errorf("uninstall: ~/.local/bin/claude is not a cc-clip wrapper; refusing to remove")
+	case "wrapper":
+		// proceed
+	default:
+		return fmt.Errorf("uninstall: unexpected classify output %q", strings.TrimSpace(out))
+	}
+
+	// Remove wrapper, restore origin from sidecar if present.
+	cmd := `set -e
+rm "$HOME/.local/bin/claude"
+if [ -e "$HOME/.local/bin/claude.cc-clip-real" ] || [ -L "$HOME/.local/bin/claude.cc-clip-real" ]; then
+    mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude"
+fi`
+	outErr, err := s.Exec(cmd)
+	if err != nil {
+		return fmt.Errorf("uninstall: %s: %w", strings.TrimSpace(outErr), err)
+	}
+	return nil
+}
+
 // DetectV070Corruption returns true when the remote exhibits the exact
 // filesystem state produced by v0.7.0's buggy InstallRemoteClaudeWrapper:
 //

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -283,28 +283,45 @@ func InstallRemoteHookScript(session *SSHSession, port int) error {
 	return nil
 }
 
-// InstallRemoteClaudeWrapper installs the claude wrapper script to
-// ~/.local/bin/claude on the remote. The wrapper auto-injects notification
-// hooks via --settings when the cc-clip tunnel is alive, and transparently
-// passes through to the real claude binary when the tunnel is down.
+// InstallRemoteClaudeWrapper installs the claude wrapper to ~/.local/bin/claude
+// on the remote, using a symlink-safe topology that never overwrites the real
+// claude binary even when ~/.local/bin/claude is a symlink to a versions store
+// (Anthropic Native Installer layout, see issue #55).
 //
-// If an existing file at ~/.local/bin/claude is found that is NOT a cc-clip
-// wrapper, it is backed up to ~/.local/bin/claude.cc-clip-bak before overwriting.
-// The backup can be restored by cc-clip uninstall or manually.
-func InstallRemoteClaudeWrapper(session *SSHSession, port int) error {
-	// Check if an existing non-cc-clip wrapper exists and back it up.
-	out, _ := session.Exec("head -5 ~/.local/bin/claude 2>/dev/null || true")
-	if out != "" && !strings.Contains(out, "cc-clip claude wrapper") {
-		session.Exec("cp ~/.local/bin/claude ~/.local/bin/claude.cc-clip-bak 2>/dev/null || true")
+// Topology:
+//   - The original entry (regular file or symlink) is renamed to
+//     ~/.local/bin/claude.cc-clip-real.
+//   - The wrapper script is written via mktemp + chmod + atomic mv.
+//   - On re-install over an existing cc-clip wrapper, the wrapper file is
+//     replaced atomically; the existing sidecar is left untouched.
+//
+// This task implements only the "none" branch; other branches return a
+// placeholder error so subsequent tasks (T7-T9) can fill them in.
+func InstallRemoteClaudeWrapper(s SessionExecutor, port int) error {
+	kind, err := classifyClaudeBin(s)
+	if err != nil {
+		return fmt.Errorf("install: classify failed: %w", err)
 	}
+	switch kind {
+	case claudeBinNone:
+		return installWrapperNoOrigin(s, port)
+	default:
+		return fmt.Errorf("install: unsupported origin kind %q (more branches added in later tasks)", kind)
+	}
+}
 
+// installWrapperNoOrigin writes the wrapper to a fresh ~/.local/bin/claude
+// when no prior file exists. No sidecar is created.
+func installWrapperNoOrigin(s SessionExecutor, port int) error {
 	script := ClaudeWrapperScript(port)
-	args := append(session.connArgs(), session.host,
-		"mkdir -p ~/.local/bin && cat > ~/.local/bin/claude && chmod +x ~/.local/bin/claude")
-	cmd := exec.Command("ssh", args...)
-	cmd.Stdin = strings.NewReader(script)
-	if outErr, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("failed to install remote claude wrapper: %s: %w", strings.TrimSpace(string(outErr)), err)
+	cmd := `mkdir -p "$HOME/.local/bin" && \
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX") && \
+cat > "$tmp" && \
+chmod +x "$tmp" && \
+mv "$tmp" "$HOME/.local/bin/claude"`
+	out, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+	if err != nil {
+		return fmt.Errorf("install (none): %s: %w", strings.TrimSpace(out), err)
 	}
 	return nil
 }
@@ -379,6 +396,17 @@ func WriteRemoteSessionID(session *SSHSession, sessionID string) error {
 	}
 	return nil
 }
+
+// claudeBinKind values returned by classifyClaudeBin. Using named constants
+// (rather than bare strings) so the switch statements in install/uninstall
+// fail at compile time if a typo or rename is ever introduced.
+const (
+	claudeBinNone      = "none"
+	claudeBinCcWrapper = "cc_wrapper"
+	claudeBinSymlink   = "symlink"
+	claudeBinRegular   = "regular"
+	claudeBinOther     = "other"
+)
 
 // classifyClaudeBin inspects ~/.local/bin/claude on the remote and returns
 // one of: "none", "cc_wrapper", "symlink", "regular", "other".

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -305,8 +305,10 @@ func InstallRemoteClaudeWrapper(s SessionExecutor, port int) error {
 	switch kind {
 	case claudeBinNone:
 		return installWrapperNoOrigin(s, port)
+	case claudeBinRegular, claudeBinSymlink:
+		return installWrapperWithSidecar(s, port)
 	default:
-		return fmt.Errorf("install: unsupported origin kind %q (more branches added in later tasks)", kind)
+		return fmt.Errorf("install: unsupported origin kind %q", kind)
 	}
 }
 
@@ -322,6 +324,48 @@ mv "$tmp" "$HOME/.local/bin/claude"`
 	out, err := s.ExecWithStdin(cmd, strings.NewReader(script))
 	if err != nil {
 		return fmt.Errorf("install (none): %s: %w", strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
+// installWrapperWithSidecar handles the regular-file and symlink origin kinds:
+// stage the origin to ~/.local/bin/claude.cc-clip-real, then commit the wrapper.
+// Uses prepare-then-commit ordering so failures before the final mv leave the
+// user's claude untouched, and failures after staging trigger a best-effort
+// rollback that restores the origin.
+//
+// Pre-flight refuses if the sidecar path already exists (regular file, symlink,
+// or directory). The user must remove a stale sidecar manually before re-running.
+// Refusing rather than overwriting avoids the silent-corruption footgun where
+// the sidecar path is a directory and `mv claude .cc-clip-real` would move
+// claude INTO the directory rather than rename to it.
+func installWrapperWithSidecar(s SessionExecutor, port int) error {
+	// Pre-flight: refuse if sidecar already exists.
+	out, _ := s.Exec(`if test -e "$HOME/.local/bin/claude.cc-clip-real" || test -L "$HOME/.local/bin/claude.cc-clip-real"; then echo conflict; fi`)
+	if strings.TrimSpace(out) == "conflict" {
+		return fmt.Errorf("install: ~/.local/bin/claude.cc-clip-real already exists; remove it manually and re-run")
+	}
+
+	script := ClaudeWrapperScript(port)
+	cmd := `set -e
+mkdir -p "$HOME/.local/bin"
+tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+cat > "$tmp"
+chmod +x "$tmp"
+# Stage origin to sidecar (mv on a symlink renames the link itself,
+# never reads/writes through it).
+mv "$HOME/.local/bin/claude" "$HOME/.local/bin/claude.cc-clip-real"
+# Commit wrapper.
+if ! mv "$tmp" "$HOME/.local/bin/claude"; then
+    # Best-effort rollback: restore origin so user's claude keeps working.
+    mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude" 2>/dev/null || true
+    exit 1
+fi
+trap - EXIT  # tmp now consumed by the mv`
+	outErr, err := s.ExecWithStdin(cmd, strings.NewReader(script))
+	if err != nil {
+		return fmt.Errorf("install (with-sidecar): %s: %w", strings.TrimSpace(outErr), err)
 	}
 	return nil
 }

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -569,41 +569,114 @@ fi`
 	return nil
 }
 
-// DetectV070Corruption returns true when the remote exhibits the exact
-// filesystem state produced by v0.7.0's buggy InstallRemoteClaudeWrapper:
+// V070State classifies the v0.7.0 wrapper-install bug aftermath into three
+// outcomes that the CLI N0 gate must distinguish:
 //
-//   C1: ~/.local/bin/claude is a symlink.
-//   C2: The symlink target's first 256 bytes contain the cc-clip wrapper marker.
-//   C3: ~/.local/bin/claude.cc-clip-bak exists as a regular file.
-//   C4: That backup is larger than 1 MiB.
-//   C5: That backup is NOT itself a cc-clip wrapper (guards against a double-
-//       install pathology where both target and backup are wrappers).
+//   V070NotCorrupted   : safe to proceed with install; either there is no
+//                        symlink at ~/.local/bin/claude, the symlink target
+//                        is not a cc-clip wrapper, or the target file does
+//                        not exist (broken symlink) — i.e. C1 or C2 failed.
+//   V070Recoverable    : C1..C5 all hold; --auto-recover can migrate the
+//                        backup at ~/.local/bin/claude.cc-clip-bak back to
+//                        the symlink target.
+//   V070NonRecoverable : C1+C2 hold (~/.local/bin/claude IS a symlink whose
+//                        target is a cc-clip wrapper) but the backup file
+//                        is missing, too small, or is itself a wrapper.
+//                        Auto-recovery cannot fix this — the real Native
+//                        Installer binary is lost. Operator must reinstall
+//                        Claude Code via curl https://claude.ai/install.sh
+//                        before re-running cc-clip.
 //
-// All five conditions must be true to return corrupted=true. The check is
-// strictly read-only — nothing is modified.
-func DetectV070Corruption(s SessionExecutor) (bool, error) {
+// The three-state split closes the fail-open gap that existed when the
+// detector only returned a boolean: previously, "target is wrapper but
+// backup is missing" collapsed into the same false branch as "no corruption
+// at all", and the install path proceeded unconditionally, layering a fresh
+// wrapper on top of an already-broken Native Installer layout.
+type V070State int
+
+const (
+	V070NotCorrupted V070State = iota
+	V070Recoverable
+	V070NonRecoverable
+)
+
+// String returns a stable short name suitable for diagnostic output.
+func (s V070State) String() string {
+	switch s {
+	case V070NotCorrupted:
+		return "not_corrupted"
+	case V070Recoverable:
+		return "recoverable"
+	case V070NonRecoverable:
+		return "non_recoverable"
+	default:
+		return "unknown"
+	}
+}
+
+// DetectV070State classifies the remote into one of three v0.7.0 states
+// and returns a stable diag token that pinpoints which condition decided
+// the outcome (useful for logs and tests). The check is strictly read-only.
+//
+// Diag tokens are stable identifiers (not human prose):
+//
+//   not_corrupted_C1_not_symlink     : ~/.local/bin/claude is not a symlink
+//   not_corrupted_C2_target_missing  : symlink target does not exist
+//   not_corrupted_C2_not_wrapper     : symlink target is not a cc-clip wrapper
+//   recoverable                       : all five conditions hold; auto-fix viable
+//   non_recoverable_C3_backup_missing : target IS wrapper but no backup
+//   non_recoverable_C4_backup_too_small : backup < 1 MiB (cannot be real binary)
+//   non_recoverable_C5_backup_is_wrapper : backup is itself a cc-clip wrapper
+//
+// Decision boundary: C1 and C2 are "is the install path actually broken?"
+// gates. If either fails, we are NOT corrupted — proceed with install. Only
+// after C1+C2 hold do C3/C4/C5 distinguish recoverable from non-recoverable.
+func DetectV070State(s SessionExecutor) (V070State, string, error) {
 	out, err := s.Exec(`set -e
 claude="$HOME/.local/bin/claude"
 bak="$HOME/.local/bin/claude.cc-clip-bak"
 # C1: claude is a symlink.
-[ -L "$claude" ] || { echo notcorrupted; exit 0; }
-# C2: target contains wrapper marker.
-target=$(readlink -f "$claude") || { echo notcorrupted; exit 0; }
-[ -f "$target" ] || { echo notcorrupted; exit 0; }
-head -c 256 "$target" 2>/dev/null | grep -qF "# cc-clip claude wrapper" || { echo notcorrupted; exit 0; }
+[ -L "$claude" ] || { echo not_corrupted_C1_not_symlink; exit 0; }
+# C2: target exists and contains wrapper marker.
+target=$(readlink -f "$claude") || { echo not_corrupted_C2_target_missing; exit 0; }
+[ -f "$target" ] || { echo not_corrupted_C2_target_missing; exit 0; }
+head -c 256 "$target" 2>/dev/null | grep -qF "# cc-clip claude wrapper" || { echo not_corrupted_C2_not_wrapper; exit 0; }
+# At this point C1+C2 hold: target IS a wrapper. Any failure below is non-recoverable.
 # C3: backup is a regular file.
-[ -f "$bak" ] || { echo notcorrupted; exit 0; }
+[ -f "$bak" ] || { echo non_recoverable_C3_backup_missing; exit 0; }
 # C4: backup > 1 MiB.
 size=$(wc -c < "$bak" | tr -d ' ')
-[ "$size" -gt 1048576 ] || { echo notcorrupted; exit 0; }
-# C5: backup is NOT a wrapper.
+[ "$size" -gt 1048576 ] || { echo non_recoverable_C4_backup_too_small; exit 0; }
+# C5: backup is NOT itself a wrapper.
 if head -c 256 "$bak" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
-    echo notcorrupted
+    echo non_recoverable_C5_backup_is_wrapper
     exit 0
 fi
-echo corrupted`)
+echo recoverable`)
 	if err != nil {
-		return false, fmt.Errorf("detect v0.7.0 corruption: %w", err)
+		return V070NotCorrupted, "", fmt.Errorf("detect v0.7.0 state: %w", err)
 	}
-	return strings.TrimSpace(out) == "corrupted", nil
+	diag := strings.TrimSpace(out)
+	switch {
+	case strings.HasPrefix(diag, "not_corrupted"):
+		return V070NotCorrupted, diag, nil
+	case diag == "recoverable":
+		return V070Recoverable, diag, nil
+	case strings.HasPrefix(diag, "non_recoverable"):
+		return V070NonRecoverable, diag, nil
+	default:
+		return V070NotCorrupted, diag, fmt.Errorf("detect v0.7.0 state: unexpected diag %q", diag)
+	}
+}
+
+// DetectV070Corruption is the boolean compat wrapper kept for RecoverV070Corruption's
+// TOCTOU re-check. Returns true only on V070Recoverable — never on V070NonRecoverable,
+// because Recover would be unsafe in that state. Use DetectV070State for callers
+// that need to distinguish all three outcomes (i.e. the N0 gate).
+func DetectV070Corruption(s SessionExecutor) (bool, error) {
+	state, _, err := DetectV070State(s)
+	if err != nil {
+		return false, err
+	}
+	return state == V070Recoverable, nil
 }

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -498,6 +498,30 @@ echo other`)
 	return strings.TrimSpace(out), nil
 }
 
+// RecoverV070Corruption migrates the v0.7.0 backup file (which contains the
+// real claude binary) back to the symlink's target path, restoring the
+// original Native Installer layout. After this call, the caller is expected
+// to re-run InstallRemoteClaudeWrapper to install a v0.7.1+ wrapper safely.
+//
+// This function re-verifies all five corruption conditions inside the same
+// SSH session before doing anything destructive (TOCTOU guard).
+func RecoverV070Corruption(s SessionExecutor) error {
+	corrupted, err := DetectV070Corruption(s)
+	if err != nil {
+		return fmt.Errorf("recover: re-detection failed: %w", err)
+	}
+	if !corrupted {
+		return fmt.Errorf("recover: corruption no longer detected; refusing to migrate backup")
+	}
+	out, err := s.Exec(`set -e
+target=$(readlink -f "$HOME/.local/bin/claude")
+mv "$HOME/.local/bin/claude.cc-clip-bak" "$target"`)
+	if err != nil {
+		return fmt.Errorf("recover: migrate backup: %s: %w", strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
 // DetectV070Corruption returns true when the remote exhibits the exact
 // filesystem state produced by v0.7.0's buggy InstallRemoteClaudeWrapper:
 //

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -379,3 +379,30 @@ func WriteRemoteSessionID(session *SSHSession, sessionID string) error {
 	}
 	return nil
 }
+
+// classifyClaudeBin inspects ~/.local/bin/claude on the remote and returns
+// one of: "none", "cc_wrapper", "symlink", "regular", "other".
+//
+// "cc_wrapper" means a regular file whose first 256 bytes contain the
+// cc-clip wrapper marker — i.e. our previous install. Used to skip the
+// sidecar staging step on re-install (we just overwrite our own wrapper).
+//
+// Inspection is read-only; nothing is modified.
+func classifyClaudeBin(s SessionExecutor) (string, error) {
+	out, err := s.Exec(`p="$HOME/.local/bin/claude"
+if [ ! -e "$p" ] && [ ! -L "$p" ]; then echo none; exit 0; fi
+if [ -L "$p" ]; then echo symlink; exit 0; fi
+if [ -f "$p" ]; then
+    if head -c 256 "$p" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+        echo cc_wrapper
+    else
+        echo regular
+    fi
+    exit 0
+fi
+echo other`)
+	if err != nil {
+		return "", fmt.Errorf("classify ~/.local/bin/claude: %w", err)
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -497,3 +497,42 @@ echo other`)
 	}
 	return strings.TrimSpace(out), nil
 }
+
+// DetectV070Corruption returns true when the remote exhibits the exact
+// filesystem state produced by v0.7.0's buggy InstallRemoteClaudeWrapper:
+//
+//   C1: ~/.local/bin/claude is a symlink.
+//   C2: The symlink target's first 256 bytes contain the cc-clip wrapper marker.
+//   C3: ~/.local/bin/claude.cc-clip-bak exists as a regular file.
+//   C4: That backup is larger than 1 MiB.
+//   C5: That backup is NOT itself a cc-clip wrapper (guards against a double-
+//       install pathology where both target and backup are wrappers).
+//
+// All five conditions must be true to return corrupted=true. The check is
+// strictly read-only — nothing is modified.
+func DetectV070Corruption(s SessionExecutor) (bool, error) {
+	out, err := s.Exec(`set -e
+claude="$HOME/.local/bin/claude"
+bak="$HOME/.local/bin/claude.cc-clip-bak"
+# C1: claude is a symlink.
+[ -L "$claude" ] || { echo notcorrupted; exit 0; }
+# C2: target contains wrapper marker.
+target=$(readlink -f "$claude") || { echo notcorrupted; exit 0; }
+[ -f "$target" ] || { echo notcorrupted; exit 0; }
+head -c 256 "$target" 2>/dev/null | grep -qF "# cc-clip claude wrapper" || { echo notcorrupted; exit 0; }
+# C3: backup is a regular file.
+[ -f "$bak" ] || { echo notcorrupted; exit 0; }
+# C4: backup > 1 MiB.
+size=$(wc -c < "$bak" | tr -d ' ')
+[ "$size" -gt 1048576 ] || { echo notcorrupted; exit 0; }
+# C5: backup is NOT a wrapper.
+if head -c 256 "$bak" 2>/dev/null | grep -qF "# cc-clip claude wrapper"; then
+    echo notcorrupted
+    exit 0
+fi
+echo corrupted`)
+	if err != nil {
+		return false, fmt.Errorf("detect v0.7.0 corruption: %w", err)
+	}
+	return strings.TrimSpace(out) == "corrupted", nil
+}

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -4,11 +4,31 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 )
+
+// SessionExecutor abstracts a remote SSH session for install/uninstall/
+// detect/recover testing. *SSHSession satisfies this interface; tests use
+// a localSession stub that runs commands locally against a temp $HOME.
+type SessionExecutor interface {
+	// Exec runs a remote shell command and returns STDOUT only.
+	// Stderr is intentionally discarded to match the existing semantics of
+	// (*SSHSession).Exec — SSH multiplex chatter (control socket noise,
+	// mux_client_forward, etc.) lands on stderr and would otherwise pollute
+	// callers that grep the output for content markers.
+	Exec(cmd string) (stdout string, err error)
+
+	// ExecWithStdin runs a remote shell command with the provided stdin
+	// and returns COMBINED stdout+stderr. Combined output is appropriate
+	// here because this method is used during install/uninstall where
+	// stderr diagnostics (e.g. "mv: cannot create regular file: Permission
+	// denied") are required for actionable error messages.
+	ExecWithStdin(cmd string, stdin io.Reader) (combinedOutput string, err error)
+}
 
 // SSHSession manages a persistent SSH ControlMaster connection for reuse
 // across multiple remote operations, avoiding repeated passphrase prompts.
@@ -122,6 +142,17 @@ func (s *SSHSession) Upload(localPath, remotePath string) error {
 	}
 
 	return nil
+}
+
+// ExecWithStdin runs a remote shell command with the provided stdin via
+// the SSH master connection. Returns combined stdout+stderr output for
+// install/uninstall error diagnostics.
+func (s *SSHSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+	args := append(s.connArgs(), s.host, cmd)
+	c := exec.Command("ssh", args...)
+	c.Stdin = stdin
+	out, err := c.CombinedOutput()
+	return string(out), err
 }
 
 // Close terminates the SSH master connection.

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -231,3 +231,8 @@ func parseUnameOutput(output string) (string, string, error) {
 
 	return goos, goarch, nil
 }
+
+func TestSessionExecutorInterface_StaticConformance(t *testing.T) {
+	// Compile-time assertion: *SSHSession implements SessionExecutor.
+	var _ SessionExecutor = (*SSHSession)(nil)
+}


### PR DESCRIPTION
## Summary

Fixes #55 — v0.7.0's `InstallRemoteClaudeWrapper` overwrote the real `claude` binary at the Native Installer symlink target (`~/.local/share/claude/versions/X.Y.Z`) instead of replacing the symlink at `~/.local/bin/claude`. Root cause: shell `>` redirection and `cp` (without `-d`/`-P`) follow symlinks. The corrupted state left users with `~/.local/bin/claude` → 250MB cc-clip bash wrapper (instead of ELF), and the real Native Installer binary moved to `~/.local/bin/claude.cc-clip-bak`.

This PR ships the complete fix:

1. **Install path** — mv-only topology with explicit `claude.cc-clip-real` sidecar, classify-dispatch over the four possible states of `~/.local/bin/claude` (none / cc_wrapper / symlink / regular), atomic mktemp + final-mv with rollback on any staging failure.
2. **Wrapper exec** — sidecar-first lookup (`$_SIDECAR="$_SELF_DIR/claude.cc-clip-real"`) with PATH-discovery fallback for legacy compat.
3. **v0.7.0 recovery** — N0 gate runs before any remote write. Tri-state `DetectV070State` (NotCorrupted / Recoverable / NonRecoverable) with stable diag tokens. `--auto-recover` flag migrates `claude.cc-clip-bak` back to the symlink target. NonRecoverable state (backup missing / too small / itself a wrapper) is **fail-closed even with `--auto-recover`** — operator must reinstall Claude Code via `curl https://claude.ai/install.sh`.
4. **Symmetric uninstall** — `cc-clip uninstall --host <host>` restores origin from sidecar and only removes the wrapper if it carries the cc-clip marker (refuses to touch user-owned files).
5. **DeployState** — new `ClaudeWrapperState` block tracks install origin for diagnostics.
6. **SessionExecutor seam** — interface introduced so tests can drive install/detect/recover paths with a `localSession` stub backed by `t.TempDir()` + `bash -c`, no SSH required.

## Key design decisions

- **mv not cp.** `cp` without `-d`/`-P` follows symlinks; `mv` on a symlink renames the link itself. Every install branch uses `mv` exclusively. Regression test `TestInstall_DoesNotCorruptSymlinkTarget` locks this behavior.
- **Sidecar-first exec, not PATH-walk in steady state.** The wrapper used to call `which -a claude` and skip its own dir; that was fragile under non-interactive SSH and `~/.local/bin` PATH-priority quirks. New wrapper resolves the real binary via the explicit sidecar path first, with PATH-discovery as fallback only for the upgrade-from-v0.6.x case.
- **Tri-state N0 gate, not boolean.** Earlier iteration returned `bool corrupted`; reviewer (shunmei) caught that this collapsed `(target is wrapper, backup missing)` into the "not corrupted" branch, letting install proceed on a half-broken layout. Tri-state with diag tokens closes the fail-open gap — see commits `820f3dc` and `cddd444`.
- **`--auto-recover` is opt-in.** Default behavior is to abort with a recovery-hint message. This avoids any code path that silently rewrites a Native Installer's binary store without operator consent.
- **`--auto-recover` mutex with `--token-only`.** Enforced at flag-parse time in both `cmdConnect` and `cmdSetup` via shared `rejectAutoRecoverWithTokenOnly` helper.
- **NonRecoverable is hard fail-closed.** Even `--auto-recover` cannot proceed when the backup file is unusable. Continuing would layer a fresh wrapper on top of a permanently broken layout and make later diagnosis harder.

## Verification

- `make test`: all 12 packages pass (`cmd/cc-clip`, `internal/{daemon,doctor,hosts,service,session,setup,shim,token,tunnel,x11bridge,xvfb}`)
- `go test -race ./internal/shim ./cmd/cc-clip -count=1`: clean
- `make vet`: silent
- `make release-preflight`: passes (no asset-format change in this PR)
- `git diff --check main..HEAD`: exit 0
- Security review (`/security-review`): NO_HIGH_CONFIDENCE_FINDINGS after exclusion-filter pass on three real target files

## Test coverage

| Surface | Tests |
|---------|-------|
| `classifyClaudeBin` | 4 cases (none / regular / cc_wrapper / symlink) |
| `InstallRemoteClaudeWrapper` | 8 cases including symlink-corruption regression, sidecar collision, rollback on final-mv failure, mktemp safety, re-install over existing wrapper |
| `DetectV070State` tri-state | 7 cases (3 not_corrupted variants, 1 recoverable, 3 non_recoverable variants) + 3-case boolean compat table |
| `RecoverV070Corruption` | TOCTOU happy path + state-degradation refuse |
| `UninstallRemoteClaudeWrapper` | absent / not-wrapper / wrapper + sidecar-restore cases |
| CLI mutex | Both `connect` and `setup` reject `--auto-recover --token-only` at flag-parse time |

## Manual smoke test passed

Local unit tests use a `localSession` stub that runs bash commands against a `t.TempDir()` fake `$HOME`. To prove the SSH master + ControlMaster integration works on a real Linux remote, all five scenarios were executed end-to-end against a Linux SSH host (Ubuntu 5.15.0-164-generic, x86_64) using the binary built from this branch (commit `cfc32a1`). See the smoke test summary comment below for the full evidence including BuildID stability proof.

**Scenarios verified:**

- [x] Healthy Native Installer baseline: `cc-clip connect <linux-host>` → wrapper installed without touching versions store
- [x] v0.7.0 corruption state manually constructed → `cc-clip connect <linux-host>` aborts at N0 with recoverable-hint message
- [x] Same + `--auto-recover` → recovery succeeds, install proceeds
- [x] NonRecoverable state (delete backup) → `cc-clip connect <linux-host> --auto-recover` fail-closed with manual-recovery instructions
- [x] `cc-clip uninstall --host <linux-host>` → wrapper removed, sidecar restored to `claude`, versions store untouched

The Native Installer's versions binary (`~/.local/share/claude/versions/2.1.138`, BuildID `72bff399c385b07004f1478b1a747ce5490762f1`) remained byte-identical across all five scenarios — direct ground-truth refutation of issue #55.

## Out of scope (intentional)

- **Codex `config.toml` section-scoping bug** (separate known issue, breaks `codex login` after `cc-clip connect --codex --force`). Design doc at `docs/superpowers/specs/2026-05-11-codex-config-toml-section-scoping-fix.md` is intentionally left untracked here; it ships in its own branch + issue targeting v0.7.2.
- ClaudeWrapperState population in production install paths (struct exists, populated in tests; deferred to v0.7.2).
- bash-execution wrapper tests for the runtime sidecar-first path (static-string assertions only in this PR).

## Test plan

- [x] `make test` passes
- [x] `make vet` passes
- [x] `go test -race` clean on changed packages
- [x] `git diff --check main..HEAD` clean
- [x] Security review passes (zero ≥8-confidence findings)
- [x] Manual SSH smoke test on real Linux SSH host: 5/5 scenarios passed (see "Manual smoke test passed" section)

## Related issues

Closes #55.

