### PR TITLE
fix(token,xvfb): atomic token-file write and local socket-wait

### DIFF
--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,13 @@ var (
 	ErrTokenExpired = errors.New("token expired")
 	ErrTokenInvalid = errors.New("token invalid")
 )
+
+// warnf logs a non-fatal warning. It is a package-level indirection so tests
+// can capture warnings (e.g. silent token rotation) without depending on the
+// standard logger's output destination.
+var warnf = func(format string, args ...any) {
+	log.Printf(format, args...)
+}
 
 type Session struct {
 	Token     string
@@ -66,6 +74,14 @@ func (m *Manager) LoadOrGenerate(ttl time.Duration) (Session, bool, error) {
 		m.ttl = ttl
 		m.mu.Unlock()
 		return s, true, nil
+	}
+
+	// A missing token file is the normal first-run path; staying silent is
+	// correct there. But any other read error (corrupt/old-format/unreadable
+	// file) means an existing token is being silently rotated, which
+	// invalidates every deployed remote shim. Surface that so it is observable.
+	if err != nil && !os.IsNotExist(err) {
+		warnf("token: existing token file unreadable (%v); rotating token — all remote shims must be re-synced", err)
 	}
 
 	// Expired, missing, or unreadable — generate fresh token with the given TTL.
@@ -139,6 +155,11 @@ func TokenDir() (string, error) {
 }
 
 // WriteTokenFile writes a two-line token file: line 1 = token, line 2 = ISO8601 expiry.
+//
+// The write is atomic: content is written to a temp file in the same directory,
+// fsync'd, then renamed onto session.token. A crash mid-write therefore leaves
+// the previous (valid) token file intact rather than a truncated file that
+// ReadTokenFileWithExpiry would mis-classify as old-format and silently rotate.
 func WriteTokenFile(tok string, expiresAt time.Time) (string, error) {
 	dir, err := TokenDir()
 	if err != nil {
@@ -146,8 +167,33 @@ func WriteTokenFile(tok string, expiresAt time.Time) (string, error) {
 	}
 	path := filepath.Join(dir, "session.token")
 	content := tok + "\n" + expiresAt.Format(time.RFC3339) + "\n"
-	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
-		return "", err
+
+	// Temp file in the same directory so os.Rename is atomic (same filesystem).
+	tmp, err := os.CreateTemp(dir, "session.token.tmp-*")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp token file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup if we fail before the rename succeeds.
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("failed to chmod temp token file: %w", err)
+	}
+	if _, err := tmp.Write([]byte(content)); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("failed to write temp token file: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("failed to fsync temp token file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("failed to close temp token file: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return "", fmt.Errorf("failed to rename token file into place: %w", err)
 	}
 	return path, nil
 }

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -347,6 +347,159 @@ func TestValidateNoSlidingWhenFresh(t *testing.T) {
 	}
 }
 
+func TestLoadOrGenerate_LogsWarningOnReadError(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "cc-clip")
+	TokenDirOverride = tmpDir
+	defer func() { TokenDirOverride = "" }()
+
+	// Capture warnings emitted during fallthrough-to-Generate.
+	var warnings []string
+	prev := warnf
+	warnf = func(format string, args ...any) {
+		warnings = append(warnings, format)
+	}
+	defer func() { warnf = prev }()
+
+	// Write a corrupt/old-format token file: a real READ ERROR (not a missing file).
+	dir, err := TokenDir()
+	if err != nil {
+		t.Fatalf("TokenDir failed: %v", err)
+	}
+	path := filepath.Join(dir, "session.token")
+	if err := os.WriteFile(path, []byte("only-one-line-no-expiry\n"), 0600); err != nil {
+		t.Fatalf("write corrupt token file failed: %v", err)
+	}
+
+	ttl := 1 * time.Hour
+	m := NewManager(ttl)
+	_, reused, err := m.LoadOrGenerate(ttl)
+	if err != nil {
+		t.Fatalf("LoadOrGenerate failed: %v", err)
+	}
+	if reused {
+		t.Fatal("expected fresh token (file is corrupt), but token was reused")
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected a warning to be logged when rotating due to a read error, got none")
+	}
+}
+
+func TestLoadOrGenerate_NoWarningOnMissingFile(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "cc-clip")
+	TokenDirOverride = tmpDir
+	defer func() { TokenDirOverride = "" }()
+
+	var warnings []string
+	prev := warnf
+	warnf = func(format string, args ...any) {
+		warnings = append(warnings, format)
+	}
+	defer func() { warnf = prev }()
+
+	// No token file exists: this is the normal first-run path, not a defect.
+	ttl := 1 * time.Hour
+	m := NewManager(ttl)
+	_, reused, err := m.LoadOrGenerate(ttl)
+	if err != nil {
+		t.Fatalf("LoadOrGenerate failed: %v", err)
+	}
+	if reused {
+		t.Fatal("expected fresh token on missing file, but token was reused")
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning on missing file, got: %v", warnings)
+	}
+}
+
+func TestWriteTokenFile_AtomicNoLingeringTempAndMode0600(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "cc-clip")
+	TokenDirOverride = tmpDir
+	defer func() { TokenDirOverride = "" }()
+
+	expiry := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	path, err := WriteTokenFile("atomic-token", expiry)
+	if err != nil {
+		t.Fatalf("WriteTokenFile failed: %v", err)
+	}
+
+	// Content must be the two-line format.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	want := "atomic-token\n" + expiry.Format(time.RFC3339) + "\n"
+	if string(data) != want {
+		t.Fatalf("content mismatch: wrote %q, got %q", want, string(data))
+	}
+
+	// Mode must be 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("expected mode 0600, got %o", perm)
+	}
+
+	// No temp file should linger in the directory.
+	dir, err := TokenDir()
+	if err != nil {
+		t.Fatalf("TokenDir failed: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "session.token" {
+			t.Fatalf("unexpected leftover file in token dir: %q", e.Name())
+		}
+	}
+}
+
+func TestWriteTokenFile_OverwriteIsAtomicAndComplete(t *testing.T) {
+	tmpDir := filepath.Join(t.TempDir(), "cc-clip")
+	TokenDirOverride = tmpDir
+	defer func() { TokenDirOverride = "" }()
+
+	expiry1 := time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	if _, err := WriteTokenFile("first-token", expiry1); err != nil {
+		t.Fatalf("first WriteTokenFile failed: %v", err)
+	}
+
+	// Overwrite with a new token; the replacement must be complete (rename, not truncate-then-write).
+	expiry2 := time.Now().Add(2 * time.Hour).Truncate(time.Second)
+	if _, err := WriteTokenFile("second-token", expiry2); err != nil {
+		t.Fatalf("second WriteTokenFile failed: %v", err)
+	}
+
+	tok, gotExpiry, err := ReadTokenFileWithExpiry()
+	if err != nil {
+		t.Fatalf("ReadTokenFileWithExpiry failed: %v", err)
+	}
+	if tok != "second-token" {
+		t.Fatalf("expected overwritten token %q, got %q", "second-token", tok)
+	}
+	if !gotExpiry.Equal(expiry2) {
+		t.Fatalf("expected expiry %v, got %v", expiry2, gotExpiry)
+	}
+
+	// Still no lingering temp files after overwrite.
+	dir, err := TokenDir()
+	if err != nil {
+		t.Fatalf("TokenDir failed: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "session.token" {
+			t.Fatalf("unexpected leftover file in token dir after overwrite: %q", e.Name())
+		}
+	}
+}
+
 func TestRotateToken_ForcesNewGeneration(t *testing.T) {
 	tmpDir := filepath.Join(t.TempDir(), "cc-clip")
 	TokenDirOverride = tmpDir

--- a/internal/xvfb/xvfb.go
+++ b/internal/xvfb/xvfb.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // RemoteExecutor is the interface for running commands on a remote host.
@@ -242,7 +243,8 @@ cat %s/display`,
 		if socketErr == nil {
 			break
 		}
-		session.Exec("sleep 0.2")
+		// Wait locally rather than paying for a remote SSH round-trip just to sleep.
+		time.Sleep(200 * time.Millisecond)
 	}
 	if socketErr != nil {
 		return nil, fmt.Errorf("Xvfb socket %s not found after startup", socketPath)

--- a/internal/xvfb/xvfb_test.go
+++ b/internal/xvfb/xvfb_test.go
@@ -236,6 +236,67 @@ func TestCleanStale(t *testing.T) {
 	}
 }
 
+// retryExecutor lets a command return failure for the first N calls, then
+// succeed. Used to drive the socket-wait retry loop in StartRemote.
+type retryExecutor struct {
+	*mockExecutor
+	failPrefix string
+	failTimes  int
+	failCount  int
+}
+
+func (r *retryExecutor) Exec(cmd string) (string, error) {
+	if r.failPrefix != "" && strings.HasPrefix(cmd, r.failPrefix) {
+		if r.failCount < r.failTimes {
+			r.failCount++
+			r.execLog = append(r.execLog, cmd)
+			return "", fmt.Errorf("not ready yet")
+		}
+	}
+	return r.mockExecutor.Exec(cmd)
+}
+
+func TestStartRemote_SocketWaitDoesNotSleepViaExecutor(t *testing.T) {
+	stateDir := "/tmp/test-xvfb"
+	socketPath := SocketPath("42")
+
+	base := newMockExecutor()
+	base.on("which Xvfb", "/usr/bin/Xvfb", nil)
+	// Force IsHealthy to report not-healthy so StartRemote takes the start path.
+	base.on("cat "+stateDir+"/xvfb.pid 2>/dev/null", "", fmt.Errorf("no pid"))
+	base.on("rm -f", "", nil)
+	// The start script returns the chosen display number.
+	base.on("mkdir -p", "42", nil)
+	// PID read (non-2>/dev/null variant used after start).
+	base.on("cat "+stateDir+"/xvfb.pid", "12345", nil)
+	// Socket check eventually succeeds (after the retry loop iterates).
+	base.on("test -S "+socketPath, "", nil)
+
+	m := &retryExecutor{
+		mockExecutor: base,
+		failPrefix:   "test -S " + socketPath,
+		failTimes:    2, // fail twice, forcing the wait loop to spin
+	}
+
+	state, err := StartRemote(m, stateDir)
+	if err != nil {
+		t.Fatalf("StartRemote failed: %v", err)
+	}
+	if state.Display != "42" || state.PID != 12345 {
+		t.Fatalf("unexpected state: %+v", state)
+	}
+
+	// The wait between socket-check retries must be a local time.Sleep,
+	// NOT a remote SSH round-trip. A standalone "sleep ..." command issued via
+	// the executor is the regression we guard against. (The "sleep 0.2" inside
+	// the embedded start-script shell loop is legitimate and not standalone.)
+	for _, cmd := range m.execLog {
+		if strings.HasPrefix(strings.TrimSpace(cmd), "sleep ") && !strings.Contains(cmd, "\n") {
+			t.Fatalf("StartRemote sent a standalone remote sleep command to the executor: %q", cmd)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Integration tests (require Xvfb)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two low-severity hardening fixes found by a multi-agent deep review with adversarial verification. Changes are confined to `internal/token` and `internal/xvfb`, implemented test-first.

## Fixes

| Sev | ID | What |
|-----|----|------|
| LOW | #7 | **Atomic token-file write**: `WriteTokenFile` used non-atomic `os.WriteFile` (O_TRUNC), so a crash mid-write truncated `session.token`, which `ReadTokenFileWithExpiry` then mis-classified as "old format", causing `LoadOrGenerate` to silently rotate the token and invalidate every remote shim. Now writes to a temp file in the same dir (0600) → `Sync` → `Rename` (atomic on POSIX same-fs). Additionally, `LoadOrGenerate` logs (via an injectable package-level `warnf`) when it rotates due to a **read error** (corrupt/unreadable file), distinguished from a normal missing-file first run, so silent token rotation is observable. |
| LOW | #1 | **Local socket-wait**: `StartRemote`'s socket-wait retry loop called `session.Exec("sleep 0.2")` — a remote SSH round-trip purely to wait, amplifying probe latency on flaky links. Replaced with `time.Sleep(200ms)`. The legitimate `sleep` inside the embedded remote start-script is untouched. |

## Test plan

New tests:

- `TestWriteTokenFile_AtomicNoLingeringTempAndMode0600`, `TestWriteTokenFile_OverwriteIsAtomicAndComplete`
- `TestLoadOrGenerate_LogsWarningOnReadError`, `TestLoadOrGenerate_NoWarningOnMissingFile`
- `TestStartRemote_SocketWaitDoesNotSleepViaExecutor` (asserts no `sleep` command is sent to the executor)

Verification: `go build ./...` ✓ · `go vet ./...` ✓ · `go test ./... -race -count=1` ✓ (all 14 packages green).
