### PR TITLE
fix(shim): close hook-script injection and wrapper-install atomicity gaps

### DIFF
--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -374,6 +375,113 @@ func TestInstall_SymlinkOrigin_NativeInstallerLayout(t *testing.T) {
 	}
 }
 
+// capturingSession records the install command(s) so we can assert on the
+// generated bash without executing it. Exec runs normally (pre-flight probe);
+// ExecWithStdin captures the script body and then delegates.
+type capturingSession struct {
+	*localSession
+	lastStdinCmd string
+}
+
+func (c *capturingSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
+	c.lastStdinCmd = cmd
+	return c.localSession.ExecWithStdin(cmd, stdin)
+}
+
+// TestInstall_SidecarTrapRestoresOnAbort asserts the with-sidecar install
+// command tracks a `committed` flag and that its EXIT trap restores the
+// sidecar back to ~/.local/bin/claude when the install was NOT committed.
+//
+// Regression: the trap previously only did `rm -f "$tmp"`. An external abort
+// (SSH disconnect / SIGKILL) AFTER the staging mv (claude -> claude.cc-clip-real)
+// but BEFORE the commit mv (tmp -> claude) left ~/.local/bin/claude missing,
+// breaking the user's claude even though the docstring promised rollback.
+func TestInstall_SidecarTrapRestoresOnAbort(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("ORIGINAL"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cap := &capturingSession{localSession: &localSession{home: home}}
+	if err := InstallRemoteClaudeWrapper(cap, 18339); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	cmd := cap.lastStdinCmd
+	// The script must introduce a committed marker and set it after the
+	// commit mv succeeds.
+	if !strings.Contains(cmd, "committed") {
+		t.Fatal("with-sidecar install script must track a `committed` flag for trap-based rollback")
+	}
+	// The EXIT trap must restore the sidecar when not committed (not merely rm the tmp).
+	if !strings.Contains(cmd, "claude.cc-clip-real") || !strings.Contains(cmd, "trap") {
+		t.Fatal("with-sidecar install script must restore the sidecar from the EXIT trap")
+	}
+	// Specifically, the trap body must reference the sidecar restore mv so an
+	// abort between the two mvs cannot leave claude missing.
+	if !strings.Contains(cmd, `mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude"`) {
+		t.Fatal("EXIT trap must restore claude from the sidecar on abort")
+	}
+}
+
+// TestInstall_SidecarAbortBeforeCommitRestoresClaude simulates an abort that
+// happens AFTER the staging mv but BEFORE the commit mv, by truncating the
+// generated script at the staging point and running the EXIT trap. After the
+// truncated run, ~/.local/bin/claude must be restored (not missing).
+func TestInstall_SidecarAbortBeforeCommitRestoresClaude(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash-based install path is Linux-only")
+	}
+	home, binDir := setupFakeHome(t)
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("ORIGINAL-CLAUDE"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cap := &capturingSession{localSession: &localSession{home: home}}
+	if err := InstallRemoteClaudeWrapper(cap, 18339); err != nil {
+		t.Fatalf("install (to capture script): %v", err)
+	}
+
+	// Reset filesystem to the pre-install state for the abort simulation.
+	if err := os.RemoveAll(binDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("ORIGINAL-CLAUDE"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Truncate the captured script right after the staging mv so the commit
+	// mv never runs, then `exit 1` to fire the EXIT trap — modeling an abort
+	// between the two mvs.
+	full := cap.lastStdinCmd
+	marker := `mv "$HOME/.local/bin/claude" "$HOME/.local/bin/claude.cc-clip-real"`
+	idx := strings.Index(full, marker)
+	if idx < 0 {
+		t.Fatalf("staging mv not found in generated script:\n%s", full)
+	}
+	truncated := full[:idx+len(marker)] + "\nexit 1\n"
+
+	c := exec.Command("bash", "-c", truncated)
+	c.Env = append(os.Environ(), "HOME="+home, "PATH=/usr/bin:/bin")
+	c.Stdin = strings.NewReader("WRAPPER-CONTENT")
+	_ = c.Run() // exit 1 expected
+
+	// CRITICAL: claude must be restored by the trap, not left missing.
+	data, err := os.ReadFile(filepath.Join(binDir, "claude"))
+	if err != nil {
+		t.Fatalf("claude missing after abort between mvs — trap did not restore: %v", err)
+	}
+	if string(data) != "ORIGINAL-CLAUDE" {
+		t.Fatalf("claude content not restored on abort, got %q", string(data))
+	}
+}
+
 // rollbackInjectingSession wraps localSession and rewrites the install
 // command to force the final mv to fail, simulating a filesystem error
 // after the staging mv has already moved origin to the sidecar.
@@ -386,11 +494,13 @@ type rollbackInjectingSession struct {
 func (r *rollbackInjectingSession) ExecWithStdin(cmd string, stdin io.Reader) (string, error) {
 	if !r.injected && strings.Contains(cmd, "claude.cc-clip-real") {
 		r.injected = true
-		// Replace the final mv guard with a forced failure so the rollback
-		// branch (mv sidecar back to claude) is exercised.
+		// Force the commit mv to fail so the EXIT trap's rollback branch
+		// (restore sidecar -> claude) is exercised. Under `set -e` the
+		// failing command aborts the script and fires the trap, exactly
+		// like an external abort between the staging and commit mvs.
 		cmd = strings.Replace(cmd,
-			`if ! mv "$tmp" "$HOME/.local/bin/claude"; then`,
-			`if ! false; then`, 1)
+			`mv "$tmp" "$HOME/.local/bin/claude"`,
+			`false`, 1)
 	}
 	return r.localSession.ExecWithStdin(cmd, stdin)
 }

--- a/internal/shim/hook_template.go
+++ b/internal/shim/hook_template.go
@@ -20,12 +20,12 @@ fi
 
 _payload=$(cat)
 
-_payload=$(echo "$_payload" | python3 -c "
-import sys, json
+_payload=$(echo "$_payload" | CC_CLIP_HOST="$_CC_CLIP_HOST_ALIAS" python3 -c '
+import sys, json, os
 d = json.load(sys.stdin)
-d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
+d["_cc_clip_host"] = os.environ["CC_CLIP_HOST"]
 json.dump(d, sys.stdout)
-" 2>/dev/null || echo "$_payload")
+' 2>/dev/null || echo "$_payload")
 
 _cc_clip_curl_config() {
 	printf 'header = "Authorization: Bearer %%s"\n' "$_nonce"

--- a/internal/shim/hook_template_test.go
+++ b/internal/shim/hook_template_test.go
@@ -89,6 +89,87 @@ func TestHookScriptKeepsNonceOutOfCurlArgv(t *testing.T) {
 	}
 }
 
+func TestHookScriptDoesNotInterpolateHostIntoPythonSource(t *testing.T) {
+	got := HookScript(18339)
+	// The host alias must be passed to python3 via the environment, never
+	// expanded by bash directly into the python -c source. An interpolated
+	// single-quoted literal like d['_cc_clip_host'] = '${_CC_CLIP_HOST_ALIAS}'
+	// is an injection-shaped construct: a value containing a single quote
+	// would break out of the literal and execute attacker-controlled python.
+	if strings.Contains(got, "${_CC_CLIP_HOST_ALIAS}") {
+		t.Fatal("host alias must not be bash-expanded into the python -c source; pass it via the environment instead")
+	}
+	// The python source must read the host from the environment.
+	if !strings.Contains(got, "os.environ") {
+		t.Fatal("expected python source to read the host alias from os.environ")
+	}
+}
+
+func TestHookScriptHandlesHostAliasWithSingleQuoteSafely(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+
+	tmpDir := t.TempDir()
+	argvLog, _ := writeFakeCurl(t, tmpDir)
+	home := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".cache", "cc-clip"), 0700); err != nil {
+		t.Fatalf("mkdir home cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".cache", "cc-clip", "notify.nonce"), []byte("nonce\n"), 0600); err != nil {
+		t.Fatalf("write nonce: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpDir, "cc-clip-hook")
+	if err := os.WriteFile(hookPath, []byte(HookScript(18339)), 0755); err != nil {
+		t.Fatalf("write hook script: %v", err)
+	}
+
+	// A malicious host alias containing a single quote. If the value were
+	// interpolated into single-quoted python source, this would either
+	// crash the python interpreter (SyntaxError) or execute injected code.
+	// Passed via env, it must be embedded verbatim into the JSON payload.
+	// The marker path is absolute so the assertion is robust regardless of
+	// the python interpreter's working directory.
+	pwnedMarker := filepath.Join(tmpDir, "pwned")
+	maliciousHost := "evil'; import os; os.system('touch " + pwnedMarker + "'); x='"
+
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader(`{"hook_event_name":"Stop"}`)
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"CC_CLIP_HOST_ALIAS="+maliciousHost,
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hook execution failed: %v output=%q", err, string(out))
+	}
+
+	// No injected command must have run.
+	if _, err := os.Stat(pwnedMarker); err == nil {
+		t.Fatal("python injection executed: marker file was created")
+	}
+
+	// The payload forwarded to curl (via -d in argv) must carry the host
+	// alias verbatim as JSON, proving the value was treated as data, not code.
+	body, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read fake curl argv: %v", err)
+	}
+	if !strings.Contains(string(body), `_cc_clip_host`) {
+		t.Fatalf("expected _cc_clip_host key in forwarded payload, got %q", string(body))
+	}
+	// The single quote and the literal text must be JSON-escaped/encoded as
+	// a string value, not interpreted. The substring "import os" appears in
+	// the alias text and should be present verbatim as data within the JSON.
+	if !strings.Contains(string(body), "import os") {
+		t.Fatalf("expected the malicious alias to be preserved as JSON data, got %q", string(body))
+	}
+}
+
 func TestHookScriptAlwaysExitsZero(t *testing.T) {
 	got := HookScript(18339)
 	if !strings.Contains(got, "exit 0") {

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -356,19 +356,22 @@ func installWrapperWithSidecar(s SessionExecutor, port int) error {
 	cmd := `set -e
 mkdir -p "$HOME/.local/bin"
 tmp=$(mktemp "$HOME/.local/bin/.claude.cc-clip-tmp.XXXXXX")
-trap 'rm -f "$tmp"' EXIT
+committed=""
+# The EXIT trap restores the sidecar back to claude whenever the install
+# did not commit. This covers in-script failures AND external aborts (SSH
+# disconnect / SIGKILL) that land between the staging mv and the commit mv,
+# which would otherwise leave ~/.local/bin/claude missing. The restore is
+# a no-op before staging (sidecar absent) and after commit (committed set).
+trap '[ -z "$committed" ] && { [ -e "$HOME/.local/bin/claude.cc-clip-real" ] || [ -L "$HOME/.local/bin/claude.cc-clip-real" ]; } && mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude" 2>/dev/null; rm -f "$tmp"' EXIT
 cat > "$tmp"
 chmod +x "$tmp"
 # Stage origin to sidecar (mv on a symlink renames the link itself,
 # never reads/writes through it).
 mv "$HOME/.local/bin/claude" "$HOME/.local/bin/claude.cc-clip-real"
 # Commit wrapper.
-if ! mv "$tmp" "$HOME/.local/bin/claude"; then
-    # Best-effort rollback: restore origin so user's claude keeps working.
-    mv "$HOME/.local/bin/claude.cc-clip-real" "$HOME/.local/bin/claude" 2>/dev/null || true
-    exit 1
-fi
-trap - EXIT  # tmp now consumed by the mv`
+mv "$tmp" "$HOME/.local/bin/claude"
+committed=1
+trap 'rm -f "$tmp"' EXIT  # tmp now consumed by the mv; nothing left to roll back`
 	outErr, err := s.ExecWithStdin(cmd, strings.NewReader(script))
 	if err != nil {
 		return fmt.Errorf("install (with-sidecar): %s: %w", strings.TrimSpace(outErr), err)
@@ -462,7 +465,7 @@ stripped=$(sed '/^%[1]s$/,/^%[2]s$/d' "$config" | sed '/./,$!d')
 # misclassifying indented sub-tables.
 if printf '%%s\n' "$stripped" | awk '
   /^[[:space:]]*\[/ { in_section = 1; next }
-  in_section == 0 && /^[[:space:]]*notify[[:space:]]*=/ { found = 1 }
+  in_section == 0 && /^[[:space:]]*(notify|"notify"|'"'"'notify'"'"')[[:space:]]*=/ { found = 1 }
   END { exit !found }
 '; then
   echo "existing top-level notify setting found in $config -- refusing to inject duplicate. Remove or comment out the top-level notify line first ([agents.X].notify is fine)" >&2

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -359,6 +359,72 @@ foo = true
 	}
 }
 
+// TestEnsureRemoteCodexNotifyConfigRefusesQuotedTopLevelNotify guards the
+// TOML key-equivalence corner: TOML treats notify, "notify", and 'notify'
+// as the SAME bare key. A quoted top-level notify must therefore still
+// trip the duplicate-key guard; otherwise cc-clip injects a second top-level
+// notify and Codex rejects the config as a duplicate key.
+//
+// Regression: prior to this fix the awk guard matched only the bare key
+// (/^[[:space:]]*notify[[:space:]]*=/), so `"notify" = [...]` slipped past
+// and a duplicate was injected.
+func TestEnsureRemoteCodexNotifyConfigRefusesQuotedTopLevelNotify(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{
+			name:    "double_quoted",
+			content: "\"notify\" = [\"custom\", \"notify\"]\n\n[other]\nfoo = true\n",
+		},
+		{
+			name:    "single_quoted",
+			content: "'notify' = [\"custom\", \"notify\"]\n\n[other]\nfoo = true\n",
+		},
+		{
+			name:    "double_quoted_with_leading_space",
+			content: "  \"notify\" = [\"custom\"]\n\n[other]\nfoo = true\n",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &localSession{home: t.TempDir()}
+			writeTestCodexConfig(t, s.home, tc.content)
+
+			if err := EnsureRemoteCodexNotifyConfig(s, 18339); err == nil {
+				t.Fatalf("quoted top-level notify (%s) must be refused to avoid a duplicate key", tc.name)
+			}
+
+			// The original config must be left untouched (no managed block injected).
+			config := readTestCodexConfig(t, s.home)
+			if strings.Contains(config, "# >>> cc-clip notify (do not edit) >>>") {
+				t.Fatalf("managed block must NOT be injected when a quoted top-level notify already exists, got:\n%s", config)
+			}
+		})
+	}
+}
+
+// TestEnsureRemoteCodexNotifyConfigAllowsQuotedAgentSectionNotify verifies
+// the section-aware half still holds for quoted keys: a quoted notify inside
+// a sub-table must NOT block top-level injection.
+func TestEnsureRemoteCodexNotifyConfigAllowsQuotedAgentSectionNotify(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeTestCodexConfig(t, s.home, "model = \"gpt-5\"\n"+
+		"\n"+
+		"[agents.docs_researcher]\n"+
+		"\"notify\" = [\"other\", \"tool\"]\n")
+
+	if err := EnsureRemoteCodexNotifyConfig(s, 9999); err != nil {
+		t.Fatalf("quoted agent-level notify must not block top-level injection: %v", err)
+	}
+
+	config := readTestCodexConfig(t, s.home)
+	if !strings.Contains(config, "CC_CLIP_PORT=9999") {
+		t.Fatalf("managed block missing after quoted agent-section notify present: %q", config)
+	}
+}
+
 func TestEnsureRemoteCodexNotifyConfigReplacesManagedBlock(t *testing.T) {
 	s := &localSession{home: t.TempDir()}
 	writeTestCodexConfig(t, s.home, "# before\n"+


### PR DESCRIPTION
## Summary

Closes three **shim script-generation / install** defects found by a multi-agent deep review with adversarial verification. Changes are confined to `internal/shim` and implemented test-first.

## Fixes

| Sev | ID | What |
|-----|----|------|
| MEDIUM | #3 | **Hook-script injection**: the `cc-clip-hook` script bash-expanded `${_CC_CLIP_HOST_ALIAS}` directly into single-quoted `python3 -c` source (`d['_cc_clip_host'] = '${...}'`), so a host alias containing a quote/backslash/newline could break out of the literal and run arbitrary Python. The value is now passed via the environment and read with `os.environ["CC_CLIP_HOST"]` inside Python; the `|| echo "$_payload"` fallback is preserved. |
| MEDIUM | #4 | **Quoted-key TOML gap**: the top-level `notify` duplicate-detection awk guard only matched the bare key. TOML treats `notify`, `"notify"`, and `'notify'` as the same key, so a quoted top-level `notify` slipped past detection and produced a duplicate-key `config.toml` that Codex rejects at startup. The guard now matches all three forms; section-aware scoping is unchanged. |
| MEDIUM | #5 | **Install crash window**: `installWrapperWithSidecar` staged `mv claude claude.cc-clip-real` before `mv tmp claude` with only an `rm -f $tmp` EXIT trap, so an SSH disconnect / SIGKILL between the two `mv`s left `~/.local/bin/claude` missing. Replaced with a `committed`-flag pattern: the EXIT trap restores the sidecar whenever `committed` is empty (covering external aborts), set after the commit `mv` succeeds. |

## Test plan

New tests (each fails on old code, passes on new):

- `TestHookScriptDoesNotInterpolateHostIntoPythonSource`, `TestHookScriptHandlesHostAliasWithSingleQuoteSafely`
- `TestEnsureRemoteCodexNotifyConfigRefusesQuotedTopLevelNotify` (double-quoted / single-quoted / leading-space subtests), `TestEnsureRemoteCodexNotifyConfigAllowsQuotedAgentSectionNotify`
- `TestInstall_SidecarTrapRestoresOnAbort`, `TestInstall_SidecarAbortBeforeCommitRestoresClaude`

Verification: `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./... -race -count=1` ✓ (all 14 packages green).
