### PR TITLE
fix(security): keep secrets out of argv

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,6 @@ cc-clip is designed with the following security principles:
 - **Token authentication:** All clipboard API calls require a Bearer token with configurable TTL (default 30d, sliding renewal)
 - **CSPRNG tokens:** Clipboard tokens are 32 random bytes generated with `crypto/rand` and hex-encoded
 - **Constant-time validation:** Token comparison uses constant-time comparison to avoid token timing leaks
-- **User-Agent validation:** API requests must include a `cc-clip` User-Agent header
 - **Token file permissions:** Token files are written with `chmod 600`
 - **SSH tunnel:** All data between local and remote travels through the existing SSH connection
 - **Shim isolation:** The shim only intercepts specific `xclip` / `wl-paste` image invocation patterns; all other calls pass through to the real binary unchanged

--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -356,7 +356,7 @@ func writeTempImage(data []byte, ext string) (string, error) {
 }
 
 func remoteExecNoForward(host, cmd string) (string, error) {
-	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", host, cmd)
+	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, cmd)
 	hideConsoleWindow(c)
 	out, err := c.CombinedOutput()
 	if err != nil {
@@ -380,7 +380,7 @@ func sshUploadNoForward(host, localPath, remotePath string) error {
 	}
 	defer f.Close()
 
-	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", host, sshUploadRemoteCmd(remotePath))
+	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, sshUploadRemoteCmd(remotePath))
 	c.Stdin = f
 	hideConsoleWindow(c)
 	if out, err := c.CombinedOutput(); err != nil {

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -97,7 +97,7 @@ func RunRemote(host string, port int) []CheckResult {
 // Doctor checks should inspect the existing tunnel, not compete with it by opening a new one.
 func remoteExecNoForward(host string, args ...string) (string, error) {
 	cmdStr := strings.Join(args, " ")
-	cmd := exec.Command("ssh", "-o", "ClearAllForwardings=yes", host, cmdStr)
+	cmd := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, cmdStr)
 	hideConsoleWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
@@ -130,14 +130,7 @@ func tunnelOK(results []CheckResult) bool {
 func runImageProbe(host string, port int) []CheckResult {
 	// Run the probe FROM the remote host through the tunnel, not from local.
 	// This validates the full chain: remote -> tunnel -> daemon.
-	cmd := fmt.Sprintf(
-		`TOKEN=$(cat ~/.cache/cc-clip/session.token 2>/dev/null) && `+
-			`curl -sf --max-time 5 `+
-			`-H "Authorization: Bearer ${TOKEN}" `+
-			`-H "User-Agent: cc-clip/0.1" `+
-			`"http://127.0.0.1:%d/clipboard/type"`,
-		port)
-
+	cmd := imageProbeCommand(port)
 	out, err := remoteExecNoForward(host, cmd)
 	if err != nil {
 		return []CheckResult{{"image-probe", false, fmt.Sprintf("remote probe failed: %v (%s)", err, strings.TrimSpace(out))}}
@@ -151,6 +144,16 @@ func runImageProbe(host string, port int) []CheckResult {
 		return []CheckResult{{"image-probe", true, fmt.Sprintf("remote response: %s (copy an image to test)", out)}}
 	}
 	return []CheckResult{{"image-probe", false, fmt.Sprintf("unexpected response: %s", out)}}
+}
+
+func imageProbeCommand(port int) string {
+	return fmt.Sprintf(
+		`TOKEN=$(cat ~/.cache/cc-clip/session.token 2>/dev/null) && `+
+			`{ printf 'header = "Authorization: Bearer %%s"\n' "$TOKEN"; `+
+			`printf 'header = "User-Agent: cc-clip/0.1"\n'; } | `+
+			`curl -sf --max-time 5 -K - `+
+			`"http://127.0.0.1:%d/clipboard/type"`,
+		port)
 }
 
 // checkTokenMatch verifies the remote token matches the local daemon token.

--- a/internal/doctor/remote_test.go
+++ b/internal/doctor/remote_test.go
@@ -1,0 +1,19 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestImageProbeCommandKeepsTokenOutOfCurlArgv(t *testing.T) {
+	cmd := imageProbeCommand(18339)
+	if strings.Contains(cmd, `-H "Authorization: Bearer ${TOKEN}"`) {
+		t.Fatalf("image probe command leaks token through curl argv: %s", cmd)
+	}
+	if !strings.Contains(cmd, "curl -sf --max-time 5 -K -") {
+		t.Fatalf("image probe command must pass curl auth config through stdin: %s", cmd)
+	}
+	if !strings.Contains(cmd, `printf 'header = "Authorization: Bearer %s"\n'`) {
+		t.Fatalf("image probe command must emit Authorization header through curl config: %s", cmd)
+	}
+}

--- a/internal/shim/connect.go
+++ b/internal/shim/connect.go
@@ -9,7 +9,7 @@ import (
 
 // DetectRemoteArch returns the remote system's GOARCH-compatible architecture string.
 func DetectRemoteArch(host string) (string, string, error) {
-	cmd := exec.Command("ssh", host, "uname -sm")
+	cmd := exec.Command("ssh", sshHostArgs(nil, host, "uname -sm")...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to detect remote arch: %w", err)
@@ -57,13 +57,13 @@ func LocalBinaryPath() (string, error) {
 
 // UploadBinary copies the cc-clip binary to the remote host.
 func UploadBinary(host, localBin, remoteBin string) error {
-	cmd := exec.Command("scp", localBin, fmt.Sprintf("%s:%s", host, remoteBin))
+	cmd := exec.Command("scp", scpUploadArgs(nil, localBin, host, remoteBin)...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scp failed: %s: %w", string(out), err)
 	}
 
 	// Make executable
-	cmd = exec.Command("ssh", host, fmt.Sprintf("chmod +x %s", remoteBin))
+	cmd = exec.Command("ssh", sshHostArgs(nil, host, fmt.Sprintf("chmod +x %s", remoteBin))...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("chmod failed: %s: %w", string(out), err)
 	}
@@ -74,7 +74,7 @@ func UploadBinary(host, localBin, remoteBin string) error {
 // RemoteExec runs a command on the remote host and returns output.
 func RemoteExec(host string, args ...string) (string, error) {
 	cmdStr := strings.Join(args, " ")
-	cmd := exec.Command("ssh", host, cmdStr)
+	cmd := exec.Command("ssh", sshHostArgs(nil, host, cmdStr)...)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err
 }
@@ -82,8 +82,8 @@ func RemoteExec(host string, args ...string) (string, error) {
 // WriteRemoteToken writes the session token to the remote host via stdin
 // to avoid exposing it in process arguments or shell history.
 func WriteRemoteToken(host, token string) error {
-	cmd := exec.Command("ssh", host,
-		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token")
+	cmd := exec.Command("ssh", sshHostArgs(nil, host,
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token")...)
 	cmd.Stdin = strings.NewReader(token + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote token: %s: %w", string(out), err)

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -86,8 +86,7 @@ func WriteRemoteState(session *SSHSession, state *DeployState) error {
 
 	// Write via stdin to avoid shell escaping issues with JSON
 	remoteCmd := fmt.Sprintf("mkdir -p ~/.cache/cc-clip && cat > %s", remoteDeployPath)
-	args := append(session.connArgs(), session.host, remoteCmd)
-	c := exec.Command("ssh", args...)
+	c := exec.Command("ssh", session.sshArgs(remoteCmd)...)
 	c.Stdin = strings.NewReader(string(data) + "\n")
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote deploy state: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/shim/hook_template.go
+++ b/internal/shim/hook_template.go
@@ -27,10 +27,13 @@ d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
 json.dump(d, sys.stdout)
 " 2>/dev/null || echo "$_payload")
 
-_http_code=$(curl -sf --connect-timeout 2 --max-time 5 -o /dev/null -w '%%{http_code}' -X POST \
-	-H "Authorization: Bearer $_nonce" \
-	-H "Content-Type: application/x-claude-hook" \
-	-H "User-Agent: cc-clip-hook/0.1" \
+_cc_clip_curl_config() {
+	printf 'header = "Authorization: Bearer %%s"\n' "$_nonce"
+	printf 'header = "Content-Type: application/x-claude-hook"\n'
+	printf 'header = "User-Agent: cc-clip-hook/0.1"\n'
+}
+
+_http_code=$(_cc_clip_curl_config | curl -sf --connect-timeout 2 --max-time 5 -K - -o /dev/null -w '%%{http_code}' -X POST \
 	-d "$_payload" \
 	"http://127.0.0.1:${_CC_CLIP_PORT}/notify" \
 	2>/dev/null) || _http_code="000"

--- a/internal/shim/hook_template_test.go
+++ b/internal/shim/hook_template_test.go
@@ -1,6 +1,9 @@
 package shim
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -11,7 +14,6 @@ func TestHookTemplateUsesNotificationNonceAndHealthLog(t *testing.T) {
 		"notify.nonce",
 		"notify-health.log",
 		"application/x-claude-hook",
-		"Authorization: Bearer $_nonce",
 	} {
 		if !strings.Contains(got, needle) {
 			t.Fatalf("expected template to contain %q", needle)
@@ -35,6 +37,55 @@ func TestHookScriptDoesNotUseSessionToken(t *testing.T) {
 	got := HookScript(18339)
 	if strings.Contains(got, "session.token") {
 		t.Fatal("hook template must use notify.nonce, not session.token")
+	}
+}
+
+func TestHookScriptKeepsNonceOutOfCurlArgv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tmpDir := t.TempDir()
+	argvLog, stdinLog := writeFakeCurl(t, tmpDir)
+	home := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".cache", "cc-clip"), 0700); err != nil {
+		t.Fatalf("mkdir home cache: %v", err)
+	}
+	nonce := "notify-nonce-must-not-appear-in-argv"
+	if err := os.WriteFile(filepath.Join(home, ".cache", "cc-clip", "notify.nonce"), []byte(nonce+"\n"), 0600); err != nil {
+		t.Fatalf("write nonce: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpDir, "cc-clip-hook")
+	if err := os.WriteFile(hookPath, []byte(HookScript(18339)), 0755); err != nil {
+		t.Fatalf("write hook script: %v", err)
+	}
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"Stop"}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"CC_CLIP_HOST_ALIAS=testhost",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hook execution failed: %v output=%q", err, string(out))
+	}
+
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read fake curl argv log: %v", err)
+	}
+	if strings.Contains(string(argv), nonce) {
+		t.Fatalf("nonce leaked through curl argv: %q", string(argv))
+	}
+
+	stdinConfig, err := os.ReadFile(stdinLog)
+	if err != nil {
+		t.Fatalf("read fake curl stdin config: %v", err)
+	}
+	if !strings.Contains(string(stdinConfig), nonce) {
+		t.Fatalf("expected nonce in curl stdin config, got %q", string(stdinConfig))
 	}
 }
 

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -55,7 +55,7 @@ func NewSSHSession(host string) (*SSHSession, error) {
 	// but we want a unique, predictable path. Let ssh expand %C itself.
 	controlPath := "/tmp/cc-clip-ssh-%C"
 
-	cmd := exec.Command("ssh",
+	cmd := exec.Command("ssh", sshHostArgs([]string{
 		"-fN",
 		"-o", "ControlMaster=yes",
 		"-o", fmt.Sprintf("ControlPath=%s", controlPath),
@@ -63,8 +63,7 @@ func NewSSHSession(host string) (*SSHSession, error) {
 		"-o", "ServerAliveInterval=15",
 		"-o", "ServerAliveCountMax=3",
 		"-o", "ClearAllForwardings=yes",
-		host,
-	)
+	}, host)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -82,7 +81,7 @@ func NewSSHSession(host string) (*SSHSession, error) {
 // NewSSHSessionWithControlPath creates an SSHSession with a specific control path.
 // This is primarily useful for testing.
 func NewSSHSessionWithControlPath(host, controlPath string) (*SSHSession, error) {
-	cmd := exec.Command("ssh",
+	cmd := exec.Command("ssh", sshHostArgs([]string{
 		"-fN",
 		"-o", "ControlMaster=yes",
 		"-o", fmt.Sprintf("ControlPath=%s", controlPath),
@@ -90,8 +89,7 @@ func NewSSHSessionWithControlPath(host, controlPath string) (*SSHSession, error)
 		"-o", "ServerAliveInterval=15",
 		"-o", "ServerAliveCountMax=3",
 		"-o", "ClearAllForwardings=yes",
-		host,
-	)
+	}, host)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -116,27 +114,41 @@ func (s *SSHSession) connArgs() []string {
 	return []string{"-o", "ClearAllForwardings=yes"}
 }
 
+func sshHostArgs(prefix []string, host string, remoteArgs ...string) []string {
+	args := append([]string{}, prefix...)
+	args = append(args, "--", host)
+	args = append(args, remoteArgs...)
+	return args
+}
+
+func scpUploadArgs(prefix []string, localPath, host, remotePath string) []string {
+	args := append([]string{}, prefix...)
+	args = append(args, "--", localPath, fmt.Sprintf("%s:%s", host, remotePath))
+	return args
+}
+
+func (s *SSHSession) sshArgs(remoteArgs ...string) []string {
+	return sshHostArgs(s.connArgs(), s.host, remoteArgs...)
+}
+
 // Exec runs a command on the remote host via the SSH master connection.
 // Only stdout is captured as the return value; stderr is discarded to avoid
 // SSH mux control messages (e.g. "mux_client_forward:") contaminating output.
 func (s *SSHSession) Exec(cmd string) (string, error) {
-	args := append(s.connArgs(), s.host, cmd)
-	c := exec.Command("ssh", args...)
+	c := exec.Command("ssh", s.sshArgs(cmd)...)
 	out, err := c.Output()
 	return strings.TrimSpace(string(out)), err
 }
 
 // Upload copies a local file to the remote host via the SSH master connection.
 func (s *SSHSession) Upload(localPath, remotePath string) error {
-	scpArgs := append(s.connArgs(), localPath, fmt.Sprintf("%s:%s", s.host, remotePath))
-	cmd := exec.Command("scp", scpArgs...)
+	cmd := exec.Command("scp", scpUploadArgs(s.connArgs(), localPath, s.host, remotePath)...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("scp failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	// Make the uploaded file executable
-	chmodArgs := append(s.connArgs(), s.host, fmt.Sprintf("chmod +x %s", remotePath))
-	chmodCmd := exec.Command("ssh", chmodArgs...)
+	chmodCmd := exec.Command("ssh", s.sshArgs(fmt.Sprintf("chmod +x %s", remotePath))...)
 	if out, err := chmodCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("chmod failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -148,8 +160,7 @@ func (s *SSHSession) Upload(localPath, remotePath string) error {
 // the SSH master connection. Returns combined stdout+stderr output for
 // install/uninstall error diagnostics.
 func (s *SSHSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
-	args := append(s.connArgs(), s.host, cmd)
-	c := exec.Command("ssh", args...)
+	c := exec.Command("ssh", s.sshArgs(cmd)...)
 	c.Stdin = stdin
 	out, err := c.CombinedOutput()
 	return string(out), err
@@ -160,11 +171,10 @@ func (s *SSHSession) Close() error {
 	if s.controlPath == "" {
 		return nil // No ControlMaster on Windows
 	}
-	cmd := exec.Command("ssh",
+	cmd := exec.Command("ssh", sshHostArgs([]string{
 		"-O", "exit",
 		"-o", fmt.Sprintf("ControlPath=%s", s.controlPath),
-		s.host,
-	)
+	}, s.host)...)
 	// Ignore errors on close — master may have already exited
 	_ = cmd.Run()
 	return nil
@@ -225,9 +235,8 @@ func RemoteExecViaSession(session *SSHSession, args ...string) (string, error) {
 // via the SSH master connection, using stdin to avoid exposing the token
 // in process arguments or shell history.
 func WriteRemoteTokenViaSession(session *SSHSession, tok string) error {
-	args := append(session.connArgs(), session.host,
-		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token")
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.Command("ssh", session.sshArgs(
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token")...)
 	cmd.Stdin = strings.NewReader(tok + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote token: %s: %w", strings.TrimSpace(string(out)), err)
@@ -259,9 +268,8 @@ func GenerateNotificationNonce() (string, error) {
 // WriteRemoteNotificationNonce writes the notification nonce to
 // ~/.cache/cc-clip/notify.nonce on the remote with chmod 600.
 func WriteRemoteNotificationNonce(session *SSHSession, nonce string) error {
-	args := append(session.connArgs(), session.host,
-		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/notify.nonce && chmod 600 ~/.cache/cc-clip/notify.nonce")
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.Command("ssh", session.sshArgs(
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/notify.nonce && chmod 600 ~/.cache/cc-clip/notify.nonce")...)
 	cmd.Stdin = strings.NewReader(nonce + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote notification nonce: %s: %w", strings.TrimSpace(string(out)), err)
@@ -273,9 +281,8 @@ func WriteRemoteNotificationNonce(session *SSHSession, nonce string) error {
 // ~/.local/bin/cc-clip-hook on the remote with chmod +x.
 func InstallRemoteHookScript(session *SSHSession, port int) error {
 	script := HookScript(port)
-	args := append(session.connArgs(), session.host,
-		"mkdir -p ~/.local/bin && cat > ~/.local/bin/cc-clip-hook && chmod +x ~/.local/bin/cc-clip-hook")
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.Command("ssh", session.sshArgs(
+		"mkdir -p ~/.local/bin && cat > ~/.local/bin/cc-clip-hook && chmod +x ~/.local/bin/cc-clip-hook")...)
 	cmd.Stdin = strings.NewReader(script)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to install remote hook script: %s: %w", strings.TrimSpace(string(out)), err)
@@ -476,9 +483,8 @@ func codexNotifyManagedBlock(markerStart, markerEnd string, port int) string {
 
 // WriteRemoteSessionID writes a session ID to ~/.cache/cc-clip/session.id on the remote.
 func WriteRemoteSessionID(session *SSHSession, sessionID string) error {
-	args := append(session.connArgs(), session.host,
-		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.id && chmod 600 ~/.cache/cc-clip/session.id")
-	cmd := exec.Command("ssh", args...)
+	cmd := exec.Command("ssh", session.sshArgs(
+		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.id && chmod 600 ~/.cache/cc-clip/session.id")...)
 	cmd.Stdin = strings.NewReader(sessionID + "\n")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to write remote session ID: %s: %w", strings.TrimSpace(string(out)), err)

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -147,6 +147,22 @@ func TestConnArgsWithoutControlPath(t *testing.T) {
 	}
 }
 
+func TestSSHHostArgsInsertOptionSeparatorBeforeHost(t *testing.T) {
+	args := sshHostArgs([]string{"-o", "ClearAllForwardings=yes"}, "-oProxyCommand=evil", "uname -sm")
+	want := []string{"-o", "ClearAllForwardings=yes", "--", "-oProxyCommand=evil", "uname -sm"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("ssh args mismatch\n got: %q\nwant: %q", args, want)
+	}
+}
+
+func TestSCPHostArgsInsertOptionSeparatorBeforePaths(t *testing.T) {
+	args := scpUploadArgs([]string{"-o", "ClearAllForwardings=yes"}, "-local", "-oProxyCommand=evil", "/remote")
+	want := []string{"-o", "ClearAllForwardings=yes", "--", "-local", "-oProxyCommand=evil:/remote"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("scp args mismatch\n got: %q\nwant: %q", args, want)
+	}
+}
+
 func TestGenerateNotificationNonce(t *testing.T) {
 	nonce, err := GenerateNotificationNonce()
 	if err != nil {

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -89,6 +89,16 @@ _cc_clip_session_header() {
     fi
 }
 
+_cc_clip_curl_config() {
+    local token="$1"
+    local session_hdr="${2:-}"
+    printf 'header = "Authorization: Bearer %%s"\n' "$token"
+    printf 'header = "User-Agent: cc-clip/0.1"\n'
+    if [ -n "$session_hdr" ]; then
+        printf 'header = "%%s"\n' "$session_hdr"
+    fi
+}
+
 _cc_clip_probe() {
     local timeout_s
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_PROBE_TIMEOUT_MS}/1000}")
@@ -110,10 +120,8 @@ _cc_clip_fetch_json() {
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
     local session_hdr
     session_hdr=$(_cc_clip_session_header)
-    curl -sf --max-time "$timeout_s" \
-        -H "Authorization: Bearer ${token}" \
-        -H "User-Agent: cc-clip/0.1" \
-        ${session_hdr:+-H "$session_hdr"} \
+    _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
+        -K - \
         "http://${CC_CLIP_ADDR}${path}"
 }
 
@@ -128,11 +136,9 @@ _cc_clip_fetch_binary() {
     session_hdr=$(_cc_clip_session_header)
     local tmpfile
     tmpfile=$(mktemp 2>/dev/null) || return 20
-    if curl -sf --max-time "$timeout_s" \
+    if _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
         -o "$tmpfile" \
-        -H "Authorization: Bearer ${token}" \
-        -H "User-Agent: cc-clip/0.1" \
-        ${session_hdr:+-H "$session_hdr"} \
+        -K - \
         "http://${CC_CLIP_ADDR}${path}"; then
         # Guard against empty response (e.g. HTTP 204 No Content)
         if [ ! -s "$tmpfile" ]; then
@@ -287,6 +293,16 @@ _cc_clip_session_header() {
     fi
 }
 
+_cc_clip_curl_config() {
+    local token="$1"
+    local session_hdr="${2:-}"
+    printf 'header = "Authorization: Bearer %%s"\n' "$token"
+    printf 'header = "User-Agent: cc-clip/0.1"\n'
+    if [ -n "$session_hdr" ]; then
+        printf 'header = "%%s"\n' "$session_hdr"
+    fi
+}
+
 _cc_clip_probe() {
     if command -v nc >/dev/null 2>&1; then
         nc -z -w 1 "${CC_CLIP_ADDR%%%%:*}" "${CC_CLIP_ADDR##*:}" 2>/dev/null
@@ -303,10 +319,8 @@ _cc_clip_fetch_json() {
     timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
     local session_hdr
     session_hdr=$(_cc_clip_session_header)
-    curl -sf --max-time "$timeout_s" \
-        -H "Authorization: Bearer ${token}" \
-        -H "User-Agent: cc-clip/0.1" \
-        ${session_hdr:+-H "$session_hdr"} \
+    _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
+        -K - \
         "http://${CC_CLIP_ADDR}${path}"
 }
 
@@ -320,11 +334,9 @@ _cc_clip_fetch_binary() {
     session_hdr=$(_cc_clip_session_header)
     local tmpfile
     tmpfile=$(mktemp 2>/dev/null) || return 20
-    if curl -sf --max-time "$timeout_s" \
+    if _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
         -o "$tmpfile" \
-        -H "Authorization: Bearer ${token}" \
-        -H "User-Agent: cc-clip/0.1" \
-        ${session_hdr:+-H "$session_hdr"} \
+        -K - \
         "http://${CC_CLIP_ADDR}${path}"; then
         # Guard against empty response (e.g. HTTP 204 No Content)
         if [ ! -s "$tmpfile" ]; then

--- a/internal/shim/template_test.go
+++ b/internal/shim/template_test.go
@@ -88,6 +88,128 @@ func startMockDaemon(t *testing.T, tmpDir string) (int, string) {
 	return port, tokenFile
 }
 
+func writeFakeCurl(t *testing.T, dir string) (argvLog, stdinLog string) {
+	t.Helper()
+
+	argvLog = filepath.Join(dir, "curl-argv.log")
+	stdinLog = filepath.Join(dir, "curl-stdin.log")
+	curlPath := filepath.Join(dir, "curl")
+	script := "#!/bin/bash\n" +
+		"set -euo pipefail\n" +
+		"argv_log=" + strconv.Quote(argvLog) + "\n" +
+		"stdin_log=" + strconv.Quote(stdinLog) + "\n" +
+		"printf '%s\\n' \"$*\" > \"$argv_log\"\n" +
+		"for ((i=1; i<=$#; i++)); do\n" +
+		"  if [ \"${!i}\" = \"-K\" ]; then\n" +
+		"    next=$((i+1))\n" +
+		"    if [ \"${!next}\" = \"-\" ]; then\n" +
+		"      cat > \"$stdin_log\"\n" +
+		"      break\n" +
+		"    fi\n" +
+		"  fi\n" +
+		"done\n" +
+		"outfile=\"\"\n" +
+		"prev=\"\"\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$prev\" = \"-o\" ]; then outfile=\"$arg\"; fi\n" +
+		"  prev=\"$arg\"\n" +
+		"done\n" +
+		"url=\"${@: -1}\"\n" +
+		"case \"$url\" in\n" +
+		"  */clipboard/type) printf '{\"type\":\"image\",\"format\":\"png\"}\\n' ;;\n" +
+		"  */clipboard/image) if [ -n \"$outfile\" ]; then printf " + strconv.Quote(string(imagePayload)) + " > \"$outfile\"; else printf " + strconv.Quote(string(imagePayload)) + "; fi ;;\n" +
+		"  */notify) printf '204' ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(curlPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake curl: %v", err)
+	}
+	return argvLog, stdinLog
+}
+
+func TestShimsKeepTokenOutOfCurlArgv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	cases := []struct {
+		name   string
+		render func(port int, real string) string
+		args   []string
+	}{
+		{
+			name:   "xclip_json",
+			render: XclipShim,
+			args:   []string{"-selection", "clipboard", "-t", "TARGETS", "-o"},
+		},
+		{
+			name:   "xclip_binary",
+			render: XclipShim,
+			args:   []string{"-selection", "clipboard", "-t", "image/png", "-o"},
+		},
+		{
+			name:   "wlpaste_json",
+			render: WlPasteShim,
+			args:   []string{"--list-types"},
+		},
+		{
+			name:   "wlpaste_binary",
+			render: WlPasteShim,
+			args:   []string{"--type", "image/png"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			argvLog, stdinLog := writeFakeCurl(t, tmpDir)
+			port, tokenFile := startMockDaemon(t, tmpDir)
+
+			token := "secret-token-must-not-appear-in-argv"
+			if err := os.WriteFile(tokenFile, []byte(token+"\n"), 0600); err != nil {
+				t.Fatalf("write token file: %v", err)
+			}
+
+			realBin := filepath.Join(tmpDir, "fake-real")
+			if err := os.WriteFile(realBin, []byte("#!/bin/bash\nexit 99\n"), 0755); err != nil {
+				t.Fatalf("write fake real: %v", err)
+			}
+
+			shimPath := filepath.Join(tmpDir, "shim.sh")
+			if err := os.WriteFile(shimPath, []byte(tc.render(port, realBin)), 0755); err != nil {
+				t.Fatalf("write shim: %v", err)
+			}
+
+			cmd := exec.Command("bash", append([]string{shimPath}, tc.args...)...)
+			cmd.Env = append(os.Environ(),
+				"PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"CC_CLIP_PORT="+strconv.Itoa(port),
+				"CC_CLIP_TOKEN_FILE="+tokenFile,
+				"CC_CLIP_PROBE_TIMEOUT_MS=2000",
+				"CC_CLIP_FETCH_TIMEOUT_MS=5000",
+			)
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("shim execution failed: %v output=%q", err, string(out))
+			}
+
+			argv, err := os.ReadFile(argvLog)
+			if err != nil {
+				t.Fatalf("read fake curl argv log: %v", err)
+			}
+			if strings.Contains(string(argv), token) {
+				t.Fatalf("token leaked through curl argv: %q", string(argv))
+			}
+
+			stdinConfig, err := os.ReadFile(stdinLog)
+			if err != nil {
+				t.Fatalf("read fake curl stdin config: %v", err)
+			}
+			if !strings.Contains(string(stdinConfig), token) {
+				t.Fatalf("expected token in curl stdin config, got %q", string(stdinConfig))
+			}
+		})
+	}
+}
+
 // TestShimInterceptsMatchingInvocations runs the generated bash shim against a
 // real mock HTTP daemon. For each case where the pattern *should* match, it
 // asserts that the shim's stdout contains the daemon's response (proving the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,6 +47,33 @@ download() {
     fi
 }
 
+verify_checksum() {
+    local archive="$1" checksums="$2" archive_name="$3"
+    local expected actual
+
+    expected=$(awk -v name="$archive_name" '$2 == name {print $1; exit}' "$checksums")
+    if [ -z "$expected" ]; then
+        echo "Error: checksum for ${archive_name} not found in checksums.txt" >&2
+        exit 1
+    fi
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$archive" | awk '{print $1}')
+    elif command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$archive" | awk '{print $1}')
+    else
+        echo "Error: sha256sum or shasum required for checksum verification" >&2
+        exit 1
+    fi
+
+    if [ "$actual" != "$expected" ]; then
+        echo "Error: checksum mismatch for ${archive_name}" >&2
+        echo "  expected: ${expected}" >&2
+        echo "  actual:   ${actual}" >&2
+        exit 1
+    fi
+}
+
 main() {
     PLATFORM=$(detect_platform)
     VERSION=$(get_latest_version)
@@ -60,12 +87,19 @@ main() {
 
     ARCHIVE_NAME="cc-clip_${VERSION#v}_${PLATFORM}.tar.gz"
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"
+    CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
 
     TMP_DIR=$(mktemp -d)
     trap 'rm -rf "$TMP_DIR"' EXIT
 
     echo "Downloading ${DOWNLOAD_URL}..."
     download "$DOWNLOAD_URL" "${TMP_DIR}/${ARCHIVE_NAME}"
+
+    echo "Downloading checksums.txt..."
+    download "$CHECKSUMS_URL" "${TMP_DIR}/checksums.txt"
+
+    echo "Verifying checksum..."
+    verify_checksum "${TMP_DIR}/${ARCHIVE_NAME}" "${TMP_DIR}/checksums.txt" "$ARCHIVE_NAME"
 
     echo "Extracting..."
     tar -xzf "${TMP_DIR}/${ARCHIVE_NAME}" -C "$TMP_DIR"

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -1,0 +1,32 @@
+package scripts_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInstallScriptVerifiesReleaseChecksumBeforeExtraction(t *testing.T) {
+	data, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	script := string(data)
+
+	for _, needle := range []string{
+		"checksums.txt",
+		"verify_checksum()",
+		"sha256sum",
+		"shasum -a 256",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("install.sh must contain %q", needle)
+		}
+	}
+
+	verifyIdx := strings.Index(script, "verify_checksum")
+	extractIdx := strings.Index(script, "tar -xzf")
+	if verifyIdx == -1 || extractIdx == -1 || verifyIdx > extractIdx {
+		t.Fatalf("install.sh must verify the archive checksum before extraction")
+	}
+}


### PR DESCRIPTION
## Summary

- Keep clipboard tokens and notification nonces out of `curl` argv by passing Authorization headers through `curl -K -` stdin config.
- Apply the same argv-safe pattern to `cc-clip doctor --host` remote image probe.
- Insert `--` before SSH/SCP host operands so leading-dash host aliases cannot be parsed as options.
- Verify `scripts/install.sh` release archives against `checksums.txt` before extraction.
- Remove User-Agent validation from SECURITY.md security-principles wording; it is not an auth boundary.

## Security notes

This fixes a contradiction introduced by the threat-model docs: tokens and nonces are now kept out of command-line arguments in shim, hook, and doctor curl paths. The secret still flows through stdin config or local/remote 0600 files as documented.

## Verification

- `go test ./internal/shim -run 'TestShimsKeepTokenOutOfCurlArgv|TestHookScriptKeepsNonceOutOfCurlArgv|TestSSHHostArgsInsertOptionSeparatorBeforeHost|TestSCPHostArgsInsertOptionSeparatorBeforePaths' -count=1`
- `go test ./scripts -run TestInstallScriptVerifiesReleaseChecksumBeforeExtraction -count=1`
- `go test ./internal/doctor -run TestImageProbeCommandKeepsTokenOutOfCurlArgv -count=1`
- `go test ./internal/shim ./internal/doctor ./scripts ./cmd/cc-clip -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./internal/shim ./internal/doctor ./cmd/cc-clip ./scripts -count=1`
- `sh -n scripts/install.sh`
- `git diff --check`
- `make release-preflight`

## Out of scope

The existing untracked marketing / plan docs are intentionally left out of this PR.