### PR TITLE
fix(x11bridge): time out stalled INCR transfers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 7. **pathfix** (`internal/shim/pathfix.go`) — Auto-detects remote shell (bash/zsh/fish) and injects `~/.local/bin` PATH marker into rc file with `# cc-clip-managed` guards.
 8. **service** (`internal/service/launchd.go`) — macOS launchd integration: `Install()`, `Uninstall()`, `Status()`. Generates plist for auto-start daemon.
 9. **xvfb** (`internal/xvfb/`) — Manages Xvfb virtual X server on remote. `StartRemote()` auto-detects display via `-displayfd`, reuses healthy instances, writes PID/display to `~/.cache/cc-clip/codex/`. `StopRemote()` verifies PID+command before killing.
-10. **x11bridge** (`internal/x11bridge/`) — Go X11 selection owner using `github.com/jezek/xgb` (pure Go, no CGo). Claims CLIPBOARD ownership on Xvfb, responds to SelectionRequest events by fetching image data on-demand from the cc-clip HTTP daemon via SSH tunnel. Supports TARGETS negotiation, direct transfer, and INCR protocol for images >256KB.
+10. **x11bridge** (`internal/x11bridge/`) — Go X11 selection owner using `github.com/jezek/xgb` (pure Go, no CGo). Claims CLIPBOARD ownership on Xvfb, responds to SelectionRequest events by fetching image data on-demand from the cc-clip HTTP daemon via SSH tunnel. Supports TARGETS negotiation, direct transfer, and INCR protocol for images >256KB; stalled INCR transfers are cleared after a 30s inactivity timeout so future paste requests are not refused forever.
 
 ### Notification Bridge
 
@@ -80,6 +80,7 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 - **Platform clipboard** — `clipboard_darwin.go` (pngpaste), `clipboard_linux.go` (xclip/wl-paste), `clipboard_windows.go` (PowerShell). Windows uses SCP upload workflow with system tray icon and global hotkey (`Ctrl+Alt+V`).
 - **Codex uses X11, not shims** — Codex CLI uses `arboard` (Rust crate) which accesses X11 CLIPBOARD directly in-process. Cannot be shimmed. Solution: Xvfb + Go X11 selection owner that claims CLIPBOARD and serves images on-demand.
 - **On-demand fetch in x11-bridge** — No polling or caching. Image data is fetched from the cc-clip daemon only when a SelectionRequest arrives. Always fresh.
+- **INCR transfer timeout** — x11-bridge intentionally handles one active INCR transfer at a time. If a requestor starts INCR but stops deleting the transfer property, the bridge clears that transfer after 30s of inactivity and continues serving later requests.
 - **Token per-request in x11-bridge** — Token is read from file on every HTTP request, enabling `--token-only` rotation without restarting the bridge.
 - **DISPLAY injection is file-driven** — The DISPLAY marker block in shell rc reads from `~/.cache/cc-clip/codex/display` at shell startup, not a hardcoded value. This supports `-displayfd` dynamic allocation.
 - **Notification uses nonce auth, not session token** — `/notify` endpoint authenticates with a separate nonce (stored at `~/.cache/cc-clip/notify.nonce`), not the clipboard Bearer token. This allows independent rotation.

--- a/internal/x11bridge/bridge.go
+++ b/internal/x11bridge/bridge.go
@@ -26,9 +26,26 @@ const (
 
 	changePropertyRequestOverheadBytes = 24
 
+	defaultIncrTimeout = 30 * time.Second
+	maxIncrTimeoutTick = time.Second
+
 	// httpTimeout is the timeout for HTTP requests to the cc-clip daemon.
 	httpTimeout = 5 * time.Second
 )
+
+// Option configures a Bridge.
+type Option func(*Bridge)
+
+// WithIncrTimeout sets the inactivity timeout for an INCR transfer. A stalled
+// requestor that never deletes the transfer property is cleared after this
+// duration so future paste requests are not refused forever.
+func WithIncrTimeout(d time.Duration) Option {
+	return func(b *Bridge) {
+		if d > 0 {
+			b.incrTimeout = d
+		}
+	}
+}
 
 // Bridge is an X11 clipboard selection owner that serves image data
 // fetched on-demand from a cc-clip HTTP daemon via SSH tunnel.
@@ -43,8 +60,10 @@ type Bridge struct {
 	atoms     *AtomCache
 	timestamp xproto.Timestamp
 
-	activeIncr *IncrTransfer
-	httpClient *http.Client
+	activeIncr   *IncrTransfer
+	incrTimeout  time.Duration
+	incrDeadline time.Time
+	httpClient   *http.Client
 }
 
 // clipboardTypeResponse mirrors daemon.ClipboardInfo.
@@ -54,7 +73,7 @@ type clipboardTypeResponse struct {
 }
 
 // New creates a Bridge connected to the given X display.
-func New(display string, port int, tokenFile string) (*Bridge, error) {
+func New(display string, port int, tokenFile string, opts ...Option) (*Bridge, error) {
 	conn, err := xgb.NewConnDisplay(display)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to X display %s: %w", display, err)
@@ -68,15 +87,19 @@ func New(display string, port int, tokenFile string) (*Bridge, error) {
 	screen := setup.Roots[0]
 
 	b := &Bridge{
-		display:   display,
-		port:      port,
-		tokenFile: tokenFile,
-		conn:      conn,
-		screen:    &screen,
-		atoms:     NewAtomCache(conn),
+		display:     display,
+		port:        port,
+		tokenFile:   tokenFile,
+		conn:        conn,
+		screen:      &screen,
+		atoms:       NewAtomCache(conn),
+		incrTimeout: defaultIncrTimeout,
 		httpClient: &http.Client{
 			Timeout: httpTimeout,
 		},
+	}
+	for _, opt := range opts {
+		opt(b)
 	}
 
 	// Create an invisible window for selection ownership.
@@ -141,6 +164,8 @@ func (b *Bridge) Run(ctx context.Context) error {
 	targetsAtom := b.atoms.MustGet(AtomNameTargets)
 	timestampAtom, _ := b.atoms.Get(AtomNameTimestamp)
 	imagePNGAtom := b.atoms.MustGet(AtomNameImagePNG)
+	incrTicker := time.NewTicker(incrTimeoutTickInterval(b.incrTimeout))
+	defer incrTicker.Stop()
 
 	for {
 		select {
@@ -158,6 +183,7 @@ func (b *Bridge) Run(ctx context.Context) error {
 
 			switch e := ev.(type) {
 			case xproto.SelectionRequestEvent:
+				b.clearExpiredIncr(time.Now())
 				if e.Selection != clipboardAtom {
 					refuseRequest(b.conn, e)
 					continue
@@ -190,6 +216,7 @@ func (b *Bridge) Run(ctx context.Context) error {
 				}
 
 			case xproto.PropertyNotifyEvent:
+				b.clearExpiredIncr(time.Now())
 				if b.activeIncr != nil &&
 					e.Atom == b.activeIncr.Property &&
 					e.Window == b.activeIncr.Requestor &&
@@ -207,6 +234,9 @@ func (b *Bridge) Run(ctx context.Context) error {
 			}
 			// Log X11 protocol errors but continue running.
 			log.Printf("x11-bridge: X11 error: %v", xerr)
+
+		case now := <-incrTicker.C:
+			b.clearExpiredIncr(now)
 		}
 	}
 }
@@ -306,7 +336,7 @@ func (b *Bridge) handleImage(event xproto.SelectionRequestEvent) {
 			refuseRequest(b.conn, event)
 			return
 		}
-		b.activeIncr = transfer
+		b.startActiveIncr(transfer)
 		log.Printf("x11-bridge: started INCR transfer (%d bytes)", len(incrData))
 	}
 }
@@ -330,14 +360,48 @@ func (b *Bridge) handleIncrChunk() {
 
 	if err := writeNextChunk(b.conn, b.activeIncr); err != nil {
 		log.Printf("x11-bridge: INCR chunk write failed: %v", err)
-		b.activeIncr = nil
+		b.clearActiveIncr()
 		return
 	}
 
 	if b.activeIncr.IsComplete() {
 		log.Printf("x11-bridge: INCR transfer complete")
-		b.activeIncr = nil
+		b.clearActiveIncr()
+		return
 	}
+	b.incrDeadline = time.Now().Add(b.incrTimeout)
+}
+
+func (b *Bridge) startActiveIncr(transfer *IncrTransfer) {
+	b.activeIncr = transfer
+	b.incrDeadline = time.Now().Add(b.incrTimeout)
+}
+
+func (b *Bridge) clearActiveIncr() {
+	b.activeIncr = nil
+	b.incrDeadline = time.Time{}
+}
+
+func (b *Bridge) clearExpiredIncr(now time.Time) {
+	if b.activeIncr == nil || b.incrDeadline.IsZero() || now.Before(b.incrDeadline) {
+		return
+	}
+	log.Printf("x11-bridge: INCR transfer timed out after %s, clearing stalled transfer (window=0x%x)", b.incrTimeout, b.activeIncr.Requestor)
+	b.clearActiveIncr()
+}
+
+func incrTimeoutTickInterval(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return maxIncrTimeoutTick
+	}
+	interval := timeout / 2
+	if interval <= 0 {
+		return time.Millisecond
+	}
+	if interval > maxIncrTimeoutTick {
+		return maxIncrTimeoutTick
+	}
+	return interval
 }
 
 // readToken reads the session token from the token file.

--- a/internal/x11bridge/bridge_test.go
+++ b/internal/x11bridge/bridge_test.go
@@ -123,6 +123,64 @@ func TestMaxDirectSizeFromRequestLengthUsesX11FourByteUnits(t *testing.T) {
 	}
 }
 
+func TestIncrTimeoutTickInterval(t *testing.T) {
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		want    time.Duration
+	}{
+		{
+			name:    "production timeout capped at one second",
+			timeout: 30 * time.Second,
+			want:    time.Second,
+		},
+		{
+			name:    "short test timeout checks faster",
+			timeout: 50 * time.Millisecond,
+			want:    25 * time.Millisecond,
+		},
+		{
+			name:    "non-positive timeout falls back to cap",
+			timeout: 0,
+			want:    time.Second,
+		},
+		{
+			name:    "sub-millisecond timeout still ticks",
+			timeout: time.Nanosecond,
+			want:    time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := incrTimeoutTickInterval(tt.timeout); got != tt.want {
+				t.Fatalf("incrTimeoutTickInterval(%s) = %s, want %s", tt.timeout, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClearExpiredIncr(t *testing.T) {
+	b := &Bridge{
+		activeIncr:   &IncrTransfer{Requestor: 42},
+		incrDeadline: time.Unix(10, 0),
+		incrTimeout:  50 * time.Millisecond,
+	}
+
+	b.clearExpiredIncr(time.Unix(9, 0))
+	if b.activeIncr == nil {
+		t.Fatal("clearExpiredIncr cleared transfer before deadline")
+	}
+
+	b.clearExpiredIncr(time.Unix(10, 0))
+	if b.activeIncr != nil {
+		t.Fatal("clearExpiredIncr should clear transfer at deadline")
+	}
+	if !b.incrDeadline.IsZero() {
+		t.Fatal("clearExpiredIncr should clear deadline")
+	}
+}
+
 func TestPublishXEventStopsWhenContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -335,6 +393,20 @@ func waitForMatchingEvent(t *testing.T, conn *xgb.Conn, timeout time.Duration, m
 
 	t.Fatalf("timed out after %s waiting for matching X11 event", timeout)
 	return nil
+}
+
+func waitForSelectionNotify(t *testing.T, conn *xgb.Conn, window xproto.Window, timeout time.Duration) xproto.SelectionNotifyEvent {
+	t.Helper()
+
+	ev := waitForMatchingEvent(t, conn, timeout, func(ev xgb.Event) bool {
+		notify, ok := ev.(xproto.SelectionNotifyEvent)
+		return ok && notify.Requestor == window
+	})
+	notify, ok := ev.(xproto.SelectionNotifyEvent)
+	if !ok {
+		t.Fatalf("matched event was %T, want SelectionNotifyEvent", ev)
+	}
+	return notify
 }
 
 // --- Integration tests (require Xvfb + xclip) ---
@@ -568,6 +640,135 @@ func TestBridge_ImageLargeINCRSendsFinalZeroLengthChunk(t *testing.T) {
 
 	if !bytes.Equal(received, imageData) {
 		t.Fatalf("INCR payload mismatch: got %d bytes, want %d", len(received), len(imageData))
+	}
+}
+
+func TestBridge_INCRTimeoutAllowsNextImageRequest(t *testing.T) {
+	requireXvfbAndXclip(t)
+	display := startTestXvfb(t)
+
+	imageData := make([]byte, 512*1024)
+	rand.Read(imageData)
+
+	tokenFile := writeTokenFile(t, "test-token")
+	srv := startMockDaemon(t, "image", imageData, "test-token")
+	port := portFromURL(srv.URL)
+
+	bridge, err := New(display, port, tokenFile, WithIncrTimeout(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go bridge.Run(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	conn1, window1, property1 := newX11Requestor(t, display)
+	atoms1 := NewAtomCache(conn1)
+	clipboardAtom1 := atoms1.MustGet(AtomNameClipboard)
+	imagePNGAtom1 := atoms1.MustGet(AtomNameImagePNG)
+	incrAtom1 := atoms1.MustGet(AtomNameIncr)
+
+	if err := xproto.ConvertSelectionChecked(
+		conn1,
+		window1,
+		clipboardAtom1,
+		imagePNGAtom1,
+		property1,
+		xproto.TimeCurrentTime,
+	).Check(); err != nil {
+		t.Fatalf("first ConvertSelection failed: %v", err)
+	}
+	notify1 := waitForSelectionNotify(t, conn1, window1, 2*time.Second)
+	if notify1.Property != property1 {
+		t.Fatalf("first request should start INCR on property %d, got property %d", property1, notify1.Property)
+	}
+	reply1, err := xproto.GetProperty(conn1, false, window1, property1, xproto.GetPropertyTypeAny, 0, math.MaxUint32).Reply()
+	if err != nil {
+		t.Fatalf("first INCR marker GetProperty failed: %v", err)
+	}
+	if reply1.Type != incrAtom1 {
+		t.Fatalf("first request should receive INCR marker type %d, got %d", incrAtom1, reply1.Type)
+	}
+
+	// Do not delete property1. A client that never acknowledges the INCR marker
+	// used to leave activeIncr set forever, causing later image requests to be refused.
+	time.Sleep(150 * time.Millisecond)
+
+	conn2, window2, property2 := newX11Requestor(t, display)
+	atoms2 := NewAtomCache(conn2)
+	clipboardAtom2 := atoms2.MustGet(AtomNameClipboard)
+	imagePNGAtom2 := atoms2.MustGet(AtomNameImagePNG)
+	incrAtom2 := atoms2.MustGet(AtomNameIncr)
+
+	if err := xproto.ConvertSelectionChecked(
+		conn2,
+		window2,
+		clipboardAtom2,
+		imagePNGAtom2,
+		property2,
+		xproto.TimeCurrentTime,
+	).Check(); err != nil {
+		t.Fatalf("second ConvertSelection failed: %v", err)
+	}
+	notify2 := waitForSelectionNotify(t, conn2, window2, 2*time.Second)
+	if notify2.Property == xproto.AtomNone {
+		t.Fatal("second image request was refused; INCR timeout did not clear the stalled transfer")
+	}
+	if notify2.Property != property2 {
+		t.Fatalf("second request property = %d, want %d", notify2.Property, property2)
+	}
+	reply2, err := xproto.GetProperty(conn2, false, window2, property2, xproto.GetPropertyTypeAny, 0, math.MaxUint32).Reply()
+	if err != nil {
+		t.Fatalf("second INCR marker GetProperty failed: %v", err)
+	}
+	if reply2.Type != incrAtom2 {
+		t.Fatalf("second request should receive INCR marker type %d, got %d", incrAtom2, reply2.Type)
+	}
+}
+
+func TestBridge_INCRTimeoutDoesNotBreakCompletedTransfer(t *testing.T) {
+	requireXvfbAndXclip(t)
+	display := startTestXvfb(t)
+
+	imageData := make([]byte, 512*1024)
+	rand.Read(imageData)
+
+	tokenFile := writeTokenFile(t, "test-token")
+	srv := startMockDaemon(t, "image", imageData, "test-token")
+	port := portFromURL(srv.URL)
+
+	bridge, err := New(display, port, tokenFile, WithIncrTimeout(50*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go bridge.Run(ctx)
+	time.Sleep(200 * time.Millisecond)
+
+	cmd := exec.Command("xclip", "-selection", "clipboard", "-t", "image/png", "-o")
+	cmd.Env = append(os.Environ(), "DISPLAY="+display)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("xclip image read failed: %v", err)
+	}
+	if !bytes.Equal(out, imageData) {
+		t.Fatalf("INCR image data mismatch: got %d bytes, want %d", len(out), len(imageData))
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	cmd = exec.Command("xclip", "-selection", "clipboard", "-t", "image/png", "-o")
+	cmd.Env = append(os.Environ(), "DISPLAY="+display)
+	out, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("second xclip image read failed after timeout window: %v", err)
+	}
+	if !bytes.Equal(out, imageData) {
+		t.Fatalf("second INCR image data mismatch: got %d bytes, want %d", len(out), len(imageData))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a 30s inactivity timeout for active X11 INCR transfers so a requestor that never deletes the transfer property cannot block later paste requests forever
- keep timeout handling serialized inside the x11bridge Run loop, including ticker and SelectionRequest/PropertyNotify deadline checks
- add `WithIncrTimeout` for test injection while preserving the existing `New(display, port, tokenFile)` call shape
- document the INCR timeout behavior in `CLAUDE.md`

## Verification
- red first: `go test ./internal/x11bridge -run 'TestBridge_INCRTimeout' -count=1` failed before implementation because timeout injection/behavior did not exist
- `go test ./internal/x11bridge -count=1`
- `go test -race ./internal/x11bridge -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check`
- `make release-preflight`

## Notes
This is intentionally separate from PR #62. PR #62 handled silent deploy-state errors; this PR only hardens long-running x11bridge INCR behavior.
