### PR TITLE
fix: insert Codex notify block at TOML top level instead of appending to EOF

### DIFF
--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -448,11 +448,23 @@ func EnsureRemoteCodexNotifyConfig(session RemoteExecutor, port int) error {
 		}
 	}
 
-	// Append the managed block to the config file.
-	appendCmd := fmt.Sprintf(
-		"mkdir -p ~/.codex && cat >> %s << 'CC_CLIP_EOF'\n%s\nCC_CLIP_EOF",
+	// Insert the managed block at the TOML top level, before any [section].
+	// A naive `cat >>` appends to EOF which nests the block inside the last
+	// section header (e.g. [tui.model_availability_nux]), corrupting the file.
+	insertCmd := fmt.Sprintf(
+		"mkdir -p ~/.codex && touch %[1]s\n"+
+			"_CC_BLK=$(mktemp)\n"+
+			"cat > \"$_CC_BLK\" << 'CC_CLIP_EOF'\n"+
+			"\n%[2]s\nCC_CLIP_EOF\n"+
+			"if grep -qm1 '^\\[' %[1]s; then\n"+
+			"  _CC_LN=$(grep -nm1 '^\\[' %[1]s | cut -d: -f1)\n"+
+			"  { head -n$((_CC_LN - 1)) %[1]s; cat \"$_CC_BLK\"; echo; tail -n+\"$_CC_LN\" %[1]s; } > \"${_CC_BLK}.new\" && mv \"${_CC_BLK}.new\" %[1]s\n"+
+			"else\n"+
+			"  cat \"$_CC_BLK\" >> %[1]s\n"+
+			"fi\n"+
+			"rm -f \"$_CC_BLK\"",
 		configPath, managedBlock)
-	_, err = session.Exec(appendCmd)
+	_, err = session.Exec(insertCmd)
 	if err != nil {
 		return fmt.Errorf("failed to inject notify config into %s: %w", configPath, err)
 	}

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -300,6 +300,29 @@ func TestEnsureRemoteCodexNotifyConfigReplacesManagedBlock(t *testing.T) {
 	}
 }
 
+func TestEnsureRemoteCodexNotifyConfigInsertsBeforeSections(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, `model = "gpt-5"
+
+[tui.model_availability_nux]
+"gpt-5" = 4
+`)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	notifyIdx := strings.Index(config, "notify =")
+	sectionIdx := strings.Index(config, "[tui.model_availability_nux]")
+	if notifyIdx < 0 || sectionIdx < 0 {
+		t.Fatalf("expected both notify and section in config: %q", config)
+	}
+	if notifyIdx > sectionIdx {
+		t.Fatalf("notify block must appear before [tui.model_availability_nux] to stay at TOML top level, got:\n%s", config)
+	}
+}
+
 func TestEnsureRemoteCodexNotifyConfigReturnsProbeError(t *testing.T) {
 	err := EnsureRemoteCodexNotifyConfig(&errorExecutor{err: fmt.Errorf("ssh failed")}, 18339)
 	if err == nil {


### PR DESCRIPTION
## Problem

`cc-clip setup <host> --codex` injects a `notify` block into `~/.codex/config.toml` using `cat >>` (EOF append). When the config file ends with a TOML section like `[tui.model_availability_nux]`, the appended block lands **inside** that section instead of at the top level:

```toml
[tui.model_availability_nux]
"gpt-5.5" = 4
# >>> cc-clip notify (do not edit) >>>
notify = ["cc-clip", "notify", "--from-codex-stdin"]
# <<< cc-clip notify (do not edit) <<<
```

Codex then fails to start:

```
Error loading config.toml: invalid type: sequence, expected u32
in `tui.model_availability_nux`
```

The `notify` key becomes `tui.model_availability_nux.notify` (a string array) in a table that expects only `u32` values. This was partially addressed in v0.7.0 (401d4d1) for the duplicate-key case, but the structural placement bug remained — any config ending with a `[section]` still triggers it.

Hit this upgrading from v0.5.0 to v0.7.4 on a fresh `cc-clip setup dev-server --codex` deploy. Codex was completely unusable until I manually edited the config.

## Fix

Replace `cat >> file` with a `head`/`tail` splice that inserts the managed block **before** the first TOML section header (`[...`). If no sections exist, falls back to append. This guarantees `notify` is always a top-level key regardless of what sections the user has in their config.

## Test plan

- [x] New regression test: `TestEnsureRemoteCodexNotifyConfigInsertsBeforeSections` — writes a config with `[tui.model_availability_nux]` as the last section, injects, asserts notify appears before the section
- [x] All 157 existing shim tests pass
- [x] Verified manually on a remote host: Codex starts without config parse errors after injection