### PR TITLE
fix(shim): atomic crash-safe codex notify config injection

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -462,12 +462,12 @@ func cmdUninstallCodexRemote(host string) {
 	var stateError bool
 
 	// Step 1: Stop x11-bridge
-	fmt.Println("[1/5] Stopping x11-bridge...")
+	fmt.Println("[1/6] Stopping x11-bridge...")
 	stopBridgeRemote(session)
 	fmt.Println("      done")
 
 	// Step 2: Stop Xvfb
-	fmt.Println("[2/5] Stopping Xvfb...")
+	fmt.Println("[2/6] Stopping Xvfb...")
 	if err := xvfb.StopRemote(session, codexStateDir); err != nil {
 		fmt.Printf("      warning: %v\n", err)
 		teardownError = true
@@ -476,7 +476,7 @@ func cmdUninstallCodexRemote(host string) {
 	}
 
 	// Step 3: Remove codex state directory
-	fmt.Println("[3/5] Removing codex state files...")
+	fmt.Println("[3/6] Removing codex state files...")
 	if _, err := session.Exec(fmt.Sprintf("rm -rf %s", codexStateDir)); err != nil {
 		fmt.Printf("      warning: could not remove codex state files: %v\n", err)
 		teardownError = true
@@ -484,8 +484,19 @@ func cmdUninstallCodexRemote(host string) {
 		fmt.Println("      done")
 	}
 
-	// Step 4: Remove DISPLAY marker
-	fmt.Println("[4/5] Removing DISPLAY marker...")
+	// Step 4: Strip cc-clip notify block from ~/.codex/config.toml.
+	// Without this, codex keeps trying to invoke a now-missing
+	// cc-clip binary on every hook event.
+	fmt.Println("[4/6] Stripping notify block from ~/.codex/config.toml...")
+	if err := shim.StripRemoteCodexNotifyConfig(session); err != nil {
+		fmt.Printf("      warning: %v\n", err)
+		teardownError = true
+	} else {
+		fmt.Println("      done")
+	}
+
+	// Step 5: Remove DISPLAY marker
+	fmt.Println("[5/6] Removing DISPLAY marker...")
 	if err := shim.RemoveDisplayMarkerSession(session); err != nil {
 		fmt.Printf("      warning: %v\n", err)
 		teardownError = true
@@ -493,8 +504,8 @@ func cmdUninstallCodexRemote(host string) {
 		fmt.Println("      done")
 	}
 
-	// Step 5: Update deploy state
-	fmt.Println("[5/5] Updating deploy state...")
+	// Step 6: Update deploy state
+	fmt.Println("[6/6] Updating deploy state...")
 	remoteState, err := shim.ReadRemoteState(session)
 	if err != nil {
 		fmt.Printf("      warning: could not read deploy state: %v\n", err)

--- a/docs/superpowers/specs/2026-05-11-codex-config-toml-section-scoping-fix.md
+++ b/docs/superpowers/specs/2026-05-11-codex-config-toml-section-scoping-fix.md
@@ -1,0 +1,258 @@
+# Codex `config.toml` section-scoping fix
+
+**Status**: Draft, awaiting separate issue creation
+**Date**: 2026-05-11
+**Author**: Claude Code session (with shunmei review)
+**Out of scope for**: issue #55 / branch `fix/issue-55-claude-wrapper-symlink-safe`
+**In scope for**: a new GitHub issue to be filed; a new branch to be cut from `main`
+
+---
+
+## Symptom
+
+After running `cc-clip connect <host> --codex --force` against a remote
+that already has a non-trivial `~/.codex/config.toml`, the remote `codex`
+CLI becomes unusable. Concretely:
+
+- `codex login` fails to start (cannot read config to determine auth
+  provider / endpoints).
+- All other `codex` subcommands fail similarly because Codex parses
+  `config.toml` first, on every invocation.
+- The user-visible message is something like
+  "无法登陆" / "cannot log in", which is the symptom — not the root cause.
+
+`~/.codex/auth.toml` is **not** touched by cc-clip; the perceived
+"auth.toml is broken" reading was a misattribution. The destruction is
+limited to `~/.codex/config.toml`.
+
+## Root cause
+
+Located in `internal/shim/ssh.go:398-437` (`EnsureRemoteCodexNotifyConfig`).
+The function writes the cc-clip notify hook to `config.toml` by
+**appending** a managed block to the end of the file:
+
+```bash
+mkdir -p ~/.codex && cat >> ~/.codex/config.toml << 'CC_CLIP_EOF'
+# >>> cc-clip notify (do not edit) >>>
+notify = ["cc-clip", "notify", "--from-codex-stdin"]
+# <<< cc-clip notify (do not edit) <<<
+CC_CLIP_EOF
+```
+
+This triggers three independent failure modes, any of which can break
+parsing:
+
+### F1 — TOML section scoping (primary cause)
+
+In TOML, every bare `key = value` line belongs to the **most recent
+preceding `[section]` header**. There is no notion of "top-level after
+a section starts".
+
+If the user's `config.toml` has any section (very common — `[history]`,
+`[mcp_servers.xyz]`, `[model_providers.openai]`), appending our
+top-level `notify = [...]` at the end reparents it under that section:
+
+```toml
+[model_providers.openai]
+api_key = "..."
+
+# >>> cc-clip notify (do not edit) >>>
+notify = ["cc-clip", "notify", "--from-codex-stdin"]
+# <<< cc-clip notify (do not edit) <<<
+```
+
+Codex parses this as `model_providers.openai.notify = [...]`. New Codex
+builds use Rust `serde` deserialization with `#[serde(deny_unknown_fields)]`
+on the provider structs, so this triggers an immediate deserialization
+error. The error short-circuits `codex` startup, so even unrelated
+subcommands like `codex login` cannot proceed.
+
+### F2 — Trailing-newline corruption
+
+If the existing `config.toml` does not end with a newline (vim users
+often have this), `cat >>` concatenates the last line with our marker:
+
+```toml
+model = "gpt-5"# >>> cc-clip notify (do not edit) >>>
+```
+
+That is a hard TOML syntax error.
+
+### F3 — Non-atomic write
+
+The append happens via the shell's `>>` redirection. If SSH is
+interrupted mid-write (network blip, user Ctrl-C), the file is left
+with a partial managed block — neither the old config nor the new one.
+This is rare but unrecoverable without manual editing.
+
+### Why `--force` makes it worse
+
+`runConnect` calls `connectNotifySetup` unconditionally, which calls
+`EnsureRemoteCodexNotifyConfig` whenever `RemoteHasCodex` returns true.
+On `--force`, the function:
+
+1. sees an existing managed block,
+2. sed-deletes it,
+3. appends a fresh block at the end again.
+
+Because step 3 still appends at the very end, every `--force` repeats
+F1: the managed block keeps landing inside whatever section happens to
+be last in the file. There is no idempotent escape — repeating the
+command does not recover.
+
+## Fix design
+
+Two structural changes plus one safety guard.
+
+### Change 1 — Prepend, don't append
+
+The fix requires `notify` to live **before** any `[section]` header, so
+TOML interprets it as truly top-level. Concretely, prepend the managed
+block to the very start of the file:
+
+```toml
+# >>> cc-clip notify (do not edit) >>>
+notify = ["cc-clip", "notify", "--from-codex-stdin"]
+# <<< cc-clip notify (do not edit) <<<
+
+# ... user's original config follows ...
+```
+
+### Change 2 — Atomic mktemp + mv (same-filesystem)
+
+Build the new file into a `mktemp` path **inside `~/.codex/` itself**,
+then atomically `mv` it over `~/.codex/config.toml`. SSH interruption
+either leaves the original file untouched or completes the swap —
+never a half-written state.
+
+**Critical**: `mktemp` defaults to `/tmp`, which on mainstream Linux is
+a tmpfs mount distinct from `$HOME`. A `mv` across filesystems is NOT
+a `rename(2)` — it degrades to `copy + unlink`, which is not atomic
+and can leave a half-written destination if interrupted. The temp
+file must live in the same directory (or at minimum the same mount
+point) as the final path, so `mv` takes the `rename(2)` path:
+
+```bash
+tmp=$(mktemp "$HOME/.codex/.config.toml.cc-clip-tmp.XXXXXX")
+```
+
+The dotfile prefix keeps the temp invisible in `ls` and signals
+"don't touch" to any tooling that scans the directory.
+
+### Change 3 — User-notify guard, post-strip
+
+Before writing, scan the *post-strip* content (i.e. with our managed
+block removed) for a non-managed `notify =` line. If found, refuse to
+write and surface a clear error. Currently the user-notify check runs
+on raw input, which means it false-fires on idempotent re-injection
+when our own block contains `notify =`.
+
+### Proposed bash logic
+
+```bash
+set -e
+mkdir -p ~/.codex
+# Temp file MUST be on the same filesystem as ~/.codex/config.toml so
+# `mv` takes the rename(2) path. Default mktemp uses /tmp, which is
+# tmpfs on most Linux distros — that would silently degrade mv to a
+# non-atomic copy+unlink and break crash safety.
+tmp=$(mktemp "$HOME/.codex/.config.toml.cc-clip-tmp.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+# Strip any prior managed block; pipe original content (or empty) through sed
+existing=""
+if [ -f ~/.codex/config.toml ]; then
+    existing=$(sed '/^# >>> cc-clip notify (do not edit) >>>/,/^# <<< cc-clip notify (do not edit) <<<$/d' ~/.codex/config.toml)
+fi
+
+# Refuse if user has a non-managed top-level notify key
+if printf '%s\n' "$existing" | grep -E '^\s*notify\s*=' >/dev/null; then
+    echo "existing notify key found; refusing to inject" >&2
+    exit 7
+fi
+
+# Build new file: managed block first, then existing content
+{
+    printf '%s\n' '# >>> cc-clip notify (do not edit) >>>'
+    printf '%s\n' 'notify = ["cc-clip", "notify", "--from-codex-stdin"]'
+    printf '%s\n' '# <<< cc-clip notify (do not edit) <<<'
+    printf '\n'
+    printf '%s' "$existing"
+    # Ensure trailing newline
+    [ -n "$existing" ] && [ "${existing: -1}" != $'\n' ] && printf '\n'
+} > "$tmp"
+
+# Preserve original permissions if file existed
+if [ -f ~/.codex/config.toml ]; then
+    chmod --reference=~/.codex/config.toml "$tmp" 2>/dev/null || true
+fi
+
+mv "$tmp" ~/.codex/config.toml
+trap - EXIT
+```
+
+### Companion fix — Uninstall path
+
+`cmdUninstallCodexRemote` (cmd/cc-clip/main.go:433) does **not** clean
+up the managed block in `config.toml`. After uninstall, the remote
+still has a `notify = [...]` line pointing at a now-missing cc-clip
+binary, so Codex tries to run a stale hook on every event. Add a
+sed-strip pass during uninstall that removes the managed block while
+preserving the rest of the file.
+
+## Test plan
+
+All tests use the existing `localSession` stub against a `t.TempDir()`
+fake $HOME, mirroring the issue #55 test pattern:
+
+1. **TestEnsureCodexNotifyConfig_PrependBeforeSection** — pre-existing
+   config with `[model_providers.openai]` section; assert managed block
+   lands BEFORE the section header, and a TOML parser (or `taplo`
+   binary, or a Go TOML package as test-only dependency) accepts the
+   result and `notify` deserializes at the root.
+2. **TestEnsureCodexNotifyConfig_NoTrailingNewline** — file without
+   trailing `\n`; assert no concatenation, valid TOML out.
+3. **TestEnsureCodexNotifyConfig_IdempotentReinjection** — run twice
+   in a row; assert only one managed block exists and content is
+   byte-identical to single-run output.
+4. **TestEnsureCodexNotifyConfig_UserHasNotify_Refuses** — pre-existing
+   file with `notify = [...]` outside our markers; assert error, file
+   unchanged.
+5. **TestEnsureCodexNotifyConfig_EmptyFile** — empty config; assert
+   managed block written, no extra blank lines.
+6. **TestEnsureCodexNotifyConfig_FileDoesNotExist** — `~/.codex/`
+   doesn't exist; assert directory + file created.
+7. **TestEnsureCodexNotifyConfig_AtomicWriteOnFailure** — inject a
+   simulated failure (e.g. read-only target dir via chmod); assert
+   original file content unchanged (or no file created if it didn't
+   exist before).
+8. **TestCmdUninstallCodexRemote_StripsManagedBlock** — extends the
+   uninstall integration test; assert post-uninstall `config.toml`
+   contains no `cc-clip notify` markers and rest of user content
+   preserved.
+
+## Scope boundary
+
+- This is a **separate issue from #55**. The branch must be cut from
+  `main` after #55 is merged (or independently if #55 lingers).
+- Do not piggyback this onto the existing `fix/issue-55-...` branch.
+  The N0 fail-closed work belongs to #55's scope; codex config.toml
+  belongs to its own narrative.
+- Suggested branch name: `fix/codex-config-toml-section-scoping`.
+- Suggested commit prefixes:
+  - `feat(shim): prepend codex notify block atomically via mktemp+mv`
+  - `feat(shim): strip codex notify block during uninstall`
+  - `test(shim): codex notify config injection table coverage`
+
+## Open questions for the new issue
+
+1. Should we add a TOML linter as a CI gate to catch this class of bug
+   structurally? `taplo` is the canonical Rust tool; pure-Go options
+   include `pelletier/go-toml`.
+2. Should `EnsureRemoteCodexNotifyConfig` accept an optional `[hooks]`
+   section name in case future Codex versions move `notify` under a
+   sub-table? (Probably YAGNI — wait until it actually moves.)
+3. Should we detect the corrupted state on N5 and offer a recovery
+   path, similar to N0 for the v0.7.0 wrapper issue? At minimum: detect
+   that our managed block is positioned under a `[section]` and warn,
+   even if we can't auto-fix older injections.

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -414,49 +414,107 @@ func RemoteHasCodex(session RemoteExecutor) (bool, error) {
 
 // EnsureRemoteCodexNotifyConfig injects the cc-clip notification hook
 // block into ~/.codex/config.toml using # cc-clip-managed guard markers.
-// Idempotent: if the managed block already exists, it is replaced.
-// If the user already has a non-managed `notify` key, injection is refused
-// to avoid creating duplicate TOML keys.
+//
+// The managed block is prepended above any [section] header so that
+// `notify` is parsed as a top-level TOML key. A naive append would land
+// the block inside whatever section happens to be last in the file
+// (e.g. [tui.model_availability_nux]), which TOML interprets as
+// tui.model_availability_nux.notify and Codex rejects with
+// "invalid type: sequence, expected u32".
+//
+// Crash-safety: the rewrite is staged into a mktemp file inside
+// ~/.codex/ (same filesystem) and then mv'd over config.toml so the
+// final swap is atomic via rename(2). mktemp's default $TMPDIR is
+// typically tmpfs on Linux, which would silently degrade mv to a
+// non-atomic copy+unlink — that path is avoided here.
+//
+// Idempotency: if a prior managed block exists, it is stripped before
+// rebuilding. The non-managed-notify guard is applied to the stripped
+// content so re-injection never false-fires on our own block.
+//
+// All work runs inside one bash script with `set -e` and a cleanup
+// trap, so any internal failure (mktemp, sed, mv) propagates to a
+// non-zero SSH exit code instead of being masked by the trailing
+// `rm -f` of the temp file.
 func EnsureRemoteCodexNotifyConfig(session RemoteExecutor, port int) error {
 	const markerStart = "# >>> cc-clip notify (do not edit) >>>"
 	const markerEnd = "# <<< cc-clip notify (do not edit) <<<"
-	const configPath = "~/.codex/config.toml"
 
 	managedBlock := codexNotifyManagedBlock(markerStart, markerEnd, port)
 
-	// Check if the managed block already exists.
-	out, err := remoteOptionalGrep(session, "-F", markerStart, configPath)
-	if err != nil {
-		return fmt.Errorf("failed to check managed notify block in %s: %w", configPath, err)
-	}
-	if strings.Contains(out, markerStart) {
-		// Replace existing block using sed.
-		sedCmd := fmt.Sprintf(
-			`sed -i.cc-clip-bak '/%s/,/%s/d' %s && rm -f %s.cc-clip-bak`,
-			sedEscape(markerStart), sedEscape(markerEnd), configPath, configPath)
-		if _, err := session.Exec(sedCmd); err != nil {
-			return fmt.Errorf("failed to replace existing managed notify block in %s: %w", configPath, err)
-		}
-	} else {
-		// Check for a user-managed notify key (not ours) to avoid duplicate keys.
-		userNotify, err := remoteOptionalGrep(session, "-E", `^[[:space:]]*notify[[:space:]]*=`, configPath)
-		if err != nil {
-			return fmt.Errorf("failed to check existing notify setting in %s: %w", configPath, err)
-		}
-		if strings.TrimSpace(userNotify) != "" {
-			return fmt.Errorf("existing notify setting found in %s — refusing to inject duplicate. Remove or comment out the existing notify line first", configPath)
-		}
+	script := fmt.Sprintf(`set -e
+mkdir -p ~/.codex
+config=~/.codex/config.toml
+touch "$config"
+
+stripped=$(sed '/^%[1]s$/,/^%[2]s$/d' "$config" | sed '/./,$!d')
+
+if printf '%%s\n' "$stripped" | grep -Eq '^[[:space:]]*notify[[:space:]]*='; then
+  echo "existing notify setting found in $config -- refusing to inject duplicate. Remove or comment out the existing notify line first" >&2
+  exit 7
+fi
+
+tmp=$(mktemp "$HOME/.codex/.config.toml.cc-clip.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+{
+  cat <<'CC_CLIP_MANAGED_BLOCK_EOF'
+%[3]s
+CC_CLIP_MANAGED_BLOCK_EOF
+  if [ -n "$stripped" ]; then
+    printf '\n%%s\n' "$stripped"
+  fi
+} > "$tmp"
+
+if [ -s "$config" ]; then
+  chmod --reference="$config" "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+fi
+
+mv "$tmp" "$config"
+trap - EXIT
+`, sedEscape(markerStart), sedEscape(markerEnd), managedBlock)
+
+	if _, err := session.Exec(script); err != nil {
+		return fmt.Errorf("failed to inject notify config into ~/.codex/config.toml: %w", err)
 	}
 
-	// Append the managed block to the config file.
-	appendCmd := fmt.Sprintf(
-		"mkdir -p ~/.codex && cat >> %s << 'CC_CLIP_EOF'\n%s\nCC_CLIP_EOF",
-		configPath, managedBlock)
-	_, err = session.Exec(appendCmd)
-	if err != nil {
-		return fmt.Errorf("failed to inject notify config into %s: %w", configPath, err)
-	}
+	return nil
+}
 
+// StripRemoteCodexNotifyConfig removes the cc-clip managed notify block
+// from ~/.codex/config.toml during uninstall. It is a no-op if the file
+// or block does not exist. Uses the same atomic mktemp+mv pattern as
+// EnsureRemoteCodexNotifyConfig so a crash mid-write leaves either the
+// original file or the cleaned file — never a partial state.
+func StripRemoteCodexNotifyConfig(session RemoteExecutor) error {
+	const markerStart = "# >>> cc-clip notify (do not edit) >>>"
+	const markerEnd = "# <<< cc-clip notify (do not edit) <<<"
+
+	script := fmt.Sprintf(`set -e
+config=~/.codex/config.toml
+if [ ! -f "$config" ]; then
+  exit 0
+fi
+if ! grep -qF '%[1]s' "$config"; then
+  exit 0
+fi
+
+tmp=$(mktemp "$HOME/.codex/.config.toml.cc-clip.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+sed '/^%[2]s$/,/^%[3]s$/d' "$config" > "$tmp"
+
+if [ -s "$config" ]; then
+  chmod --reference="$config" "$tmp" 2>/dev/null || chmod 0644 "$tmp"
+fi
+
+mv "$tmp" "$config"
+trap - EXIT
+`, markerStart, sedEscape(markerStart), sedEscape(markerEnd))
+
+	if _, err := session.Exec(script); err != nil {
+		return fmt.Errorf("failed to strip cc-clip notify block from ~/.codex/config.toml: %w", err)
+	}
 	return nil
 }
 

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -307,15 +307,165 @@ func TestEnsureRemoteCodexNotifyConfigReturnsProbeError(t *testing.T) {
 	}
 }
 
-func TestEnsureRemoteCodexNotifyConfigStopsOnSedError(t *testing.T) {
-	exec := &codexNotifySedErrorExecutor{}
+// TestEnsureRemoteCodexNotifyConfigPrependsBeforeSection is the primary
+// regression test for the F1 (section-scoping) bug.
+func TestEnsureRemoteCodexNotifyConfigPrependsBeforeSection(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, `model = "gpt-5"
 
-	err := EnsureRemoteCodexNotifyConfig(exec, 18339)
-	if err == nil {
-		t.Fatal("EnsureRemoteCodexNotifyConfig should surface sed errors")
+[tui.model_availability_nux]
+"gpt-5" = 4
+`)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
 	}
-	if exec.appended {
-		t.Fatal("EnsureRemoteCodexNotifyConfig appended after sed failure")
+
+	config := readTestCodexConfig(t, s.home)
+	notifyIdx := strings.Index(config, "notify =")
+	sectionIdx := strings.Index(config, "[tui.model_availability_nux]")
+	if notifyIdx < 0 || sectionIdx < 0 {
+		t.Fatalf("expected both notify and section in config: %q", config)
+	}
+	if notifyIdx > sectionIdx {
+		t.Fatalf("notify must appear before [tui.model_availability_nux] to stay at TOML top level, got:\n%s", config)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigFirstLineSection covers the corner case
+// where the very first line is a [section] header.
+func TestEnsureRemoteCodexNotifyConfigFirstLineSection(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "[tui.model_availability_nux]\n\"gpt-5\" = 4\n")
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	notifyIdx := strings.Index(config, "notify =")
+	sectionIdx := strings.Index(config, "[tui.model_availability_nux]")
+	if notifyIdx < 0 || sectionIdx < 0 || notifyIdx > sectionIdx {
+		t.Fatalf("notify must precede the first-line section, got:\n%s", config)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigNoTrailingNewline ensures the rewrite
+// does not concatenate the managed block with the last line.
+func TestEnsureRemoteCodexNotifyConfigNoTrailingNewline(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, `model = "gpt-5"`)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if strings.Contains(config, `gpt-5"# >>>`) || strings.Contains(config, `gpt-5"#>>>`) {
+		t.Fatalf("managed block must not concatenate with trailing line, got:\n%s", config)
+	}
+	if !strings.HasSuffix(config, "\n") {
+		t.Fatalf("rewritten config must end with newline, got: %q", config)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigIdempotentReinjection asserts running
+// the injection twice yields a byte-identical result.
+func TestEnsureRemoteCodexNotifyConfigIdempotentReinjection(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "model = \"gpt-5\"\n\n[tui.foo]\n\"gpt-5\" = 4\n")
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("first injection failed: %v", err)
+	}
+	first := readTestCodexConfig(t, s.home)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("second injection failed: %v", err)
+	}
+	second := readTestCodexConfig(t, s.home)
+
+	if first != second {
+		t.Fatalf("re-injection must be byte-identical.\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+	if strings.Count(second, "# >>> cc-clip notify (do not edit) >>>") != 1 {
+		t.Fatalf("expected exactly one managed block, got:\n%s", second)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigEmptyFile covers an empty existing
+// config — no extra blank lines should pad the managed block.
+func TestEnsureRemoteCodexNotifyConfigEmptyFile(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "")
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if !strings.Contains(config, "# >>> cc-clip notify (do not edit) >>>") {
+		t.Fatalf("managed block missing: %q", config)
+	}
+	if strings.Contains(config, "\n\n\n") {
+		t.Fatalf("empty file should not produce triple newlines, got: %q", config)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigFileDoesNotExist covers the case
+// where ~/.codex/ itself does not exist yet.
+func TestEnsureRemoteCodexNotifyConfigFileDoesNotExist(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err != nil {
+		t.Fatalf("EnsureRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if !strings.Contains(config, "notify =") {
+		t.Fatalf("managed block missing after first-run write: %q", config)
+	}
+}
+
+// TestStripRemoteCodexNotifyConfigRemovesManagedBlock covers the
+// uninstall companion: managed block must be removed, user content
+// preserved.
+func TestStripRemoteCodexNotifyConfigRemovesManagedBlock(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "model = \"gpt-5\"\n"+
+		codexNotifyManagedBlock("# >>> cc-clip notify (do not edit) >>>", "# <<< cc-clip notify (do not edit) <<<", 18339)+
+		"\n[tui.foo]\n\"gpt-5\" = 4\n")
+
+	if err := StripRemoteCodexNotifyConfig(s); err != nil {
+		t.Fatalf("StripRemoteCodexNotifyConfig returned error: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if strings.Contains(config, "cc-clip notify") {
+		t.Fatalf("managed block must be fully removed, got:\n%s", config)
+	}
+	if !strings.Contains(config, "[tui.foo]") || !strings.Contains(config, `model = "gpt-5"`) {
+		t.Fatalf("user content must be preserved, got:\n%s", config)
+	}
+}
+
+// TestStripRemoteCodexNotifyConfigNoOpWhenAbsent verifies that strip on
+// a config without a managed block (or missing file) is a no-op.
+func TestStripRemoteCodexNotifyConfigNoOpWhenAbsent(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+
+	original := `model = "gpt-5"` + "\n[tui.foo]\n\"gpt-5\" = 4\n"
+	writeTestCodexConfig(t, s.home, original)
+	if err := StripRemoteCodexNotifyConfig(s); err != nil {
+		t.Fatalf("strip on no-block file failed: %v", err)
+	}
+	if got := readTestCodexConfig(t, s.home); got != original {
+		t.Fatalf("strip must not modify file without managed block.\nwant: %q\ngot:  %q", original, got)
+	}
+
+	s2 := &localSession{home: t.TempDir()}
+	if err := StripRemoteCodexNotifyConfig(s2); err != nil {
+		t.Fatalf("strip on missing file must be no-op, got: %v", err)
 	}
 }
 
@@ -346,23 +496,6 @@ func parseUnameOutput(output string) (string, string, error) {
 func TestSessionExecutorInterface_StaticConformance(t *testing.T) {
 	// Compile-time assertion: *SSHSession implements SessionExecutor.
 	var _ SessionExecutor = (*SSHSession)(nil)
-}
-
-type codexNotifySedErrorExecutor struct {
-	appended bool
-}
-
-func (c *codexNotifySedErrorExecutor) Exec(cmd string) (string, error) {
-	if strings.Contains(cmd, "grep -F") {
-		return "# >>> cc-clip notify (do not edit) >>>", nil
-	}
-	if strings.Contains(cmd, "sed -i") {
-		return "", fmt.Errorf("sed failed")
-	}
-	if strings.Contains(cmd, "cat >>") {
-		c.appended = true
-	}
-	return "", nil
 }
 
 func writeTestCodexConfig(t *testing.T, home, content string) {


### PR DESCRIPTION
## Summary
- Rewrite `EnsureRemoteCodexNotifyConfig` to prepend the managed block above all section headers (closes the F1 "TOML section scoping" bug surfaced by @affromero in #66).
- Stage rewrites in a same-filesystem `mktemp` inside `~/.codex/` and `mv` atomically via `rename(2)`, eliminating the silent half-write failure that the previous `cat >>` and default-`mktemp` paths both had.
- Run everything under `set -e` + cleanup `trap` so internal failures surface as non-zero SSH exit codes instead of being masked by `rm -f`.
- Add `StripRemoteCodexNotifyConfig` and wire it into `cmdUninstallCodexRemote` so uninstall no longer leaves a stale notify hook pointing at a missing cc-clip binary.

## Relationship to #66
This PR supersedes #66. @affromero independently surfaced the same bug on a fresh v0.5.0 → v0.7.4 upgrade and contributed the first fix attempt. That work shaped this PR's primary regression test (config ending with a `[section]`); attribution is preserved via a `Co-authored-by` trailer on the commit. The broader scope here (atomic mktemp, set -e, idempotency, uninstall cleanup) follows `docs/superpowers/specs/2026-05-11-codex-config-toml-section-scoping-fix.md`.

## Test plan
- [x] \`go test ./internal/shim/... -count=1 -race\` — 12 codex tests pass (4 retained + 7 new + 1 strip noop).
- [x] \`go test ./... -count=1 -race\` — full project, 15 packages PASS, 0 regressions.
- [x] \`go vet ./...\` clean.
- [ ] Manual: run \`cc-clip setup --codex\` against a remote whose config ends with \`[tui.x]\`, confirm codex starts cleanly after injection.
- [ ] Manual: run \`cc-clip uninstall --codex\` and confirm \`~/.codex/config.toml\` no longer contains the managed block.