### PR TITLE
fix(shim): section-aware top-level notify detection in codex inject

### DIFF
--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -349,7 +349,7 @@ func installWrapperWithSidecar(s SessionExecutor, port int) error {
 	// Pre-flight: refuse if sidecar already exists.
 	out, _ := s.Exec(`if test -e "$HOME/.local/bin/claude.cc-clip-real" || test -L "$HOME/.local/bin/claude.cc-clip-real"; then echo conflict; fi`)
 	if strings.TrimSpace(out) == "conflict" {
-		return fmt.Errorf("install: ~/.local/bin/claude.cc-clip-real already exists; remove it manually and re-run")
+		return fmt.Errorf("install: ~/.local/bin/claude.cc-clip-real already exists; inspect with `ls -la ~/.local/bin/claude*` (compare to ~/.local/bin/claude to decide if it is a stale backup safe to remove, or restore it as ~/.local/bin/claude before re-running)")
 	}
 
 	script := ClaudeWrapperScript(port)
@@ -449,8 +449,18 @@ touch "$config"
 
 stripped=$(sed '/^%[1]s$/,/^%[2]s$/d' "$config" | sed '/./,$!d')
 
-if printf '%%s\n' "$stripped" | grep -Eq '^[[:space:]]*notify[[:space:]]*='; then
-  echo "existing notify setting found in $config -- refusing to inject duplicate. Remove or comment out the existing notify line first" >&2
+# Section-aware top-level notify detection. Codex supports per-agent
+# notify overrides under [agents.X], which are NOT the same as the
+# top-level notify cc-clip injects. Only refuse when a notify line
+# appears in the file BEFORE any [section] header (i.e. in the TOML
+# top-level table). Lines after any [...] header belong to that
+# section's sub-table and must be ignored.
+if printf '%%s\n' "$stripped" | awk '
+  /^\[/ { in_section = 1; next }
+  in_section == 0 && /^[[:space:]]*notify[[:space:]]*=/ { found = 1 }
+  END { exit !found }
+'; then
+  echo "existing top-level notify setting found in $config -- refusing to inject duplicate. Remove or comment out the top-level notify line first ([agents.X].notify is fine)" >&2
   exit 7
 fi
 

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -278,6 +278,59 @@ func TestEnsureRemoteCodexNotifyConfigRefusesUserNotify(t *testing.T) {
 	}
 }
 
+// TestEnsureRemoteCodexNotifyConfigAllowsAgentSectionNotify asserts that a
+// notify key living inside a sub-table such as [agents.X] does NOT trigger
+// the top-level notify guard. Codex supports per-agent notify overrides;
+// cc-clip's top-level injection should not be blocked by them.
+//
+// Regression: prior to this test the injection script used
+// `grep -Eq '^[[:space:]]*notify[[:space:]]*='` which matched ANY notify
+// line regardless of section context, causing `cc-clip connect --codex` to
+// fail with exit status 7 whenever the user (or a previous tool) had set
+// an agent-level notify.
+func TestEnsureRemoteCodexNotifyConfigAllowsAgentSectionNotify(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, `model = "gpt-5"
+
+[agents.docs_researcher]
+description = "Docs researcher"
+notify = ["other", "tool"]
+`)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 9999); err != nil {
+		t.Fatalf("agent-level notify must not block top-level injection: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if !strings.Contains(config, "CC_CLIP_PORT=9999") {
+		t.Fatalf("managed block missing after agent-section notify present: %q", config)
+	}
+	if !strings.Contains(config, `[agents.docs_researcher]`) {
+		t.Fatalf("agent section must be preserved: %q", config)
+	}
+	if !strings.Contains(config, `notify = ["other", "tool"]`) {
+		t.Fatalf("agent-level notify line must be preserved verbatim: %q", config)
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigStillRefusesTopLevelNotifyAboveSection
+// guards the other half of section-aware detection: a top-level notify
+// that appears BEFORE any section header must still trigger refusal. This
+// pins #67's original contract so it cannot be silently regressed.
+func TestEnsureRemoteCodexNotifyConfigStillRefusesTopLevelNotifyAboveSection(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, `model = "gpt-5"
+notify = ["users", "thing"]
+
+[features]
+foo = true
+`)
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err == nil {
+		t.Fatal("top-level notify (above any section) must still be refused")
+	}
+}
+
 func TestEnsureRemoteCodexNotifyConfigReplacesManagedBlock(t *testing.T) {
 	s := &localSession{home: t.TempDir()}
 	writeTestCodexConfig(t, s.home, "# before\n"+


### PR DESCRIPTION
## Summary

The codex notify injection script in v0.7.5 (introduced by #67) detected "existing top-level notify" with `grep -Eq '^[[:space:]]*notify[[:space:]]*='`, which matched **any** notify line regardless of TOML section context. A perfectly legal per-agent override under \`[agents.X]\` would falsely trip the guard and make \`cc-clip connect --codex\` fail with \`exit status 7\`.

Observed on a real venus deployment where a pre-#67 cc-clip had \`append\`-ed \`notify = ...\` to EOF; subsequent Codex edits turned the file's tail into \`[agents.docs_researcher]\`, so the legacy line silently became \`[agents.docs_researcher].notify\` — a valid sub-table key but still matched by the over-broad grep.

## Fix

Replace the grep with a section-aware awk that only considers lines **before** the first \`[section]\` header (the TOML top-level table). Lines after any \`[...]\` header belong to that section's sub-table and are correctly ignored.

\`\`\`bash
if printf '%s\n' \"\$stripped\" | awk '
  /^\\[/ { in_section = 1; next }
  in_section == 0 && /^[[:space:]]*notify[[:space:]]*=/ { found = 1 }
  END { exit !found }
'; then
  echo \"existing top-level notify setting found ... ([agents.X].notify is fine)\" >&2
  exit 7
fi
\`\`\`

## Side fix (N4 UX)

Extend the wrapper-install sidecar conflict message from \"remove it manually\" to a concrete \`ls -la ~/.local/bin/claude*\` inspect hint plus the option to restore the stale backup as the live claude binary. Pre-existing test asserts on the \"already exists\" substring, preserved verbatim.

## Regression tests

- \`TestEnsureRemoteCodexNotifyConfigAllowsAgentSectionNotify\` reproduces the venus failure: top-level injection succeeds despite \`[agents.docs_researcher].notify\` being present.
- \`TestEnsureRemoteCodexNotifyConfigStillRefusesTopLevelNotifyAboveSection\` pins the other half so #67's original "refuse user's top-level notify" contract cannot be silently regressed.

## Test plan

- [x] \`go test ./internal/shim -run TestEnsureRemoteCodexNotifyConfig -race -count=1\` — 12 tests pass including the 2 new regression tests
- [x] \`go test ./internal/shim -run TestInstallWrapperWithSidecar -race -count=1\` — N4 error-message change does not break the \"already exists\" substring contract
- [x] \`go test ./... -race -count=1\` — all 14 packages pass, zero races
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] **Real-world verification on venus**: identical config layout to the bug fixture; after merging this fix \`cc-clip connect venus --codex --force\` will no longer require manual cleanup of \`[agents.X].notify\` lines.

## Backward compatibility

The contract remains: user-set TOP-LEVEL \`notify\` is refused; agent-level (sub-table) \`notify\` is now allowed. No flag changes, no schema changes, no exit-code changes (still exit 7 on refusal, same stderr structure plus a friendlier hint).