### PR TITLE
fix(shim): whitespace-tolerant section-header detection in codex notify inject

### DIFF
--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -455,8 +455,13 @@ stripped=$(sed '/^%[1]s$/,/^%[2]s$/d' "$config" | sed '/./,$!d')
 # appears in the file BEFORE any [section] header (i.e. in the TOML
 # top-level table). Lines after any [...] header belong to that
 # section's sub-table and must be ignored.
+#
+# TOML 1.0.0 treats leading whitespace on a section header line as
+# whitespace and ignores it, so "  [agents.X]" is still a valid
+# header. Match it symmetrically with [[:space:]]* to avoid
+# misclassifying indented sub-tables.
 if printf '%%s\n' "$stripped" | awk '
-  /^\[/ { in_section = 1; next }
+  /^[[:space:]]*\[/ { in_section = 1; next }
   in_section == 0 && /^[[:space:]]*notify[[:space:]]*=/ { found = 1 }
   END { exit !found }
 '; then

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -313,6 +313,34 @@ notify = ["other", "tool"]
 	}
 }
 
+// TestEnsureRemoteCodexNotifyConfigAllowsIndentedAgentSectionNotify
+// covers the TOML 1.0.0 corner where a section header has leading
+// whitespace. Per the spec, indentation is whitespace and ignored, so
+// "  [agents.X]" remains a valid section header and any "  notify ="
+// inside it must NOT be treated as a top-level notify.
+//
+// Regression: prior to v0.7.7 the awk used /^\[/ which only matched
+// section headers at column 0, so indented headers were silently
+// skipped and the notify line below them was mis-classified as
+// top-level — falsely tripping exit 7.
+func TestEnsureRemoteCodexNotifyConfigAllowsIndentedAgentSectionNotify(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "model = \"gpt-5\"\n"+
+		"\n"+
+		"  [agents.docs_researcher]\n"+
+		"  description = \"Docs researcher\"\n"+
+		"  notify = [\"other\", \"tool\"]\n")
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 9999); err != nil {
+		t.Fatalf("indented agent-level notify must not block top-level injection: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if !strings.Contains(config, "CC_CLIP_PORT=9999") {
+		t.Fatalf("managed block missing after indented agent-section notify present: %q", config)
+	}
+}
+
 // TestEnsureRemoteCodexNotifyConfigStillRefusesTopLevelNotifyAboveSection
 // guards the other half of section-aware detection: a top-level notify
 // that appears BEFORE any section header must still trigger refusal. This


### PR DESCRIPTION
## Summary

v0.7.6 introduced section-aware notify detection but its awk used \`/^\[/\`, matching only column-0 \`[section]\` headers. Per [TOML 1.0.0 Table](https://toml.io/en/v1.0.0#table) leading whitespace on a section header is ignored, so a legitimate \`  [agents.X]\` was silently skipped and any \`  notify =\` beneath it was mis-classified as top-level — falsely tripping \`exit 7\`.

## Fix

\`\`\`diff
-  /^\[/ { in_section = 1; next }
+  /^[[:space:]]*\[/ { in_section = 1; next }
\`\`\`

Symmetric with the \`[[:space:]]*\` tolerance already present in the notify-line regex.

## Test plan

- [x] RED: \`TestEnsureRemoteCodexNotifyConfigAllowsIndentedAgentSectionNotify\` reproduces \`exit status 7\` against v0.7.6 awk
- [x] GREEN: same test passes after regex fix
- [x] No regression: 11 prior \`TestEnsureRemoteCodexNotifyConfig*\` tests still pass
- [x] \`go test ./... -race -count=1\` — 14 packages green
- [x] \`go vet ./...\` / \`go build ./...\` clean

## Backward compatibility

Contract unchanged: user-set top-level notify still refused; any sub-table notify (now correctly detected regardless of indentation) is allowed. No flag/schema/exit-code changes.