### PR TITLE
fix(shim): wrap injected Stop/Notification entries in {matcher, hooks: []} per Claude Code hook schema

### DIFF
--- a/internal/shim/claude_wrapper.go
+++ b/internal/shim/claude_wrapper.go
@@ -33,8 +33,8 @@ fi
 if curl -sf --connect-timeout 1 --max-time 2 "http://127.0.0.1:${CC_CLIP_PORT:-%d}/health" >/dev/null 2>&1; then
     exec "$_REAL_CLAUDE" --settings '{
   "hooks": {
-    "Stop": [{"type":"command","command":"cc-clip-hook"}],
-    "Notification": [{"type":"command","command":"cc-clip-hook"}]
+    "Stop": [{"hooks":[{"type":"command","command":"cc-clip-hook"}]}],
+    "Notification": [{"hooks":[{"type":"command","command":"cc-clip-hook"}]}]
   }
 }' "$@"
 else

--- a/internal/shim/claude_wrapper_test.go
+++ b/internal/shim/claude_wrapper_test.go
@@ -1,6 +1,8 @@
 package shim
 
 import (
+	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -87,5 +89,59 @@ func TestClaudeWrapperScript_KeepsPathFallback(t *testing.T) {
 	script := ClaudeWrapperScript(18339)
 	if !strings.Contains(script, "_PATH_DIRS") || !strings.Contains(script, "_SELF_DIR") {
 		t.Fatal("wrapper missing PATH-discovery fallback")
+	}
+}
+
+// TestClaudeWrapperEmitsValidHookSchema is a regression test for the malformed
+// --settings JSON shape that tripped Claude Code 2.x /doctor validation: each
+// event entry MUST have an inner "hooks" array, not a flat {type,command}.
+// See https://github.com/ShunmeiCho/cc-clip/issues/58.
+func TestClaudeWrapperEmitsValidHookSchema(t *testing.T) {
+	script := ClaudeWrapperScript(18339)
+
+	// Extract the JSON payload passed to --settings (single-quoted in bash,
+	// and the JSON itself contains no single quotes).
+	re := regexp.MustCompile(`--settings '(\{[^']*\})'`)
+	m := re.FindStringSubmatch(script)
+	if len(m) != 2 {
+		t.Fatalf("could not extract --settings JSON from wrapper:\n%s", script)
+	}
+
+	var parsed struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher,omitempty"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal([]byte(m[1]), &parsed); err != nil {
+		t.Fatalf("--settings JSON does not parse: %v\npayload: %s", err, m[1])
+	}
+
+	// Every Stop / Notification entry must wrap its commands in {hooks: [...]}.
+	// A flat entry (the pre-fix shape) parses into a zero-length Hooks slice
+	// here and is what Claude Code's /doctor flags as
+	//   "hooks.<Event>.0.hooks: Expected array, but received undefined".
+	for _, event := range []string{"Stop", "Notification"} {
+		entries, ok := parsed.Hooks[event]
+		if !ok || len(entries) == 0 {
+			t.Errorf("expected at least one %s entry; got %v", event, entries)
+			continue
+		}
+		for i, entry := range entries {
+			if len(entry.Hooks) == 0 {
+				t.Errorf("%s[%d].hooks is empty; entry must wrap commands in {hooks: [...]}", event, i)
+			}
+			for j, cmd := range entry.Hooks {
+				if cmd.Type != "command" {
+					t.Errorf("%s[%d].hooks[%d].type = %q, want %q", event, i, j, cmd.Type, "command")
+				}
+				if cmd.Command == "" {
+					t.Errorf("%s[%d].hooks[%d].command is empty", event, i, j)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Wraps the inline `--settings` JSON in `claudeWrapperTemplate` so each Stop/Notification entry has the `{hooks: [...]}` wrapper required by the current Claude Code hook schema.
- Adds a regression test that parses the emitted script and asserts the wrapper shape via `json.Unmarshal`, so this cannot silently regress to flat-shape JSON again.

## Why
See #58. `/doctor` flags the injected settings as invalid because `Stop[0].hooks` and `Notification[0].hooks` are `undefined` — entries lack the inner `hooks` array. The runtime still tolerates the legacy shape, but the validator does not, and a future Claude Code release could promote this to a hard rejection (which would silently disable `cc-clip-hook` for SSH users without warning during `cc-clip connect`).

## Changes
- `internal/shim/claude_wrapper.go`: 2-line template edit, wrap each entry in `{hooks: [...]}`.
- `internal/shim/claude_wrapper_test.go`: new `TestClaudeWrapperEmitsValidHookSchema` parses the emitted script, extracts the JSON passed to `--settings`, and asserts each Stop/Notification entry has a non-empty `hooks` array whose elements have `type: "command"` and a non-empty `command`.

## Test plan
- [ ] `go test ./internal/shim/... -run TestClaudeWrapper -v` — existing tests still pass, new regression test passes.
- [ ] Revert just `claude_wrapper.go` (keep the new test): new regression test fails with `Stop[0].hooks is empty; entry must wrap commands in {hooks: [...]}`.
- [ ] Manual: rerun `cc-clip connect <host>`, open Claude Code, run `/doctor` — no errors on `hooks.Stop.0.hooks` or `hooks.Notification.0.hooks`.

## Notes
Local toolchain on the reporter's machine has no `go`/`gofmt` available, so the new test was validated by visual inspection (tab indentation, balanced braces, alphabetized imports, RE2-compatible regex) rather than `go test`. The CI in this repo only runs on `v*` tags, not on PRs.

Closes #58