### PR TITLE
fix(daemon): bind notification nonce to SSH host in /register-nonce

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -887,7 +887,7 @@ remote has a valid claude binary installed.
 
 	// Notification bridge setup (unless --no-notify)
 	if !opts.noNotify {
-		connectNotifySetup(session, port, daemonToken, newState)
+		connectNotifySetup(session, port, daemonToken, host, newState)
 		if err := shim.WriteRemoteState(session, newState); err != nil {
 			log.Printf("      warning: could not write remote deploy state: %v", err)
 		}
@@ -946,7 +946,7 @@ func newDeployState(localBin, binaryVersion, shimTarget string, pathFixed bool, 
 // 4. Print Claude Code hook config
 // 5. Detect and configure Codex notify (if ~/.codex exists)
 // 6. Run health probe
-func connectNotifySetup(session *shim.SSHSession, port int, daemonToken string, state *shim.DeployState) {
+func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host string, state *shim.DeployState) {
 	fmt.Println()
 	fmt.Println("Notification bridge setup:")
 
@@ -958,8 +958,10 @@ func connectNotifySetup(session *shim.SSHSession, port int, daemonToken string, 
 		return
 	}
 
-	// Register nonce with the local daemon via HTTP
-	if err := registerNonceWithDaemon(port, daemonToken, notifyNonce); err != nil {
+	// Register nonce with the local daemon via HTTP. host binds this
+	// nonce to the SSH target so a reconnect immediately revokes the
+	// previously issued nonce instead of waiting on TTL or FIFO cap.
+	if err := registerNonceWithDaemon(port, daemonToken, notifyNonce, host); err != nil {
 		log.Printf("      warning: failed to register nonce with daemon: %v", err)
 		return
 	}
@@ -1036,11 +1038,19 @@ func connectNotifySetup(session *shim.SSHSession, port int, daemonToken string, 
 
 // registerNonceWithDaemon sends the notification nonce to the local daemon
 // via POST /register-nonce, authenticated with the clipboard bearer token.
-func registerNonceWithDaemon(port int, bearerToken, nonce string) error {
-	payload := fmt.Sprintf(`{"nonce":%q}`, nonce)
+// host binds the nonce to the SSH target so the daemon can revoke any
+// previously issued nonce for the same host on reconnect.
+func registerNonceWithDaemon(port int, bearerToken, nonce, host string) error {
+	payloadBytes, err := json.Marshal(struct {
+		Nonce string `json:"nonce"`
+		Host  string `json:"host,omitempty"`
+	}{Nonce: nonce, Host: host})
+	if err != nil {
+		return fmt.Errorf("failed to encode register-nonce payload: %w", err)
+	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/register-nonce", port)
 
-	req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+	req, err := http.NewRequest("POST", url, strings.NewReader(string(payloadBytes)))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -307,13 +307,53 @@ func TestRegisterNonceWithDaemonIntegration(t *testing.T) {
 	port := extractPort(t, ts.URL)
 	testNonce := "test-nonce-0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
 
-	if err := registerNonceWithDaemon(port, sess.Token, testNonce); err != nil {
+	if err := registerNonceWithDaemon(port, sess.Token, testNonce, ""); err != nil {
 		t.Fatalf("registerNonceWithDaemon failed: %v", err)
 	}
 
 	// Verify the nonce works by sending a health probe
 	if err := runNotificationHealthProbe(port, testNonce); err != nil {
 		t.Fatalf("health probe failed after nonce registration: %v", err)
+	}
+}
+
+// TestRegisterNonceWithDaemonHostRevokesPrior asserts the client→daemon
+// wiring: a second registration for the same host invalidates the first
+// nonce immediately, instead of waiting on TTL or FIFO eviction. This
+// regression-guards the host parameter threading through main.go +
+// connectNotifySetup + registerNonceWithDaemon + handleRegisterNonce.
+func TestRegisterNonceWithDaemonHostRevokesPrior(t *testing.T) {
+	tm := token.NewManager(time.Hour)
+	sess, err := tm.Generate()
+	if err != nil {
+		t.Fatalf("failed to generate token: %v", err)
+	}
+	store := session.NewStore(12 * time.Hour)
+	srv := daemon.NewServer("127.0.0.1:0", &testClipboard{}, tm, store)
+
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	port := extractPort(t, ts.URL)
+
+	oldNonce := "old-nonce-0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab"
+	newNonce := "new-nonce-fedcba9876543210fedcba9876543210fedcba9876543210fedcba98765432"
+	const host = "venus.example"
+
+	if err := registerNonceWithDaemon(port, sess.Token, oldNonce, host); err != nil {
+		t.Fatalf("first register: %v", err)
+	}
+	if err := runNotificationHealthProbe(port, oldNonce); err != nil {
+		t.Fatalf("old nonce should be valid right after registration: %v", err)
+	}
+
+	if err := registerNonceWithDaemon(port, sess.Token, newNonce, host); err != nil {
+		t.Fatalf("second register: %v", err)
+	}
+	if err := runNotificationHealthProbe(port, newNonce); err != nil {
+		t.Fatalf("new nonce should be valid after reregistration: %v", err)
+	}
+	if err := runNotificationHealthProbe(port, oldNonce); err == nil {
+		t.Fatal("same-host reconnect must revoke the previous nonce, but old nonce still authenticates")
 	}
 }
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -376,17 +376,21 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleRegisterNonce accepts a notification nonce from an authenticated
-// connect session. The request body is a JSON object with a "nonce" field.
+// connect session. The request body is a JSON object with "nonce" and
+// optional "host" fields. When host is non-empty, any previous nonce
+// bound to that host is revoked so a reconnect immediately invalidates
+// the prior credential instead of waiting for TTL or FIFO eviction.
 // Protected by authMiddleware (requires clipboard bearer token).
 func (s *Server) handleRegisterNonce(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Nonce string `json:"nonce"`
+		Host  string `json:"host"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := s.RegisterNotificationNonce(req.Nonce); err != nil {
+	if err := s.RegisterNotificationNonceForHost(req.Nonce, req.Host); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -124,6 +124,38 @@ func TestRegisterNotificationNonceCapsRegistry(t *testing.T) {
 	}
 }
 
+func TestHandleRegisterNonceRevokesPreviousNonceForSameHost(t *testing.T) {
+	srv, tok := newTestServer(&mockClipboard{})
+
+	post := func(nonce, host string) int {
+		body := fmt.Sprintf(`{"nonce":%q,"host":%q}`, nonce, host)
+		req := httptest.NewRequest("POST", "/register-nonce", strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("User-Agent", "cc-clip/connect")
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := post("nonce-old", "host-venus"); code != http.StatusNoContent {
+		t.Fatalf("first register: expected 204, got %d", code)
+	}
+	if !srv.validNotificationNonce("nonce-old") {
+		t.Fatal("first registration should make nonce-old valid")
+	}
+
+	if code := post("nonce-new", "host-venus"); code != http.StatusNoContent {
+		t.Fatalf("second register: expected 204, got %d", code)
+	}
+	if !srv.validNotificationNonce("nonce-new") {
+		t.Fatal("second registration should make nonce-new valid")
+	}
+	if srv.validNotificationNonce("nonce-old") {
+		t.Fatal("second registration for the same host must revoke nonce-old; old nonce still valid")
+	}
+}
+
 func TestRegisterNotificationNonceSameHostKeepsOrderBounded(t *testing.T) {
 	srv, _ := newTestServer(&mockClipboard{})
 


### PR DESCRIPTION
## Summary

PR #68 added per-host nonce revocation via `RegisterNotificationNonceForHost`, but the production call chain never passed the host through. The same-host revocation guarded by `if host != \"\"` was unreachable in practice, so old nonces persisted until 7-day TTL or 1024-entry FIFO cap eviction.

This is a small forward-fix to #68: thread `host` through `cmdConnect` → `connectNotifySetup` → `registerNonceWithDaemon` → `handleRegisterNonce`, and switch the client payload to `json.Marshal` so SSH targets containing `@` or `:` round-trip safely.

## Changes

| Layer | Before | After |
|---|---|---|
| `handleRegisterNonce` (server) | decodes only `nonce`, calls `RegisterNotificationNonce` (empty-host wrapper) | decodes `nonce` + optional `host`, calls `RegisterNotificationNonceForHost` directly |
| `registerNonceWithDaemon` (client) | `fmt.Sprintf('{\"nonce\":%q}', nonce)` | `json.Marshal` of `{Nonce, Host omitempty}` |
| `connectNotifySetup` (client) | no host parameter | accepts `host`, forwards to register call |
| `cmdConnect` call site | `connectNotifySetup(session, port, daemonToken, newState)` | `connectNotifySetup(session, port, daemonToken, host, newState)` |

## Backward compatibility

Payloads without `host` decode to `req.Host == \"\"`, which routes to the legacy empty-host path. The pre-existing `TestRegisterNonceWithDaemonIntegration` test updated to pass `host=\"\"` explicitly to confirm this branch still works.

## Test plan

- [x] `go test ./internal/daemon -run TestHandleRegisterNonceRevokesPreviousNonceForSameHost -race`  — handler-level wire format + revocation
- [x] `go test ./cmd/cc-clip -run TestRegisterNonceWithDaemonHostRevokesPrior -race` — full client→daemon roundtrip via httptest; verifies old nonce rejected by `runNotificationHealthProbe` after same-host reregistration
- [x] `go test ./... -race -count=1` — all 14 packages pass, zero races
- [x] `go vet ./...` clean
- [x] `go build ./...` clean

## Discovery

Found during read-only review of #68's merged state. Endpoint-level unit tests (`TestRegisterNotificationNonceCapsRegistry`, `TestRegisterNotificationNonceSameHostKeepsOrderBounded`) all exercise `RegisterNotificationNonceForHost` directly with a host argument — they pass — but no test pierced the HTTP handler or the `cmdConnect` payload construction, masking the gap. The two new regression tests close that hole at both levels.