### PR TITLE
fix(shim): Claude Code 2.x hook schema + xclip fallback runtime resolver

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -1030,14 +1030,24 @@ func claudeHookConfigJSON() string {
   "hooks": {
     "Notification": [
       {
-        "type": "command",
-        "command": "cc-clip-hook"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cc-clip-hook"
+          }
+        ]
       }
     ],
     "Stop": [
       {
-        "type": "command",
-        "command": "cc-clip-hook"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cc-clip-hook"
+          }
+        ]
       }
     ]
   }

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http/httptest"
 	"os"
 	"os/exec"
@@ -276,6 +277,50 @@ func TestClaudeHookConfigJSONIncludesNotificationAndStop(t *testing.T) {
 	}
 	if strings.Count(cfg, `"command": "cc-clip-hook"`) != 2 {
 		t.Fatalf("expected hook command to appear twice, got %q", cfg)
+	}
+}
+
+func TestClaudeHookConfigJSONUsesClaudeV2HookSchema(t *testing.T) {
+	cfg := claudeHookConfigJSON()
+	assertClaudeV2HookSchema(t, cfg)
+}
+
+type claudeHookSettings struct {
+	Hooks map[string][]claudeHookMatcher `json:"hooks"`
+}
+
+type claudeHookMatcher struct {
+	Matcher string              `json:"matcher"`
+	Hooks   []claudeHookCommand `json:"hooks"`
+}
+
+type claudeHookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+func assertClaudeV2HookSchema(t *testing.T, cfg string) {
+	t.Helper()
+
+	var settings claudeHookSettings
+	if err := json.Unmarshal([]byte(cfg), &settings); err != nil {
+		t.Fatalf("hook config is not valid JSON: %v\n%s", err, cfg)
+	}
+	for _, event := range []string{"Notification", "Stop"} {
+		matchers := settings.Hooks[event]
+		if len(matchers) != 1 {
+			t.Fatalf("%s: expected exactly one matcher entry, got %#v", event, matchers)
+		}
+		if matchers[0].Matcher != "" {
+			t.Fatalf("%s: expected empty matcher, got %q", event, matchers[0].Matcher)
+		}
+		if len(matchers[0].Hooks) != 1 {
+			t.Fatalf("%s: expected exactly one hook command, got %#v", event, matchers[0].Hooks)
+		}
+		cmd := matchers[0].Hooks[0]
+		if cmd.Type != "command" || cmd.Command != "cc-clip-hook" {
+			t.Fatalf("%s: unexpected hook command: %#v", event, cmd)
+		}
 	}
 }
 

--- a/internal/shim/claude_wrapper.go
+++ b/internal/shim/claude_wrapper.go
@@ -33,8 +33,18 @@ fi
 if curl -sf --connect-timeout 1 --max-time 2 "http://127.0.0.1:${CC_CLIP_PORT:-%d}/health" >/dev/null 2>&1; then
     exec "$_REAL_CLAUDE" --settings '{
   "hooks": {
-    "Stop": [{"type":"command","command":"cc-clip-hook"}],
-    "Notification": [{"type":"command","command":"cc-clip-hook"}]
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [{"type":"command","command":"cc-clip-hook"}]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [{"type":"command","command":"cc-clip-hook"}]
+      }
+    ]
   }
 }' "$@"
 else

--- a/internal/shim/claude_wrapper_test.go
+++ b/internal/shim/claude_wrapper_test.go
@@ -1,6 +1,7 @@
 package shim
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -11,12 +12,67 @@ func TestClaudeWrapperContainsHookInjection(t *testing.T) {
 		"--settings",
 		`"Stop"`,
 		`"Notification"`,
+		`"matcher": ""`,
 		"cc-clip-hook",
 		"CC_CLIP_PORT:-18339",
 		"exec \"$_REAL_CLAUDE\"",
 	} {
 		if !strings.Contains(got, needle) {
 			t.Errorf("expected wrapper to contain %q", needle)
+		}
+	}
+}
+
+func TestClaudeWrapperUsesClaudeV2HookSchema(t *testing.T) {
+	script := ClaudeWrapperScript(18339)
+	const marker = "--settings '"
+	start := strings.Index(script, marker)
+	if start == -1 {
+		t.Fatal("wrapper missing --settings JSON")
+	}
+	start += len(marker)
+	end := strings.Index(script[start:], "' \"$@\"")
+	if end == -1 {
+		t.Fatal("wrapper settings JSON terminator not found")
+	}
+	assertClaudeV2HookSchema(t, script[start:start+end])
+}
+
+type claudeHookSettings struct {
+	Hooks map[string][]claudeHookMatcher `json:"hooks"`
+}
+
+type claudeHookMatcher struct {
+	Matcher string              `json:"matcher"`
+	Hooks   []claudeHookCommand `json:"hooks"`
+}
+
+type claudeHookCommand struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+func assertClaudeV2HookSchema(t *testing.T, cfg string) {
+	t.Helper()
+
+	var settings claudeHookSettings
+	if err := json.Unmarshal([]byte(cfg), &settings); err != nil {
+		t.Fatalf("hook config is not valid JSON: %v\n%s", err, cfg)
+	}
+	for _, event := range []string{"Notification", "Stop"} {
+		matchers := settings.Hooks[event]
+		if len(matchers) != 1 {
+			t.Fatalf("%s: expected exactly one matcher entry, got %#v", event, matchers)
+		}
+		if matchers[0].Matcher != "" {
+			t.Fatalf("%s: expected empty matcher, got %q", event, matchers[0].Matcher)
+		}
+		if len(matchers[0].Hooks) != 1 {
+			t.Fatalf("%s: expected exactly one hook command, got %#v", event, matchers[0].Hooks)
+		}
+		cmd := matchers[0].Hooks[0]
+		if cmd.Type != "command" || cmd.Command != "cc-clip-hook" {
+			t.Fatalf("%s: unexpected hook command: %#v", event, cmd)
 		}
 	}
 }

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -17,6 +17,15 @@ CC_CLIP_PROBE_TIMEOUT_MS="${CC_CLIP_PROBE_TIMEOUT_MS:-500}"
 CC_CLIP_FETCH_TIMEOUT_MS="${CC_CLIP_FETCH_TIMEOUT_MS:-5000}"
 CC_CLIP_TOTAL_TIMEOUT_MS="${CC_CLIP_TOTAL_TIMEOUT_MS:-8000}"
 REAL_XCLIP="%s"
+_CC_CLIP_SELF_PATH="${BASH_SOURCE[0]:-$0}"
+case "$_CC_CLIP_SELF_PATH" in
+    */*) _CC_CLIP_SELF_DIR="${_CC_CLIP_SELF_PATH%%/*}" ;;
+    *) _CC_CLIP_SELF_DIR="$(pwd)" ;;
+esac
+if ! _CC_CLIP_SELF_DIR="$(cd "$_CC_CLIP_SELF_DIR" 2>/dev/null && pwd)"; then
+    _CC_CLIP_SELF_DIR="$(pwd)"
+fi
+_CC_CLIP_SELF_FILE="$_CC_CLIP_SELF_DIR/${_CC_CLIP_SELF_PATH##*/}"
 
 _cc_clip_log() {
     if [ "${CC_CLIP_DEBUG:-}" = "1" ]; then
@@ -24,9 +33,47 @@ _cc_clip_log() {
     fi
 }
 
+_cc_clip_resolve_real_xclip() {
+    if [ -n "${REAL_XCLIP:-}" ] && [ -x "$REAL_XCLIP" ]; then
+        local real_parent real_name real_dir real_path
+        case "$REAL_XCLIP" in
+            */*) real_parent="${REAL_XCLIP%%/*}"; real_name="${REAL_XCLIP##*/}" ;;
+            *) real_parent="."; real_name="$REAL_XCLIP" ;;
+        esac
+        real_dir="$(cd "$real_parent" 2>/dev/null && pwd)" || real_dir=""
+        real_path="$real_dir/$real_name"
+        if [ "$real_path" != "$_CC_CLIP_SELF_FILE" ]; then
+            printf '%%s\n' "$REAL_XCLIP"
+            return 0
+        fi
+    fi
+
+    local old_ifs="$IFS"
+    IFS=:
+    local dir
+    for dir in $PATH; do
+        [ -n "$dir" ] || dir="."
+        local abs_dir
+        abs_dir="$(cd "$dir" 2>/dev/null && pwd)" || continue
+        [ "$abs_dir" = "$_CC_CLIP_SELF_DIR" ] && continue
+        if [ -x "$abs_dir/xclip" ] && [ ! -d "$abs_dir/xclip" ]; then
+            IFS="$old_ifs"
+            printf '%%s\n' "$abs_dir/xclip"
+            return 0
+        fi
+    done
+    IFS="$old_ifs"
+    return 1
+}
+
 _cc_clip_fallback() {
-    _cc_clip_log "falling back to real xclip: $REAL_XCLIP $*"
-    exec "$REAL_XCLIP" "$@"
+    local real_xclip
+    if ! real_xclip="$(_cc_clip_resolve_real_xclip)"; then
+        echo "cc-clip-shim: real xclip binary not found; install xclip or remove the cc-clip shim" >&2
+        exit 127
+    fi
+    _cc_clip_log "falling back to real xclip: $real_xclip $*"
+    exec "$real_xclip" "$@"
 }
 
 _cc_clip_read_token() {
@@ -168,6 +215,15 @@ CC_CLIP_SESSION_FILE="${CC_CLIP_SESSION_FILE:-${HOME}/.cache/cc-clip/session.id}
 CC_CLIP_PROBE_TIMEOUT_MS="${CC_CLIP_PROBE_TIMEOUT_MS:-500}"
 CC_CLIP_FETCH_TIMEOUT_MS="${CC_CLIP_FETCH_TIMEOUT_MS:-5000}"
 REAL_WL_PASTE="%s"
+_CC_CLIP_SELF_PATH="${BASH_SOURCE[0]:-$0}"
+case "$_CC_CLIP_SELF_PATH" in
+    */*) _CC_CLIP_SELF_DIR="${_CC_CLIP_SELF_PATH%%/*}" ;;
+    *) _CC_CLIP_SELF_DIR="$(pwd)" ;;
+esac
+if ! _CC_CLIP_SELF_DIR="$(cd "$_CC_CLIP_SELF_DIR" 2>/dev/null && pwd)"; then
+    _CC_CLIP_SELF_DIR="$(pwd)"
+fi
+_CC_CLIP_SELF_FILE="$_CC_CLIP_SELF_DIR/${_CC_CLIP_SELF_PATH##*/}"
 
 _cc_clip_log() {
     if [ "${CC_CLIP_DEBUG:-}" = "1" ]; then
@@ -175,9 +231,47 @@ _cc_clip_log() {
     fi
 }
 
+_cc_clip_resolve_real_wl_paste() {
+    if [ -n "${REAL_WL_PASTE:-}" ] && [ -x "$REAL_WL_PASTE" ]; then
+        local real_parent real_name real_dir real_path
+        case "$REAL_WL_PASTE" in
+            */*) real_parent="${REAL_WL_PASTE%%/*}"; real_name="${REAL_WL_PASTE##*/}" ;;
+            *) real_parent="."; real_name="$REAL_WL_PASTE" ;;
+        esac
+        real_dir="$(cd "$real_parent" 2>/dev/null && pwd)" || real_dir=""
+        real_path="$real_dir/$real_name"
+        if [ "$real_path" != "$_CC_CLIP_SELF_FILE" ]; then
+            printf '%%s\n' "$REAL_WL_PASTE"
+            return 0
+        fi
+    fi
+
+    local old_ifs="$IFS"
+    IFS=:
+    local dir
+    for dir in $PATH; do
+        [ -n "$dir" ] || dir="."
+        local abs_dir
+        abs_dir="$(cd "$dir" 2>/dev/null && pwd)" || continue
+        [ "$abs_dir" = "$_CC_CLIP_SELF_DIR" ] && continue
+        if [ -x "$abs_dir/wl-paste" ] && [ ! -d "$abs_dir/wl-paste" ]; then
+            IFS="$old_ifs"
+            printf '%%s\n' "$abs_dir/wl-paste"
+            return 0
+        fi
+    done
+    IFS="$old_ifs"
+    return 1
+}
+
 _cc_clip_fallback() {
-    _cc_clip_log "falling back to real wl-paste: $REAL_WL_PASTE $*"
-    exec "$REAL_WL_PASTE" "$@"
+    local real_wl_paste
+    if ! real_wl_paste="$(_cc_clip_resolve_real_wl_paste)"; then
+        echo "cc-clip-shim: real wl-paste binary not found; install wl-paste or remove the cc-clip shim" >&2
+        exit 127
+    fi
+    _cc_clip_log "falling back to real wl-paste: $real_wl_paste $*"
+    exec "$real_wl_paste" "$@"
 }
 
 _cc_clip_read_token() {

--- a/internal/shim/template_test.go
+++ b/internal/shim/template_test.go
@@ -21,6 +21,9 @@ func TestXclipShimSubstitutesPortAndRealBinary(t *testing.T) {
 	if !strings.Contains(got, `REAL_XCLIP="/usr/bin/xclip"`) {
 		t.Fatalf("real xclip path substitution missing: %q", got)
 	}
+	if !strings.Contains(got, "_cc_clip_resolve_real_xclip") {
+		t.Fatalf("xclip fallback resolver missing: %q", got)
+	}
 }
 
 func TestWlPasteShimSubstitutesPortAndRealBinary(t *testing.T) {
@@ -30,6 +33,9 @@ func TestWlPasteShimSubstitutesPortAndRealBinary(t *testing.T) {
 	}
 	if !strings.Contains(got, `REAL_WL_PASTE="/usr/bin/wl-paste"`) {
 		t.Fatalf("real wl-paste path substitution missing: %q", got)
+	}
+	if !strings.Contains(got, "_cc_clip_resolve_real_wl_paste") {
+		t.Fatalf("wl-paste fallback resolver missing: %q", got)
 	}
 }
 
@@ -232,5 +238,69 @@ func TestShimInterceptsMatchingInvocations(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestXclipShimFallbackResolvesRealBinaryFromPathWhenConfiguredPathIsMissing(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tmpDir := t.TempDir()
+	realDir := filepath.Join(tmpDir, "real")
+	if err := os.Mkdir(realDir, 0755); err != nil {
+		t.Fatalf("mkdir real dir: %v", err)
+	}
+	sentinel := filepath.Join(tmpDir, "fallback.log")
+	realBin := filepath.Join(realDir, "xclip")
+	fakeScript := "#!/bin/bash\n" +
+		"printf '%s\\n' \"$*\" > \"" + sentinel + "\"\n" +
+		"exit 0\n"
+	if err := os.WriteFile(realBin, []byte(fakeScript), 0755); err != nil {
+		t.Fatalf("write fake real xclip: %v", err)
+	}
+
+	shimPath := filepath.Join(tmpDir, "xclip")
+	if err := os.WriteFile(shimPath, []byte(XclipShim(18339, "/missing/xclip")), 0755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	cmd := exec.Command("bash", shimPath, "-selection", "primary", "-o")
+	cmd.Env = append(os.Environ(), "PATH="+tmpDir+string(os.PathListSeparator)+realDir)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("shim fallback failed: %v (stdout=%q)", err, string(out))
+	}
+	recorded, err := os.ReadFile(sentinel)
+	if err != nil {
+		t.Fatalf("fallback sentinel missing: %v", err)
+	}
+	if got, want := strings.TrimSpace(string(recorded)), "-selection primary -o"; got != want {
+		t.Fatalf("fallback args mismatch\n  got:  %q\n  want: %q", got, want)
+	}
+}
+
+func TestXclipShimFallbackFailsClearlyWhenRealBinaryIsMissing(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tmpDir := t.TempDir()
+	shimPath := filepath.Join(tmpDir, "xclip")
+	if err := os.WriteFile(shimPath, []byte(XclipShim(18339, "/missing/xclip")), 0755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	cmd := exec.Command("bash", shimPath, "-selection", "primary", "-o")
+	cmd.Env = append(os.Environ(), "PATH="+tmpDir)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected fallback failure when real xclip is absent, got success: %q", string(out))
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 127 {
+		t.Fatalf("expected exit 127, got err=%v output=%q", err, string(out))
+	}
+	if !strings.Contains(string(out), "real xclip binary not found") {
+		t.Fatalf("expected clear missing-binary error, got %q", string(out))
 	}
 }


### PR DESCRIPTION
## Summary

Two related fixes surfaced when running v0.7.1 against a real Linux remote with Claude Code 2.x:

1. **Claude Code 2.x hook schema** — the cc-clip claude wrapper injected `--settings` with the v1 hook shape (`{Notification: [{type, command}]}`), but Claude Code 2.x expects matcher-based shape (`{Notification: [{matcher, hooks: []}]}`). On launch, `claude` shows a settings-error menu and refuses to start with the wrapper.
2. **xclip shim fallback path** — `REAL_XCLIP` was baked at install time. If install-time detection picked a path (e.g. `/usr/bin/xclip`) that doesn't actually exist on the remote, every fallback `exec` failed with an opaque error.

## Changes

- `internal/shim/claude_wrapper.go`: wrapper `--settings` JSON now uses Claude Code 2.x matcher schema.
- `cmd/cc-clip/main.go:claudeHookConfigJSON()`: fallback printout when wrapper install fails now matches new schema.
- `internal/shim/template.go`: xclip/wl-paste fallback now resolves the real binary at runtime via `command -v`. If no real binary is found, exits 127 with a clear message instead of blindly `exec`-ing a missing path.
- New lock-in tests for both the JSON schema and the xclip fallback resolver.

## Verification

- `go test ./internal/shim ./cmd/cc-clip -count=1`: green
- `go test -race ./internal/shim ./cmd/cc-clip -count=1`: clean
- `make test`, `make vet`, `git diff --check`: clean
- `make release-preflight` on `e036394`: pass

## Smoke test plan

After merge, against a real Linux SSH remote that was already running v0.7.1:

```bash
cc-clip connect <host> --force
ssh <host> 'claude --version'         # should NOT show settings-error menu
ssh <host> 'xclip -version; echo exit=$?'  # if no real xclip, clear 127 error
```

If both pass, tag v0.7.2.

## Related

- Discovered during real-remote use of v0.7.1 (post-#56).
- Reference: [Claude Code hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks) — hooks are `EventName: [{ matcher, hooks: [...] }]`.

## Test plan

- [x] `make test` passes
- [x] `make vet` passes
- [x] `go test -race` clean on changed packages
- [x] `git diff --check` clean
- [x] `make release-preflight` clean
- [ ] Manual SSH smoke test against real Linux remote (post-merge or pre-merge)