### PR TITLE
fix(tunnel,x11bridge): durable image writes, daemon-liveness probe, INCR lifecycle

### DIFF
--- a/internal/tunnel/fetch.go
+++ b/internal/tunnel/fetch.go
@@ -105,15 +105,28 @@ func (c *Client) FetchImage(outDir string) (string, error) {
 	filename := fmt.Sprintf("%s-%s.%s", time.Now().Format("20060102-150405"), suffix, ext)
 	outPath := filepath.Join(outDir, filename)
 
-	f, err := os.Create(outPath)
+	f, err := os.OpenFile(outPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return "", fmt.Errorf("failed to create image file: %w", err)
 	}
-	defer f.Close()
 
 	if _, err := io.Copy(f, resp.Body); err != nil {
+		f.Close()
 		os.Remove(outPath)
 		return "", fmt.Errorf("failed to write image file: %w", err)
+	}
+
+	// Flush to disk and surface any deferred write errors (e.g. ENOSPC) that
+	// only become visible on Sync/Close. Returning the error lets the shim fall
+	// back instead of emitting a truncated image.
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(outPath)
+		return "", fmt.Errorf("failed to sync image file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(outPath)
+		return "", fmt.Errorf("failed to close image file: %w", err)
 	}
 
 	return outPath, nil

--- a/internal/tunnel/fetch_test.go
+++ b/internal/tunnel/fetch_test.go
@@ -92,6 +92,36 @@ func TestFetchImageRoundTrip(t *testing.T) {
 	t.Logf("Image saved to: %s (%d bytes)", path, len(data))
 }
 
+func TestFetchImageWritesPrivateFileMode(t *testing.T) {
+	fakeImage := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	testToken := "test-token-123"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /clipboard/image", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.Write(fakeImage)
+	})
+
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	client := NewClient(ts.URL, testToken, 5*time.Second)
+	outDir := t.TempDir()
+
+	path, err := client.FetchImage(outDir)
+	if err != nil {
+		t.Fatalf("FetchImage failed: %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat saved image: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0600 {
+		t.Fatalf("expected file mode 0600, got %o", perm)
+	}
+}
+
 func TestFetchImageUnauthorized(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /clipboard/image", func(w http.ResponseWriter, r *http.Request) {
@@ -181,5 +211,63 @@ func TestProbeFailure(t *testing.T) {
 	err := Probe(fmt.Sprintf("127.0.0.1:%d", 59999), 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("probe should fail for closed port")
+	}
+}
+
+func TestProbeHealthSuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	addr := ts.Listener.Addr().String()
+	if err := ProbeHealth(addr, 500*time.Millisecond); err != nil {
+		t.Fatalf("ProbeHealth should succeed: %v", err)
+	}
+}
+
+func TestProbeHealthFailsWhenTCPUnreachable(t *testing.T) {
+	err := ProbeHealth(fmt.Sprintf("127.0.0.1:%d", 59998), 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("ProbeHealth should fail for closed port")
+	}
+	if errors.Is(err, ErrDaemonNotAnswering) {
+		t.Fatalf("closed port should not report ErrDaemonNotAnswering, got: %v", err)
+	}
+}
+
+func TestProbeHealthFailsWhenTCPUpButDaemonDead(t *testing.T) {
+	// A listener that accepts the TCP handshake but never speaks HTTP — this
+	// mimics an SSH RemoteForward listener whose local daemon is down.
+	l, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind 127.0.0.1: %v (restricted environment?)", err)
+	}
+	defer l.Close()
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without responding so the HTTP
+			// client times out waiting for headers.
+			go func(c net.Conn) {
+				time.Sleep(2 * time.Second)
+				c.Close()
+			}(conn)
+		}
+	}()
+
+	err = ProbeHealth(l.Addr().String(), 200*time.Millisecond)
+	if err == nil {
+		t.Fatal("ProbeHealth should fail when daemon does not answer HTTP")
+	}
+	if !errors.Is(err, ErrDaemonNotAnswering) {
+		t.Fatalf("expected ErrDaemonNotAnswering, got: %v", err)
 	}
 }

--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -1,16 +1,51 @@
 package tunnel
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 )
 
+// ErrDaemonNotAnswering indicates the address accepted a TCP connection but the
+// cc-clip daemon did not answer a /health request. This distinguishes a live
+// SSH RemoteForward listener whose local daemon is down from a fully
+// unreachable address.
+var ErrDaemonNotAnswering = errors.New("tunnel reachable but daemon not answering")
+
+// Probe verifies TCP reachability of addr. Note: an SSH RemoteForward listener
+// satisfies the handshake even when the local daemon is down. Use ProbeHealth
+// when daemon liveness (not just port reachability) must be confirmed.
 func Probe(addr string, timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return fmt.Errorf("tunnel unreachable at %s: %w", addr, err)
 	}
 	conn.Close()
+	return nil
+}
+
+// ProbeHealth verifies that a cc-clip daemon is actually answering at addr. It
+// first checks TCP reachability (so a closed port reports a plain unreachable
+// error), then performs an HTTP GET /health. When TCP succeeds but the HTTP
+// probe fails, it wraps ErrDaemonNotAnswering so callers can distinguish a
+// stale RemoteForward listener from a healthy daemon.
+func ProbeHealth(addr string, timeout time.Duration) error {
+	if err := Probe(addr, timeout); err != nil {
+		return err
+	}
+
+	client := &http.Client{Timeout: timeout}
+	url := "http://" + addr + "/health"
+	resp, err := client.Get(url)
+	if err != nil {
+		return fmt.Errorf("%w at %s: %v", ErrDaemonNotAnswering, addr, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w at %s: GET /health -> %d", ErrDaemonNotAnswering, addr, resp.StatusCode)
+	}
 	return nil
 }

--- a/internal/x11bridge/bridge.go
+++ b/internal/x11bridge/bridge.go
@@ -63,7 +63,13 @@ type Bridge struct {
 	activeIncr   *IncrTransfer
 	incrTimeout  time.Duration
 	incrDeadline time.Time
-	httpClient   *http.Client
+	// incrRequestor records the window we subscribed to PropertyChange events
+	// on for the active INCR transfer, so we can unsubscribe even after
+	// activeIncr has been nilled out. hasIncrRequestor distinguishes a real
+	// window 0 from "no subscription".
+	incrRequestor    xproto.Window
+	hasIncrRequestor bool
+	httpClient       *http.Client
 }
 
 // clipboardTypeResponse mirrors daemon.ClipboardInfo.
@@ -375,11 +381,40 @@ func (b *Bridge) handleIncrChunk() {
 func (b *Bridge) startActiveIncr(transfer *IncrTransfer) {
 	b.activeIncr = transfer
 	b.incrDeadline = time.Now().Add(b.incrTimeout)
+	b.incrRequestor = transfer.Requestor
+	b.hasIncrRequestor = true
 }
 
 func (b *Bridge) clearActiveIncr() {
 	b.activeIncr = nil
 	b.incrDeadline = time.Time{}
+	b.unsubscribeIncrRequestor()
+}
+
+// unsubscribeIncrRequestor resets the event mask on the requestor window we
+// subscribed to during an INCR transfer. Leaving CwEventMask set leaks the
+// PropertyChange subscription on that window for the lifetime of the bridge.
+// A BadWindow error (the requestor may already be gone) is tolerated.
+func (b *Bridge) unsubscribeIncrRequestor() {
+	if !b.hasIncrRequestor {
+		return
+	}
+	requestor := b.incrRequestor
+	b.hasIncrRequestor = false
+	b.incrRequestor = 0
+	if b.conn == nil {
+		return
+	}
+	err := xproto.ChangeWindowAttributesChecked(b.conn, requestor,
+		xproto.CwEventMask,
+		[]uint32{0},
+	).Check()
+	if err != nil {
+		if _, ok := err.(xproto.WindowError); ok {
+			return
+		}
+		log.Printf("x11-bridge: failed to clear event mask on requestor 0x%x: %v", requestor, err)
+	}
 }
 
 func (b *Bridge) clearExpiredIncr(now time.Time) {

--- a/internal/x11bridge/bridge_test.go
+++ b/internal/x11bridge/bridge_test.go
@@ -181,6 +181,55 @@ func TestClearExpiredIncr(t *testing.T) {
 	}
 }
 
+func TestStartActiveIncrTracksRequestorForUnsubscribe(t *testing.T) {
+	b := &Bridge{incrTimeout: 50 * time.Millisecond}
+
+	b.startActiveIncr(&IncrTransfer{Requestor: 0x1234})
+
+	if !b.hasIncrRequestor {
+		t.Fatal("startActiveIncr should record that a requestor was subscribed")
+	}
+	if b.incrRequestor != 0x1234 {
+		t.Fatalf("incrRequestor = 0x%x, want 0x1234", b.incrRequestor)
+	}
+}
+
+func TestClearActiveIncrUnsubscribesRequestor(t *testing.T) {
+	// conn is nil: clearActiveIncr must still reset the tracking state without
+	// panicking, proving the unsubscribe path does not depend on activeIncr
+	// remaining non-nil and tolerates the absence of a live connection.
+	b := &Bridge{
+		activeIncr:       &IncrTransfer{Requestor: 0x1234},
+		incrRequestor:    0x1234,
+		hasIncrRequestor: true,
+		incrDeadline:     time.Unix(10, 0),
+	}
+
+	b.clearActiveIncr()
+
+	if b.activeIncr != nil {
+		t.Fatal("clearActiveIncr should clear activeIncr")
+	}
+	if b.hasIncrRequestor {
+		t.Fatal("clearActiveIncr should clear the requestor subscription flag")
+	}
+	if b.incrRequestor != 0 {
+		t.Fatalf("clearActiveIncr should reset incrRequestor, got 0x%x", b.incrRequestor)
+	}
+	if !b.incrDeadline.IsZero() {
+		t.Fatal("clearActiveIncr should clear deadline")
+	}
+}
+
+func TestUnsubscribeIncrRequestorNoOpWhenNotSubscribed(t *testing.T) {
+	b := &Bridge{}
+	// Must not panic or attempt an X call when nothing was subscribed.
+	b.unsubscribeIncrRequestor()
+	if b.hasIncrRequestor {
+		t.Fatal("unsubscribeIncrRequestor should remain unsubscribed")
+	}
+}
+
 func TestPublishXEventStopsWhenContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/x11bridge/incr.go
+++ b/internal/x11bridge/incr.go
@@ -63,10 +63,15 @@ func startIncr(
 
 	// Subscribe to PropertyNotify on the requestor's window so we can
 	// detect when the requestor deletes the property (ready for next chunk).
-	xproto.ChangeWindowAttributes(conn, event.Requestor,
+	// If the subscription fails we would never observe PropertyDelete and the
+	// transfer would stall until the inactivity timeout, so fail loudly and let
+	// the caller refuse the request instead of registering a dead transfer.
+	if err := xproto.ChangeWindowAttributesChecked(conn, event.Requestor,
 		xproto.CwEventMask,
 		[]uint32{xproto.EventMaskPropertyChange},
-	)
+	).Check(); err != nil {
+		return nil, err
+	}
 
 	if err := sendSelectionNotify(conn, event, event.Property); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Hardens the **image-transfer and X11 INCR** paths against I/O and protocol-lifecycle defects found by a multi-agent deep review with adversarial verification. Changes are confined to `internal/tunnel` and `internal/x11bridge`, implemented test-first.

## Fixes

| Sev | ID | What |
|-----|----|------|
| MEDIUM | #18 | **Durable image writes**: `FetchImage` used `os.Create` (0666 → world-readable under umask) + `defer f.Close()` (dropped the close error, no fsync), so a delayed-write failure (NFS/fuse/full disk) could return a truncated image as a valid path. Now `os.OpenFile(..., 0600)`, then explicit `f.Sync()` + `f.Close()` with both errors checked; on any failure the partial file is removed and a wrapped error is returned so the shim falls back to real xclip instead of emitting a half-written image. |
| LOW | #21 | **Daemon-liveness probe**: added sibling `ProbeHealth` + sentinel `ErrDaemonNotAnswering`. It does TCP-first then `GET /health`, so a stale SSH RemoteForward listener (daemon down) is distinguishable from a healthy daemon. The original `Probe` (TCP-only) contract is unchanged — existing callers are unaffected; the new function is available for adoption. |
| LOW | #20 | **INCR subscribe**: `startIncr` now uses `ChangeWindowAttributesChecked(...).Check()` and returns the error if the PropertyChange subscription fails, so the bridge never commits an `activeIncr` for a window it cannot observe (which previously stalled the transfer until the 30s timeout). |
| LOW | #22 | **INCR unsubscribe**: the requestor window id is now tracked independently of `activeIncr`; `clearActiveIncr` resets the requestor's `CwEventMask` back to 0 on both the completion and timeout paths, tolerating `BadWindow`. Stops leaking PropertyChange subscriptions across transfers. |

## Test plan

New tests:

- `TestFetchImageWritesPrivateFileMode`
- `TestProbeHealthSuccess`, `TestProbeHealthFailsWhenTCPUnreachable`, `TestProbeHealthFailsWhenTCPUpButDaemonDead`
- `TestStartActiveIncrTracksRequestorForUnsubscribe`, `TestClearActiveIncrUnsubscribesRequestor`, `TestUnsubscribeIncrRequestorNoOpWhenNotSubscribed`

Verification: `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./internal/tunnel/ ./internal/x11bridge/ -race` ✓ and full `go test ./... -race` ✓.
