### PR TITLE
fix: harden P0 security and correctness paths

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -176,15 +176,13 @@ Internal (used by deploy):
 
 func getPort() int {
 	port := 18339
-	for i, arg := range os.Args {
-		if arg == "--port" && i+1 < len(os.Args) {
-			if p, err := strconv.Atoi(os.Args[i+1]); err == nil {
-				port = p
-			}
-		}
-	}
 	if env := os.Getenv("CC_CLIP_PORT"); env != "" {
 		if p, err := strconv.Atoi(env); err == nil {
+			port = p
+		}
+	}
+	if flag := getFlag("port", ""); flag != "" {
+		if p, err := strconv.Atoi(flag); err == nil {
 			port = p
 		}
 	}
@@ -192,18 +190,38 @@ func getPort() int {
 }
 
 func getFlag(name, fallback string) string {
-	for i, arg := range os.Args {
-		if arg == "--"+name && i+1 < len(os.Args) {
-			return os.Args[i+1]
-		}
+	if value, ok := flagValue(name); ok {
+		return value
 	}
 	return fallback
 }
 
+func flagValue(name string) (string, bool) {
+	prefix := "--" + name + "="
+	for i, arg := range os.Args {
+		if strings.HasPrefix(arg, prefix) {
+			return strings.TrimPrefix(arg, prefix), true
+		}
+		if arg == "--"+name && i+1 < len(os.Args) {
+			return os.Args[i+1], true
+		}
+	}
+	return "", false
+}
+
 func hasFlag(name string) bool {
+	prefix := "--" + name + "="
 	for _, arg := range os.Args {
 		if arg == "--"+name {
 			return true
+		}
+		if strings.HasPrefix(arg, prefix) {
+			value := strings.TrimPrefix(arg, prefix)
+			enabled, err := strconv.ParseBool(value)
+			if err != nil {
+				return true
+			}
+			return enabled
 		}
 	}
 	return false

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -85,6 +85,60 @@ func helperSleepProcess(t *testing.T) *exec.Cmd {
 	return cmd
 }
 
+func TestGetPortFlagOverridesEnv(t *testing.T) {
+	oldArgs := os.Args
+	oldEnv, hadEnv := os.LookupEnv("CC_CLIP_PORT")
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		if hadEnv {
+			_ = os.Setenv("CC_CLIP_PORT", oldEnv)
+		} else {
+			_ = os.Unsetenv("CC_CLIP_PORT")
+		}
+	})
+
+	os.Args = []string{"cc-clip", "serve", "--port", "19000"}
+	if err := os.Setenv("CC_CLIP_PORT", "18000"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+
+	if got := getPort(); got != 19000 {
+		t.Fatalf("getPort() = %d, want CLI flag to override env with 19000", got)
+	}
+}
+
+func TestManualFlagParsingSupportsEqualsForm(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	os.Args = []string{"cc-clip", "connect", "venus", "--port=19001", "--local-bin=/tmp/cc-clip", "--force=true"}
+
+	if got := getPort(); got != 19001 {
+		t.Fatalf("getPort() = %d, want 19001", got)
+	}
+	if got := getFlag("local-bin", "fallback"); got != "/tmp/cc-clip" {
+		t.Fatalf("getFlag(local-bin) = %q", got)
+	}
+	if !hasFlag("force") {
+		t.Fatal("hasFlag(force) should accept --force=true")
+	}
+}
+
+func TestManualFlagParsingRejectsExplicitFalseBool(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() {
+		os.Args = oldArgs
+	})
+
+	os.Args = []string{"cc-clip", "connect", "venus", "--force=false"}
+
+	if hasFlag("force") {
+		t.Fatal("hasFlag(force) should not treat --force=false as enabled")
+	}
+}
+
 func TestReleaseVersion(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -30,6 +30,13 @@ const (
 	claudeHookCType = "application/x-claude-hook"
 )
 
+const (
+	httpReadHeaderTimeout = 2 * time.Second
+	httpReadTimeout       = 10 * time.Second
+	httpWriteTimeout      = 30 * time.Second
+	httpIdleTimeout       = 60 * time.Second
+)
+
 const notifyChCap = 8
 
 type Server struct {
@@ -67,9 +74,9 @@ func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, se
 
 // nonceEntry tracks metadata for a registered notification nonce.
 type nonceEntry struct {
-	Host       string
-	IssuedAt   time.Time
-	ExpiresAt  time.Time
+	Host      string
+	IssuedAt  time.Time
+	ExpiresAt time.Time
 }
 
 // nonceTTL is the default lifetime for notification nonces.
@@ -240,7 +247,11 @@ func (s *Server) Handler() http.Handler {
 
 // Serve accepts connections on the given listener and serves HTTP.
 func (s *Server) Serve(ln net.Listener) error {
-	return http.Serve(ln, s.mux)
+	if err := requireLoopbackListener(ln.Addr()); err != nil {
+		_ = ln.Close()
+		return err
+	}
+	return s.httpServer().Serve(ln)
 }
 
 func (s *Server) ListenAndServe() error {
@@ -249,30 +260,66 @@ func (s *Server) ListenAndServe() error {
 		return fmt.Errorf("failed to listen on %s: %w", s.addr, err)
 	}
 
-	host, _, _ := net.SplitHostPort(s.addr)
-	if host != "127.0.0.1" && host != "localhost" && host != "::1" {
-		listener.Close()
-		return fmt.Errorf("refusing to listen on non-loopback address: %s", host)
+	if err := requireLoopbackListener(listener.Addr()); err != nil {
+		_ = listener.Close()
+		return err
 	}
 
 	log.Printf("cc-clip daemon listening on %s", s.addr)
-	return http.Serve(listener, s.mux)
+	return s.httpServer().Serve(listener)
+}
+
+func (s *Server) httpServer() *http.Server {
+	return &http.Server{
+		Handler:           s.mux,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		ReadTimeout:       httpReadTimeout,
+		WriteTimeout:      httpWriteTimeout,
+		IdleTimeout:       httpIdleTimeout,
+		MaxHeaderBytes:    1 << 20,
+	}
+}
+
+func requireLoopbackListener(addr net.Addr) error {
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
+		if tcpAddr.IP != nil && tcpAddr.IP.IsLoopback() {
+			return nil
+		}
+		host := "unspecified"
+		if tcpAddr.IP != nil {
+			host = tcpAddr.IP.String()
+		}
+		return fmt.Errorf("refusing to listen on non-loopback address: %s", host)
+	}
+
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return fmt.Errorf("refusing to listen on non-loopback address: %s", addr.String())
+	}
+	if host == "localhost" {
+		return nil
+	}
+	ip := net.ParseIP(host)
+	if ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	return fmt.Errorf("refusing to listen on non-loopback address: %s", host)
 }
 
 func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		// Check User-Agent
-		ua := r.Header.Get("User-Agent")
-		if ua != "" && !strings.HasPrefix(ua, userAgent) {
-			http.Error(w, "forbidden", http.StatusForbidden)
-			return
-		}
-
 		auth := r.Header.Get("Authorization")
 		if !strings.HasPrefix(auth, "Bearer ") {
 			http.Error(w, "missing authorization", http.StatusUnauthorized)
 			return
 		}
+
+		ua := r.Header.Get("User-Agent")
+		if !strings.HasPrefix(ua, userAgent) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
 		tok := strings.TrimPrefix(auth, "Bearer ")
 
 		if err := s.tokens.Validate(tok); err != nil {

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -34,6 +36,53 @@ func newTestServer(clip ClipboardReader) (*Server, string) {
 	store := session.NewStore(12 * time.Hour)
 	srv := NewServer("127.0.0.1:0", clip, tm, store)
 	return srv, s.Token
+}
+
+type staticAddrListener struct {
+	addr net.Addr
+}
+
+func (l staticAddrListener) Accept() (net.Conn, error) {
+	return nil, errors.New("accept should not be reached")
+}
+
+func (l staticAddrListener) Close() error {
+	return nil
+}
+
+func (l staticAddrListener) Addr() net.Addr {
+	return l.addr
+}
+
+func TestServeRejectsNonLoopbackListener(t *testing.T) {
+	srv, _ := newTestServer(&mockClipboard{})
+	err := srv.Serve(staticAddrListener{
+		addr: &net.TCPAddr{IP: net.ParseIP("0.0.0.0"), Port: 18339},
+	})
+	if err == nil || !strings.Contains(err.Error(), "non-loopback") {
+		t.Fatalf("expected non-loopback listener rejection, got %v", err)
+	}
+}
+
+func TestHTTPServerHasDefensiveTimeouts(t *testing.T) {
+	srv, _ := newTestServer(&mockClipboard{})
+	httpSrv := srv.httpServer()
+
+	if httpSrv.Handler != srv.mux {
+		t.Fatal("http server should use server mux")
+	}
+	if httpSrv.ReadHeaderTimeout <= 0 {
+		t.Fatal("ReadHeaderTimeout must be configured")
+	}
+	if httpSrv.ReadTimeout <= 0 {
+		t.Fatal("ReadTimeout must be configured")
+	}
+	if httpSrv.WriteTimeout <= 0 {
+		t.Fatal("WriteTimeout must be configured")
+	}
+	if httpSrv.IdleTimeout <= 0 {
+		t.Fatal("IdleTimeout must be configured")
+	}
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -89,6 +138,20 @@ func TestClipboardTypeWithAuth(t *testing.T) {
 	}
 	if info.Format != "png" {
 		t.Fatalf("expected png format, got %s", info.Format)
+	}
+}
+
+func TestClipboardTypeRejectsMissingUserAgentWithAuth(t *testing.T) {
+	clip := &mockClipboard{clipType: ClipboardInfo{Type: ClipboardImage, Format: "png"}}
+	srv, tok := newTestServer(clip)
+
+	req := httptest.NewRequest("GET", "/clipboard/type", nil)
+	req.Header.Set("Authorization", "Bearer "+tok)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without User-Agent, got %d", w.Code)
 	}
 }
 
@@ -325,6 +388,7 @@ func TestRegisterNonceEndpointRegistersNonce(t *testing.T) {
 	req := httptest.NewRequest("POST", "/register-nonce", body)
 	req.Header.Set("Authorization", "Bearer "+s.Token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip/0.1")
 	w := httptest.NewRecorder()
 
 	srv.mux.ServeHTTP(w, req)
@@ -378,6 +442,7 @@ func TestRegisterNonceEndpointRejectsEmptyNonce(t *testing.T) {
 	req := httptest.NewRequest("POST", "/register-nonce", body)
 	req.Header.Set("Authorization", "Bearer "+s.Token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip/0.1")
 	w := httptest.NewRecorder()
 
 	srv.mux.ServeHTTP(w, req)
@@ -398,6 +463,7 @@ func TestRegisterNonceEndpointRejectsInvalidJSON(t *testing.T) {
 	req := httptest.NewRequest("POST", "/register-nonce", body)
 	req.Header.Set("Authorization", "Bearer "+s.Token)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "cc-clip/0.1")
 	w := httptest.NewRecorder()
 
 	srv.mux.ServeHTTP(w, req)

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -86,7 +87,7 @@ func (m *Manager) Validate(tok string) error {
 	if time.Now().After(m.session.ExpiresAt) {
 		return ErrTokenExpired
 	}
-	if m.session.Token != strings.TrimSpace(tok) {
+	if !constantTimeTokenEqual(m.session.Token, strings.TrimSpace(tok)) {
 		return ErrTokenInvalid
 	}
 
@@ -99,6 +100,13 @@ func (m *Manager) Validate(tok string) error {
 	}
 
 	return nil
+}
+
+func constantTimeTokenEqual(expected, candidate string) bool {
+	if len(expected) != len(candidate) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(expected), []byte(candidate)) == 1
 }
 
 func (m *Manager) Current() *Session {

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -36,6 +36,18 @@ func TestValidateWrongToken(t *testing.T) {
 	}
 }
 
+func TestConstantTimeTokenEqual(t *testing.T) {
+	if !constantTimeTokenEqual("abc123", "abc123") {
+		t.Fatal("expected equal tokens to match")
+	}
+	if constantTimeTokenEqual("abc123", "abc124") {
+		t.Fatal("expected different tokens of equal length to be rejected")
+	}
+	if constantTimeTokenEqual("abc123", "abc1234") {
+		t.Fatal("expected different-length tokens to be rejected")
+	}
+}
+
 func TestValidateExpired(t *testing.T) {
 	m := NewManager(1 * time.Millisecond)
 

--- a/internal/tunnel/fetch.go
+++ b/internal/tunnel/fetch.go
@@ -15,6 +15,8 @@ import (
 	"github.com/shunmei/cc-clip/internal/daemon"
 )
 
+var randReader io.Reader = rand.Reader
+
 var (
 	ErrNoImage      = errors.New("no image in clipboard")
 	ErrTokenInvalid = errors.New("token invalid or expired")
@@ -96,9 +98,11 @@ func (c *Client) FetchImage(outDir string) (string, error) {
 		ext = "jpg"
 	}
 
-	randBytes := make([]byte, 4)
-	rand.Read(randBytes)
-	filename := fmt.Sprintf("%s-%s.%s", time.Now().Format("20060102-150405"), hex.EncodeToString(randBytes), ext)
+	suffix, err := randomHexSuffix(4)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate filename suffix: %w", err)
+	}
+	filename := fmt.Sprintf("%s-%s.%s", time.Now().Format("20060102-150405"), suffix, ext)
 	outPath := filepath.Join(outDir, filename)
 
 	f, err := os.Create(outPath)
@@ -113,6 +117,14 @@ func (c *Client) FetchImage(outDir string) (string, error) {
 	}
 
 	return outPath, nil
+}
+
+func randomHexSuffix(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := io.ReadFull(randReader, b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }
 
 func DefaultOutDir() string {

--- a/internal/tunnel/fetch_test.go
+++ b/internal/tunnel/fetch_test.go
@@ -8,11 +8,20 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/shunmei/cc-clip/internal/daemon"
 )
+
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read([]byte) (int, error) {
+	return 0, r.err
+}
 
 // newIPv4TestServer creates an httptest server bound to 127.0.0.1 (IPv4 only).
 // Returns nil and skips the test if binding fails (restricted sandbox/CI).
@@ -100,6 +109,41 @@ func TestFetchImageUnauthorized(t *testing.T) {
 	}
 	if !errors.Is(err, ErrTokenInvalid) {
 		t.Fatalf("expected ErrTokenInvalid, got: %v", err)
+	}
+}
+
+func TestFetchImageFailsWhenRandomSuffixGenerationFails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /clipboard/image", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write([]byte("png-data"))
+	})
+
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	oldReader := randReader
+	randReader = failingReader{err: errors.New("entropy unavailable")}
+	defer func() {
+		randReader = oldReader
+	}()
+
+	client := NewClient(ts.URL, "test-token", 5*time.Second)
+	outDir := t.TempDir()
+	_, err := client.FetchImage(outDir)
+	if err == nil {
+		t.Fatal("expected random suffix generation error")
+	}
+	if !strings.Contains(err.Error(), "filename suffix") {
+		t.Fatalf("expected filename suffix error, got %v", err)
+	}
+
+	entries, readErr := os.ReadDir(outDir)
+	if readErr != nil {
+		t.Fatalf("failed to read output dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no partial files, found %d", len(entries))
 	}
 }
 

--- a/internal/x11bridge/bridge.go
+++ b/internal/x11bridge/bridge.go
@@ -24,6 +24,8 @@ const (
 	// defaultChunkSize is the INCR chunk size (64KB is a safe, common choice).
 	defaultChunkSize = 64 * 1024
 
+	changePropertyRequestOverheadBytes = 24
+
 	// httpTimeout is the timeout for HTTP requests to the cc-clip daemon.
 	httpTimeout = 5 * time.Second
 )
@@ -125,18 +127,11 @@ func (b *Bridge) Run(ctx context.Context) error {
 	errors := make(chan xgb.Error, 16)
 
 	go func() {
+		defer close(events)
+		defer close(errors)
 		for {
 			ev, err := b.conn.WaitForEvent()
-			if ev != nil {
-				events <- ev
-			}
-			if err != nil {
-				errors <- err
-			}
-			if ev == nil && err == nil {
-				// Connection closed.
-				close(events)
-				close(errors)
+			if !publishXEvent(ctx, events, errors, ev, err) {
 				return
 			}
 		}
@@ -155,6 +150,9 @@ func (b *Bridge) Run(ctx context.Context) error {
 
 		case ev, ok := <-events:
 			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				return fmt.Errorf("X11 connection closed")
 			}
 
@@ -202,6 +200,9 @@ func (b *Bridge) Run(ctx context.Context) error {
 
 		case xerr, ok := <-errors:
 			if !ok {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				return fmt.Errorf("X11 connection closed")
 			}
 			// Log X11 protocol errors but continue running.
@@ -233,6 +234,27 @@ func (b *Bridge) claimOwnership() error {
 	b.timestamp = xproto.TimeCurrentTime
 	log.Printf("x11-bridge: claimed CLIPBOARD ownership")
 	return nil
+}
+
+func publishXEvent(ctx context.Context, events chan<- xgb.Event, errors chan<- xgb.Error, ev xgb.Event, xerr xgb.Error) bool {
+	if ev == nil && xerr == nil {
+		return false
+	}
+	if ev != nil {
+		select {
+		case events <- ev:
+		case <-ctx.Done():
+			return false
+		}
+	}
+	if xerr != nil {
+		select {
+		case errors <- xerr:
+		case <-ctx.Done():
+			return false
+		}
+	}
+	return true
 }
 
 // handleTargets responds to a TARGETS request.
@@ -267,11 +289,7 @@ func (b *Bridge) handleImage(event xproto.SelectionRequestEvent) {
 	}
 
 	// Determine max direct transfer size from X server's max request length.
-	maxDirect := defaultMaxDirectSize
-	maxReq := xproto.Setup(b.conn).MaximumRequestLength
-	if maxReq > 0 {
-		maxDirect = int(maxReq) * 4 / 4 // conservative: use 1/4 of max
-	}
+	maxDirect := maxDirectSizeFromRequestLength(xproto.Setup(b.conn).MaximumRequestLength)
 
 	incrData, err := handleImageRequest(b.conn, event, b.atoms, imageData, maxDirect)
 	if err != nil {
@@ -291,6 +309,17 @@ func (b *Bridge) handleImage(event xproto.SelectionRequestEvent) {
 		b.activeIncr = transfer
 		log.Printf("x11-bridge: started INCR transfer (%d bytes)", len(incrData))
 	}
+}
+
+func maxDirectSizeFromRequestLength(maxReq uint16) int {
+	if maxReq == 0 {
+		return defaultMaxDirectSize
+	}
+	n := int(maxReq)*4 - changePropertyRequestOverheadBytes
+	if n < 0 {
+		return 0
+	}
+	return n
 }
 
 // handleIncrChunk writes the next INCR chunk on PropertyDelete.

--- a/internal/x11bridge/bridge_test.go
+++ b/internal/x11bridge/bridge_test.go
@@ -107,6 +107,41 @@ func TestAtomsToBytes(t *testing.T) {
 	}
 }
 
+func TestMaxDirectSizeFromRequestLengthUsesX11FourByteUnits(t *testing.T) {
+	got := maxDirectSizeFromRequestLength(65535)
+	want := 65535*4 - changePropertyRequestOverheadBytes
+	if got != want {
+		t.Fatalf("max direct size = %d, want %d", got, want)
+	}
+
+	if got := maxDirectSizeFromRequestLength(0); got != defaultMaxDirectSize {
+		t.Fatalf("zero max request should use default %d, got %d", defaultMaxDirectSize, got)
+	}
+
+	if got := maxDirectSizeFromRequestLength(4); got != 0 {
+		t.Fatalf("tiny max request should force INCR, got %d", got)
+	}
+}
+
+func TestPublishXEventStopsWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- publishXEvent(ctx, make(chan xgb.Event), make(chan xgb.Error), xproto.SelectionClearEvent{}, nil)
+	}()
+
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("publishXEvent should report false after context cancellation")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("publishXEvent blocked after context cancellation")
+	}
+}
+
 // --- Helpers for integration tests ---
 
 func requireXvfbAndXclip(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR lands the P0 security/correctness batch as five independently reviewable commits:

1. `fix(daemon): enforce HTTP timeouts and loopback listeners`
   - Uses an explicit `http.Server` with read-header/read/write/idle timeouts.
   - Applies the loopback-only guard to both `ListenAndServe()` and `Serve(listener)`.
   - Requires authenticated daemon endpoints to use the `cc-clip` User-Agent prefix.

2. `fix(token): use constant-time token comparison`
   - Replaces direct token string equality in `token.Manager.Validate` with `subtle.ConstantTimeCompare` behind a small helper.

3. `fix(tunnel): propagate random suffix errors`
   - Stops ignoring entropy failures when generating fetched-image filenames.
   - Ensures no partial output file is created when suffix generation fails.

4. `fix(x11bridge): honor context while publishing events`
   - Makes the X11 event publisher stop on context cancellation rather than blocking forever on channel sends.
   - Fixes direct-transfer size calculation from X11 max request units and covers the fallback/tiny-request cases.

5. `fix(cli): support equals-form flags`
   - Adds support for `--flag=value` in the existing manual flag parser.
   - Makes CLI `--port` override `CC_CLIP_PORT`.
   - Treats explicit boolean false forms such as `--force=false` as disabled.

## Notes From Review

- The stricter User-Agent gate does not affect `/health` because it is not behind `authMiddleware`.
- Existing cc-clip callers for clipboard/register-nonce paths set explicit cc-clip User-Agent headers.
- The x11bridge context change is a defensive guard; the main shutdown path already closes the X connection.
- The changed `hasFlag()` callers are boolean toggles, so `--codex=false` becoming false is a bug fix, not a behavior regression.

## Verification

- [x] `go test -race ./internal/daemon ./internal/token ./internal/tunnel ./internal/x11bridge ./cmd/cc-clip -count=1`
- [x] `go test ./... -count=1`
- [x] `go vet ./...`
- [x] `git diff --check`
- [x] `make release-preflight`

## Out Of Scope

- P1 silent-error follow-up: swallowed errors, SSH `Exec` error handling, deploy sentinel handling.
- Documentation drift: `deploy-state.json` wording and sidecar mechanism docs.
