### PR TITLE
fix(doctor,setup,connect): surface swallowed SSH/IO errors (incl. HIGH doctor misdiagnosis)

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -720,10 +720,12 @@ remote has a valid claude binary installed.
 		}
 		fmt.Println("      token synced from local daemon")
 
-		if sid, genErr := shim.GenerateSessionID(); genErr == nil {
-			if writeErr := shim.WriteRemoteSessionID(session, sid); writeErr == nil {
-				fmt.Printf("      session ID: %s\n", sid[:16])
-			}
+		if sid, genErr := shim.GenerateSessionID(); genErr != nil {
+			log.Printf("      warning: failed to generate session ID: %v", genErr)
+		} else if writeErr := shim.WriteRemoteSessionID(session, sid); writeErr != nil {
+			log.Printf("      warning: failed to write session ID: %v", writeErr)
+		} else {
+			fmt.Printf("      session ID: %s\n", sid[:16])
 		}
 
 		connectVerifyTunnel(session, port, host)
@@ -1213,9 +1215,16 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string) {
 	probeCmd := fmt.Sprintf(
 		"bash -c 'echo >/dev/tcp/127.0.0.1/%d' 2>/dev/null && echo 'tunnel:ok' || echo 'tunnel:fail'",
 		port)
-	probeOut, _ := session.Exec(probeCmd)
+	probeOut, probeErr := session.Exec(probeCmd)
 
-	if probeOut == "tunnel:ok" {
+	if probeErr != nil {
+		// The probe itself could not run — the SSH master is dead, not the
+		// tunnel. Surfacing the generic "tunnel not detected" guidance here
+		// would send the user chasing a RemoteForward problem that does not
+		// exist; name the real failure instead.
+		fmt.Printf("      tunnel probe could not be executed over SSH: %v\n", probeErr)
+		fmt.Println("      The SSH session appears to be down; re-run 'cc-clip connect' once SSH is reachable.")
+	} else if probeOut == "tunnel:ok" {
 		fmt.Println("      tunnel verified (via existing SSH session)")
 	} else {
 		fmt.Println("      tunnel not detected (this is normal if no interactive SSH session is open)")
@@ -1622,7 +1631,9 @@ func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded 
 	if opts.force {
 		fmt.Println("      --force: stopping existing Codex runtime")
 		stopBridgeRemote(session)
-		xvfb.StopRemote(session, codexStateDir)
+		if err := xvfb.StopRemote(session, codexStateDir); err != nil {
+			fmt.Printf("      warning: could not stop existing Xvfb: %v\n", err)
+		}
 	}
 
 	// Step 9: Start or reuse Xvfb
@@ -1711,7 +1722,12 @@ kill -0 "$pid" 2>/dev/null && kill -9 "$pid" 2>/dev/null; \
 rm -f %s/bridge.pid; true`,
 		codexStateDir, codexStateDir,
 	)
-	session.Exec(stopScript)
+	// The script ends in `true`, so a non-nil error here means the SSH
+	// transport itself failed (not the kill). Log it non-fatally so a dead
+	// session does not silently leave a stale bridge running.
+	if _, err := session.Exec(stopScript); err != nil {
+		log.Printf("      warning: could not stop x11-bridge over SSH: %v", err)
+	}
 }
 
 // isBridgeHealthy checks if x11-bridge is running on the remote.

--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -66,7 +66,15 @@ func cmdUpdate() {
 		if err != nil {
 			log.Fatalf("failed to query latest release: %v", err)
 		}
-		target = latest
+		// Normalize the GitHub tag the same way the --to path does, so the
+		// sameVer equality check below is not prefix-sensitive (a baked-in
+		// "v0.6.1" must compare equal to a GitHub "0.6.1" tag, and vice
+		// versa). A tag GitHub returns that is not a clean semver is a
+		// release-pipeline bug we surface loudly rather than silently skip.
+		target, err = normalizeReleaseTag(latest)
+		if err != nil {
+			log.Fatalf("latest release tag %q is not a usable version: %v", latest, err)
+		}
 	}
 	if target == "" {
 		log.Fatal("could not determine a target version to install.")
@@ -383,6 +391,20 @@ func normalizeVersion(v string) string {
 		return ""
 	}
 	return "v" + v
+}
+
+// normalizeReleaseTag canonicalizes a release tag (e.g. from the GitHub API or
+// the --to flag) into "vX.Y.Z" form, returning an error when the tag is not a
+// clean release version. Unlike normalizeVersion (which returns "" for dev/git
+// -describe builds of the LOCAL binary), a non-semver value here means the
+// remote published a tag we cannot install, so we want a hard, explicit error
+// rather than a silent "".
+func normalizeReleaseTag(tag string) (string, error) {
+	normalized := normalizeVersion(tag)
+	if normalized == "" {
+		return "", fmt.Errorf("%q is not a clean semver release tag (expected vMAJOR.MINOR.PATCH)", strings.TrimSpace(tag))
+	}
+	return normalized, nil
 }
 
 // gitDescribeMarker matches the "-<commits>-g<sha>" suffix that

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -52,10 +52,10 @@ func TestNormalizeVersion(t *testing.T) {
 		{"v0.6.1+build.7", "v0.6.1+build.7"},
 		{"dev", ""},
 		{"", ""},
-		{"abc123", ""},      // git-describe SHA-like
-		{"v0.6", ""},        // only two components
-		{"v0.x.1", ""},      // non-numeric
-		{"v0.6.abc", ""},    // non-numeric patch with no suffix sep
+		{"abc123", ""},   // git-describe SHA-like
+		{"v0.6", ""},     // only two components
+		{"v0.x.1", ""},   // non-numeric
+		{"v0.6.abc", ""}, // non-numeric patch with no suffix sep
 
 		// git-describe output between tags (real dev-build ldflags value)
 		// must not be treated as a release version; otherwise the updater
@@ -73,6 +73,44 @@ func TestNormalizeVersion(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("normalizeVersion(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+// TestNormalizeReleaseTag pins the normalization applied to a tag returned by
+// the GitHub "latest release" API. Both the --to path and the latest path must
+// run the raw tag through the same normalizer so the sameVer equality check is
+// not prefix-sensitive (e.g. baked-in "v0.6.1" vs a GitHub "0.6.1" tag).
+func TestNormalizeReleaseTag(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{"v-prefixed", "v0.6.1", "v0.6.1", false},
+		{"no v prefix normalizes to v form", "0.6.1", "v0.6.1", false},
+		{"whitespace trimmed", "  v0.6.2 ", "v0.6.2", false},
+		{"prerelease kept", "v0.6.1-rc1", "v0.6.1-rc1", false},
+		{"non-semver tag is an error", "nightly", "", true},
+		{"empty tag is an error", "", "", true},
+		{"two-component tag is an error", "v0.6", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := normalizeReleaseTag(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("normalizeReleaseTag(%q) = %q, want error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeReleaseTag(%q) unexpected error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("normalizeReleaseTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -62,19 +62,11 @@ func RunRemote(host string, port int) []CheckResult {
 	// Check tunnel from remote side
 	out, err = remoteExecNoForward(host, fmt.Sprintf(
 		"bash -c 'echo >/dev/tcp/127.0.0.1/%d' 2>&1 && echo 'tunnel ok' || echo 'tunnel fail'", port))
-	if strings.Contains(out, "tunnel ok") {
-		results = append(results, CheckResult{"tunnel", true, fmt.Sprintf("port %d forwarded", port)})
-	} else {
-		results = append(results, CheckResult{"tunnel", false, fmt.Sprintf("port %d not reachable from remote", port)})
-	}
+	results = append(results, classifyTunnelCheck(out, err, port))
 
 	// Check token on remote
 	out, err = remoteExecNoForward(host, "test -f ~/.cache/cc-clip/session.token && echo 'present' || echo 'missing'")
-	if strings.Contains(out, "present") {
-		results = append(results, CheckResult{"remote-token", true, "token file present"})
-	} else {
-		results = append(results, CheckResult{"remote-token", false, "token file missing"})
-	}
+	results = append(results, classifyRemoteTokenCheck(out, err))
 
 	// Check remote token matches local token
 	results = append(results, checkTokenMatch(host)...)
@@ -91,6 +83,34 @@ func RunRemote(host string, port int) []CheckResult {
 	}
 
 	return results
+}
+
+// classifyTunnelCheck turns the result of the remote tunnel probe into a
+// CheckResult. An SSH transport failure (err != nil) is reported as a distinct
+// "check did not run" result so it is not confused with the legitimate
+// "check ran and the port is not reachable" outcome.
+func classifyTunnelCheck(out string, err error, port int) CheckResult {
+	if err != nil {
+		return CheckResult{"tunnel", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	if strings.Contains(out, "tunnel ok") {
+		return CheckResult{"tunnel", true, fmt.Sprintf("port %d forwarded", port)}
+	}
+	return CheckResult{"tunnel", false, fmt.Sprintf("port %d not reachable from remote", port)}
+}
+
+// classifyRemoteTokenCheck turns the result of the remote token-presence probe
+// into a CheckResult. An SSH transport failure (err != nil) is reported as a
+// distinct "check did not run" result rather than the misleading
+// "token file missing", which means the check ran and found the file absent.
+func classifyRemoteTokenCheck(out string, err error) CheckResult {
+	if err != nil {
+		return CheckResult{"remote-token", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	if strings.Contains(out, "present") {
+		return CheckResult{"remote-token", true, "token file present"}
+	}
+	return CheckResult{"remote-token", false, "token file missing"}
 }
 
 // remoteExecNoForward runs an SSH command without applying RemoteForward from ssh config.

--- a/internal/doctor/remote_test.go
+++ b/internal/doctor/remote_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -15,5 +16,98 @@ func TestImageProbeCommandKeepsTokenOutOfCurlArgv(t *testing.T) {
 	}
 	if !strings.Contains(cmd, `printf 'header = "Authorization: Bearer %s"\n'`) {
 		t.Fatalf("image probe command must emit Authorization header through curl config: %s", cmd)
+	}
+}
+
+// TestClassifyTunnelCheck verifies that an SSH transport failure is reported
+// as a distinct "could not run over SSH" result rather than being misreported
+// as "port not reachable". The latter would mislead the user into debugging a
+// forwarding problem when the real issue is the SSH connection itself.
+func TestClassifyTunnelCheck(t *testing.T) {
+	cases := []struct {
+		name        string
+		out         string
+		err         error
+		wantOK      bool
+		wantContain string
+	}{
+		{
+			name:        "ssh transport failure",
+			out:         "ssh: connect to host example.com port 22: Connection refused",
+			err:         fmt.Errorf("exit status 255"),
+			wantOK:      false,
+			wantContain: "could not run over SSH",
+		},
+		{
+			name:        "tunnel reachable",
+			out:         "tunnel ok",
+			err:         nil,
+			wantOK:      true,
+			wantContain: "forwarded",
+		},
+		{
+			name:        "tunnel not reachable",
+			out:         "tunnel fail",
+			err:         nil,
+			wantOK:      false,
+			wantContain: "not reachable from remote",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyTunnelCheck(tc.out, tc.err, 18339)
+			if got.OK != tc.wantOK {
+				t.Fatalf("classifyTunnelCheck OK = %v, want %v (msg=%q)", got.OK, tc.wantOK, got.Message)
+			}
+			if !strings.Contains(got.Message, tc.wantContain) {
+				t.Fatalf("classifyTunnelCheck message = %q, want it to contain %q", got.Message, tc.wantContain)
+			}
+		})
+	}
+}
+
+// TestClassifyRemoteTokenCheck verifies that an SSH transport failure during
+// the remote-token check is reported as a distinct SSH-failure result, not as
+// "token file missing" (which would ran-and-found-absence, a different bug).
+func TestClassifyRemoteTokenCheck(t *testing.T) {
+	cases := []struct {
+		name        string
+		out         string
+		err         error
+		wantOK      bool
+		wantContain string
+	}{
+		{
+			name:        "ssh transport failure",
+			out:         "ssh: Could not resolve hostname badhost",
+			err:         fmt.Errorf("exit status 255"),
+			wantOK:      false,
+			wantContain: "could not run over SSH",
+		},
+		{
+			name:        "token present",
+			out:         "present",
+			err:         nil,
+			wantOK:      true,
+			wantContain: "present",
+		},
+		{
+			name:        "token missing",
+			out:         "missing",
+			err:         nil,
+			wantOK:      false,
+			wantContain: "token file missing",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyRemoteTokenCheck(tc.out, tc.err)
+			if got.OK != tc.wantOK {
+				t.Fatalf("classifyRemoteTokenCheck OK = %v, want %v (msg=%q)", got.OK, tc.wantOK, got.Message)
+			}
+			if !strings.Contains(got.Message, tc.wantContain) {
+				t.Fatalf("classifyRemoteTokenCheck message = %q, want it to contain %q", got.Message, tc.wantContain)
+			}
+		})
 	}
 }

--- a/internal/setup/sshconfig.go
+++ b/internal/setup/sshconfig.go
@@ -92,12 +92,18 @@ func ensureSSHConfigAt(configPath string, host string, port int) ([]SSHConfigCha
 	}
 
 	if modified {
+		// Write the backup BEFORE mutating the live config, and abort on
+		// failure. Overwriting ~/.ssh/config without a verified backup would
+		// break the safe-to-revert contract: a corrupted write with no backup
+		// could leave the user locked out of every host in the file.
 		if len(content) > 0 {
 			backupPath := configPath + ".cc-clip-backup"
-			_ = os.WriteFile(backupPath, content, 0644)
+			if err := os.WriteFile(backupPath, content, 0600); err != nil {
+				return nil, fmt.Errorf("cannot write backup %s (refusing to modify live config): %w", backupPath, err)
+			}
 		}
 		newContent := strings.Join(lines, "\n")
-		if err := os.WriteFile(configPath, []byte(newContent), 0644); err != nil {
+		if err := os.WriteFile(configPath, []byte(newContent), 0600); err != nil {
 			return nil, fmt.Errorf("cannot write %s: %w", configPath, err)
 		}
 	}

--- a/internal/setup/sshconfig_test.go
+++ b/internal/setup/sshconfig_test.go
@@ -144,6 +144,68 @@ func TestEnsureSSHConfig_CreatesBackup(t *testing.T) {
 	}
 }
 
+func TestEnsureSSHConfig_BackupFailureAbortsBeforeMutation(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permission checks")
+	}
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+
+	initial := "Host myserver\n    HostName 10.0.0.1\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory read+execute but not writable, so creating the
+	// backup file inside it fails. The live config already exists, but
+	// os.WriteFile to overwrite it would also be blocked — the point of the
+	// fix is that we abort on the backup error BEFORE attempting the live
+	// overwrite, so the original content survives intact.
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(dir, 0700) // restore so t.TempDir cleanup can remove it
+
+	_, err := ensureSSHConfigAt(configPath, "myserver", 18339)
+	if err == nil {
+		t.Fatal("expected error when backup cannot be written, got nil")
+	}
+
+	// Restore writability to read the live config back.
+	if err := os.Chmod(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	content, readErr := os.ReadFile(configPath)
+	if readErr != nil {
+		t.Fatalf("cannot read config after failed backup: %v", readErr)
+	}
+	if string(content) != initial {
+		t.Fatalf("live config was mutated despite backup failure:\ngot  %q\nwant %q", string(content), initial)
+	}
+}
+
+func TestEnsureSSHConfig_BackupModeIs0600(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+
+	initial := "Host myserver\n    HostName 10.0.0.1\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ensureSSHConfigAt(configPath, "myserver", 18339); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(configPath + ".cc-clip-backup")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("backup mode = %o, want 0600", perm)
+	}
+}
+
 func TestEnsureSSHConfig_PreservesExistingDirectives(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config")


### PR DESCRIPTION
## Summary

Surfaces a set of **swallowed errors** along the connect / doctor / setup paths, found by a multi-agent deep review with adversarial verification. The headline is the one HIGH finding: the `cc-clip doctor` command — whose entire job is correct failure classification — silently mis-diagnosed SSH transport failures. Changes span `internal/doctor`, `internal/setup`, and `cmd/cc-clip`, implemented test-first.

## Fixes

| Sev | ID | What |
|-----|----|------|
| **HIGH** | #14 | `doctor` tunnel and remote-token checks captured `err` from `remoteExecNoForward` but never inspected it (staticcheck **SA4006** dead-store), so an SSH transport failure (network blip, killed ControlMaster, expired auth) was misreported as "port not reachable" / "token file missing" — sending operators to fix the wrong subsystem. New `classifyTunnelCheck` / `classifyRemoteTokenCheck` inspect `err` first and emit a distinct "remote check could not run over SSH" result. |
| MEDIUM | #15 | `EnsureSSHConfig` discarded the backup `WriteFile` error (`_ =`) before overwriting `~/.ssh/config`, breaking the safe-to-revert contract. The backup error is now checked and returned **before** mutating the live config; both files tightened from 0644 → 0600. |
| MEDIUM | #12 | The `--token-only` branch swallowed `GenerateSessionID` / `WriteRemoteSessionID` errors (no `else`), printing a green-looking success. Now mirrors the full-deploy path with `log.Printf` warnings for both failures. |
| MEDIUM | #13 | `connectVerifyTunnel` discarded `session.Exec`'s error, so a dead SSH master printed misleading "tunnel not detected" RemoteForward guidance. Now binds `probeErr` and prints a distinct "tunnel probe could not be executed over SSH" message. |
| LOW | #16 | The `--force` Codex branch ignored `xvfb.StopRemote`'s error and `stopBridgeRemote` ignored `session.Exec`'s return. Both now log a non-fatal warning so a dead session is visible before the next start attempt. |
| LOW | #19 | `cc-clip update` assigned the GitHub latest tag raw while `--to` ran `normalizeVersion`, making the `sameVer` check prefix-sensitive. The GitHub result now goes through a new `normalizeReleaseTag` helper (canonicalizes to `vX.Y.Z`, errors loudly on a non-semver tag). |

## Test plan

New tests:

- `TestClassifyTunnelCheck`, `TestClassifyRemoteTokenCheck` (ssh-failure vs reachable vs absence)
- `TestEnsureSSHConfig_BackupFailureAbortsBeforeMutation`, `TestEnsureSSHConfig_BackupModeIs0600`
- `TestNormalizeReleaseTag` (v-prefix / no-prefix / whitespace / prerelease / non-semver / empty / two-component)

Verification: `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./... -race -count=1` ✓ (all 14 packages green).

> Note: `update.go` and `sshconfig.go` are scoped to this branch because they are silent-failure surfaces of the same class; they live here to keep one file per PR and avoid cross-branch conflicts.
