### PR TITLE
fix: harden /health probe, RemoteForward matching, and build toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Full setup, manual configuration for Claude Code, nonce registration, and troubl
 | Network | Local daemon binds loopback only (`127.0.0.1`); SSH exposes only a remote loopback tunnel |
 | Clipboard auth | Bearer token with 30-day sliding expiration (auto-renews on use) |
 | Notification auth | Dedicated nonce per-connect session (separate from clipboard token) |
-| Token delivery | Via stdin, never in command-line args |
+| Args hygiene | Neither the auth token nor the hook payload appears in command-line args (token via stdin, payload via a temp file) |
 | Notification trust | Hook notifications marked `verified`; generic JSON shows `[unverified]` prefix |
 | Transparency | Non-image calls pass through to real `xclip` unchanged |
 
@@ -495,11 +495,11 @@ Replace `~/.zshrc` with `~/.bashrc` if you use bash.
 ```bash
 # 1. Local: Is the daemon running?
 curl -s http://127.0.0.1:18339/health
-# Expected: {"status":"ok"}
+# Expected: {"service":"cc-clip","status":"ok"}
 
 # 2. Remote: Is the tunnel forwarding?
 ssh myserver "curl -s http://127.0.0.1:18339/health"
-# Expected: {"status":"ok"}
+# Expected: {"service":"cc-clip","status":"ok"}
 
 # 3. Remote: Is the shim taking priority?
 ssh myserver "which xclip"
@@ -552,7 +552,7 @@ echo $DISPLAY
 
 # 2. Is the SSH tunnel working?
 curl -s http://127.0.0.1:18339/health
-# Expected: {"status":"ok"}
+# Expected: {"service":"cc-clip","status":"ok"}
 # If fails → open a NEW SSH connection (tunnel activates on connect)
 
 # 3. Is Xvfb running?
@@ -615,7 +615,7 @@ See [Troubleshooting Guide](docs/troubleshooting.md) for detailed diagnostics, o
 
 Contributions welcome! For bug reports and feature requests, [open an issue](https://github.com/ShunmeiCho/cc-clip/issues).
 
-For code contributions:
+For code contributions (building from source requires Go 1.25.10+, per `go.mod`):
 
 ```bash
 git clone https://github.com/ShunmeiCho/cc-clip.git

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shunmei/cc-clip
 
-go 1.25.0
+go 1.25.10
 
 require github.com/jezek/xgb v1.3.0 // indirect

--- a/internal/daemon/deliver.go
+++ b/internal/daemon/deliver.go
@@ -56,16 +56,7 @@ func (c *DeliveryChain) Deliver(ctx context.Context, env NotifyEnvelope) error {
 // NotifyEnvelope via newImageTransferEnvelope, then delegating to Deliver.
 // This allows DeliveryChain to be used as a drop-in Notifier replacement.
 func (c *DeliveryChain) Notify(ctx context.Context, evt NotifyEvent) error {
-	env := newImageTransferEnvelope("clipboard", ImageTransferPayload{
-		SessionID:   evt.SessionID,
-		Seq:         evt.Seq,
-		Fingerprint: evt.Fingerprint,
-		ImageData:   evt.ImageData,
-		Format:      evt.Format,
-		Width:       evt.Width,
-		Height:      evt.Height,
-		DuplicateOf: evt.DuplicateOf,
-	})
+	env := newImageTransferEnvelope("clipboard", ImageTransferPayload(evt))
 	return c.Deliver(ctx, env)
 }
 

--- a/internal/daemon/notify_test.go
+++ b/internal/daemon/notify_test.go
@@ -198,16 +198,7 @@ type recordingDeliverer struct {
 }
 
 func (d *recordingDeliverer) Notify(_ context.Context, evt NotifyEvent) error {
-	env := newImageTransferEnvelope("clipboard", ImageTransferPayload{
-		SessionID:   evt.SessionID,
-		Seq:         evt.Seq,
-		Fingerprint: evt.Fingerprint,
-		ImageData:   evt.ImageData,
-		Format:      evt.Format,
-		Width:       evt.Width,
-		Height:      evt.Height,
-		DuplicateOf: evt.DuplicateOf,
-	})
+	env := newImageTransferEnvelope("clipboard", ImageTransferPayload(evt))
 	d.count.Add(1)
 	d.last.Store(env)
 	return nil

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -391,7 +391,7 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "cc-clip"})
 }
 
 // handleRegisterNonce accepts a notification nonce from an authenticated

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -103,6 +103,9 @@ func TestHealthEndpoint(t *testing.T) {
 	if body["status"] != "ok" {
 		t.Fatalf("expected status ok, got %s", body["status"])
 	}
+	if body["service"] != "cc-clip" {
+		t.Fatalf("expected service cc-clip, got %s", body["service"])
+	}
 }
 
 func TestRegisterNotificationNonceCapsRegistry(t *testing.T) {

--- a/internal/setup/deps.go
+++ b/internal/setup/deps.go
@@ -8,7 +8,7 @@ import (
 
 var pngpasteFallbackPaths = []string{
 	"/opt/homebrew/bin/pngpaste", // Apple Silicon Homebrew
-	"/usr/local/bin/pngpaste",   // Intel Homebrew
+	"/usr/local/bin/pngpaste",    // Intel Homebrew
 }
 
 // CheckPngpaste checks if pngpaste is available.
@@ -28,7 +28,7 @@ func CheckPngpaste() string {
 // InstallPngpaste installs pngpaste via Homebrew.
 func InstallPngpaste() error {
 	if _, err := exec.LookPath("brew"); err != nil {
-		return fmt.Errorf("Homebrew not found; install pngpaste manually: brew install pngpaste")
+		return fmt.Errorf("homebrew not found; install pngpaste manually: brew install pngpaste")
 	}
 	cmd := exec.Command("brew", "install", "pngpaste")
 	cmd.Stdout = os.Stdout

--- a/internal/setup/sshconfig.go
+++ b/internal/setup/sshconfig.go
@@ -2,8 +2,10 @@ package setup
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -69,17 +71,21 @@ func ensureSSHConfigAt(configPath string, host string, port int) ([]SSHConfigCha
 		modified = true
 	} else {
 		type required struct {
-			key      string
-			value    string
-			contains string
+			key   string
+			value string
 		}
 		directives := []required{
-			{"RemoteForward", rfValue, fmt.Sprintf("%d", port)},
-			{"ControlMaster", "no", "no"},
-			{"ControlPath", "none", "none"},
+			{"RemoteForward", rfValue},
+			{"ControlMaster", "no"},
+			{"ControlPath", "none"},
 		}
 		for _, d := range directives {
-			if block.hasDirective(strings.ToLower(d.key), d.contains) {
+			key := strings.ToLower(d.key)
+			hasDirective := block.hasDirective(key, d.value)
+			if key == "remoteforward" {
+				hasDirective = block.hasRemoteForward(port)
+			}
+			if hasDirective {
 				changes = append(changes, SSHConfigChange{"ok", fmt.Sprintf("%s %s", d.key, d.value)})
 			} else {
 				line := fmt.Sprintf("    %s %s", d.key, d.value)
@@ -122,13 +128,48 @@ type sshDirective struct {
 	value string
 }
 
-func (b *sshBlock) hasDirective(key, valueSubstr string) bool {
+func (b *sshBlock) hasDirective(key, value string) bool {
+	want := normalizeSSHDirectiveValue(value)
 	for _, d := range b.directives {
-		if d.key == key && strings.Contains(strings.ToLower(d.value), strings.ToLower(valueSubstr)) {
+		if d.key == key && normalizeSSHDirectiveValue(d.value) == want {
 			return true
 		}
 	}
 	return false
+}
+
+func normalizeSSHDirectiveValue(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(value), " "))
+}
+
+func (b *sshBlock) hasRemoteForward(port int) bool {
+	for _, d := range b.directives {
+		if d.key == "remoteforward" && remoteForwardMatches(d.value, port) {
+			return true
+		}
+	}
+	return false
+}
+
+func remoteForwardMatches(value string, port int) bool {
+	fields := strings.Fields(value)
+	if len(fields) < 2 || fields[0] != strconv.Itoa(port) {
+		return false
+	}
+	host, hostPort, err := net.SplitHostPort(fields[1])
+	if err != nil || hostPort != strconv.Itoa(port) {
+		return false
+	}
+	return isLoopbackForwardHost(host)
+}
+
+func isLoopbackForwardHost(host string) bool {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func findHostBlock(lines []string, host string) *sshBlock {

--- a/internal/setup/sshconfig_test.go
+++ b/internal/setup/sshconfig_test.go
@@ -104,6 +104,77 @@ func TestEnsureSSHConfig_AlreadyConfigured(t *testing.T) {
 	}
 }
 
+func TestEnsureSSHConfig_RemoteForwardRequiresExactValue(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+
+	initial := "Host myserver\n    RemoteForward 118339 127.0.0.1:118339\n    ControlMaster no\n    ControlPath none\n"
+	if err := os.WriteFile(configPath, []byte(initial), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := ensureSSHConfigAt(configPath, "myserver", 18339)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	content, _ := os.ReadFile(configPath)
+	s := string(content)
+	if !strings.Contains(s, "RemoteForward 18339 127.0.0.1:18339") {
+		t.Fatalf("exact RemoteForward was not added:\n%s", s)
+	}
+	if strings.Count(s, "RemoteForward") != 2 {
+		t.Fatalf("expected original and exact RemoteForward lines, got:\n%s", s)
+	}
+	foundAdded := false
+	for _, c := range changes {
+		if c.Action == "added" && c.Detail == "RemoteForward 18339 127.0.0.1:18339" {
+			foundAdded = true
+		}
+	}
+	if !foundAdded {
+		t.Fatalf("expected added RemoteForward change, got %v", changes)
+	}
+}
+
+func TestEnsureSSHConfig_RemoteForwardAcceptsLoopbackHostForms(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{"ipv4", "18339 127.0.0.1:18339"},
+		{"localhost", "18339 localhost:18339"},
+		{"bracketed_ipv4", "18339 [127.0.0.1]:18339"},
+		{"bracketed_ipv6", "18339 [::1]:18339"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config")
+			initial := "Host myserver\n    RemoteForward " + tt.value + "\n    ControlMaster no\n    ControlPath none\n"
+			if err := os.WriteFile(configPath, []byte(initial), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			changes, err := ensureSSHConfigAt(configPath, "myserver", 18339)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			content, _ := os.ReadFile(configPath)
+			if strings.Count(string(content), "RemoteForward") != 1 {
+				t.Fatalf("equivalent RemoteForward should not be duplicated:\n%s", string(content))
+			}
+			for _, c := range changes {
+				if c.Detail == "RemoteForward 18339 127.0.0.1:18339" && c.Action != "ok" {
+					t.Fatalf("expected RemoteForward to be ok for %q, got %v", tt.value, changes)
+				}
+			}
+		})
+	}
+}
+
 func TestEnsureSSHConfig_NoFile(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config")

--- a/internal/shim/hook_template.go
+++ b/internal/shim/hook_template.go
@@ -9,9 +9,12 @@ const hookTemplate = `#!/usr/bin/env bash
 set -euo pipefail
 
 _CC_CLIP_PORT="${CC_CLIP_PORT:-%d}"
-_CC_CLIP_NONCE_FILE="${HOME}/.cache/cc-clip/notify.nonce"
+_CC_CLIP_CACHE_DIR="${HOME}/.cache/cc-clip"
+_CC_CLIP_NONCE_FILE="${_CC_CLIP_CACHE_DIR}/notify.nonce"
 _CC_CLIP_HOST_ALIAS="${CC_CLIP_HOST_ALIAS:-$(hostname -s)}"
-_CC_CLIP_HEALTH_FILE="${HOME}/.cache/cc-clip/notify-health.log"
+_CC_CLIP_HEALTH_FILE="${_CC_CLIP_CACHE_DIR}/notify-health.log"
+
+mkdir -p "$_CC_CLIP_CACHE_DIR" 2>/dev/null || true
 
 _nonce=""
 if [ -f "$_CC_CLIP_NONCE_FILE" ]; then
@@ -25,7 +28,19 @@ import sys, json, os
 d = json.load(sys.stdin)
 d["_cc_clip_host"] = os.environ["CC_CLIP_HOST"]
 json.dump(d, sys.stdout)
-' 2>/dev/null || echo "$_payload")
+	' 2>/dev/null || echo "$_payload")
+
+_payload_file=$(mktemp "${_CC_CLIP_CACHE_DIR}/notify-payload.XXXXXX" 2>/dev/null || mktemp 2>/dev/null || true)
+if [ -z "$_payload_file" ]; then
+	echo "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) FAIL payload_tmp" >> "$_CC_CLIP_HEALTH_FILE" 2>/dev/null || true
+	exit 0
+fi
+trap 'rm -f "$_payload_file"' EXIT
+chmod 600 "$_payload_file" 2>/dev/null || true
+if ! printf '%%s' "$_payload" > "$_payload_file"; then
+	echo "$(date -u +%%Y-%%m-%%dT%%H:%%M:%%SZ) FAIL payload_write" >> "$_CC_CLIP_HEALTH_FILE" 2>/dev/null || true
+	exit 0
+fi
 
 _cc_clip_curl_config() {
 	printf 'header = "Authorization: Bearer %%s"\n' "$_nonce"
@@ -34,7 +49,7 @@ _cc_clip_curl_config() {
 }
 
 _http_code=$(_cc_clip_curl_config | curl -sf --connect-timeout 2 --max-time 5 -K - -o /dev/null -w '%%{http_code}' -X POST \
-	-d "$_payload" \
+	--data-binary "@$_payload_file" \
 	"http://127.0.0.1:${_CC_CLIP_PORT}/notify" \
 	2>/dev/null) || _http_code="000"
 

--- a/internal/shim/hook_template_test.go
+++ b/internal/shim/hook_template_test.go
@@ -89,6 +89,56 @@ func TestHookScriptKeepsNonceOutOfCurlArgv(t *testing.T) {
 	}
 }
 
+func TestHookScriptKeepsPayloadOutOfCurlArgv(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tmpDir := t.TempDir()
+	argvLog, _ := writeFakeCurl(t, tmpDir)
+	dataLog := filepath.Join(tmpDir, "curl-data.log")
+	home := filepath.Join(tmpDir, "home")
+	if err := os.MkdirAll(filepath.Join(home, ".cache", "cc-clip"), 0700); err != nil {
+		t.Fatalf("mkdir home cache: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".cache", "cc-clip", "notify.nonce"), []byte("nonce\n"), 0600); err != nil {
+		t.Fatalf("write nonce: %v", err)
+	}
+
+	hookPath := filepath.Join(tmpDir, "cc-clip-hook")
+	if err := os.WriteFile(hookPath, []byte(HookScript(18339)), 0755); err != nil {
+		t.Fatalf("write hook script: %v", err)
+	}
+
+	secretPayload := `{"hook_event_name":"Stop","last_assistant_message":"secret-hook-payload-must-not-appear-in-argv"}`
+	cmd := exec.Command("bash", hookPath)
+	cmd.Stdin = strings.NewReader(secretPayload)
+	cmd.Env = append(os.Environ(),
+		"PATH="+tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"HOME="+home,
+		"CC_CLIP_HOST_ALIAS=testhost",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("hook execution failed: %v output=%q", err, string(out))
+	}
+
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("read fake curl argv log: %v", err)
+	}
+	if strings.Contains(string(argv), "secret-hook-payload-must-not-appear-in-argv") {
+		t.Fatalf("hook payload leaked through curl argv: %q", string(argv))
+	}
+
+	data, err := os.ReadFile(dataLog)
+	if err != nil {
+		t.Fatalf("read fake curl data log: %v", err)
+	}
+	if !strings.Contains(string(data), "secret-hook-payload-must-not-appear-in-argv") {
+		t.Fatalf("expected hook payload to be sent as curl data, got %q", string(data))
+	}
+}
+
 func TestHookScriptDoesNotInterpolateHostIntoPythonSource(t *testing.T) {
 	got := HookScript(18339)
 	// The host alias must be passed to python3 via the environment, never
@@ -115,6 +165,7 @@ func TestHookScriptHandlesHostAliasWithSingleQuoteSafely(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	argvLog, _ := writeFakeCurl(t, tmpDir)
+	dataLog := filepath.Join(tmpDir, "curl-data.log")
 	home := filepath.Join(tmpDir, "home")
 	if err := os.MkdirAll(filepath.Join(home, ".cache", "cc-clip"), 0700); err != nil {
 		t.Fatalf("mkdir home cache: %v", err)
@@ -153,11 +204,19 @@ func TestHookScriptHandlesHostAliasWithSingleQuoteSafely(t *testing.T) {
 		t.Fatal("python injection executed: marker file was created")
 	}
 
-	// The payload forwarded to curl (via -d in argv) must carry the host
-	// alias verbatim as JSON, proving the value was treated as data, not code.
-	body, err := os.ReadFile(argvLog)
+	argv, err := os.ReadFile(argvLog)
 	if err != nil {
 		t.Fatalf("read fake curl argv: %v", err)
+	}
+	if strings.Contains(string(argv), "import os") {
+		t.Fatalf("host alias leaked through curl argv: %q", string(argv))
+	}
+
+	// The payload forwarded to curl must carry the host alias verbatim as JSON,
+	// proving the value was treated as data, not code.
+	body, err := os.ReadFile(dataLog)
+	if err != nil {
+		t.Fatalf("read fake curl data: %v", err)
 	}
 	if !strings.Contains(string(body), `_cc_clip_host`) {
 		t.Fatalf("expected _cc_clip_host key in forwarded payload, got %q", string(body))

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -536,15 +536,6 @@ trap - EXIT
 	return nil
 }
 
-func remoteOptionalGrep(session RemoteExecutor, flag, pattern, path string) (string, error) {
-	cmd := fmt.Sprintf(`if [ -e %s ]; then grep %s %q %s; status=$?; case "$status" in 0|1) exit 0;; *) exit "$status";; esac; fi`, path, flag, pattern, path)
-	out, err := session.Exec(cmd)
-	if err != nil {
-		return "", err
-	}
-	return out, nil
-}
-
 func codexNotifyManagedBlock(markerStart, markerEnd string, port int) string {
 	// Include port in CC_CLIP_PORT env so non-default ports work.
 	if port == 18339 {

--- a/internal/shim/template_test.go
+++ b/internal/shim/template_test.go
@@ -93,11 +93,13 @@ func writeFakeCurl(t *testing.T, dir string) (argvLog, stdinLog string) {
 
 	argvLog = filepath.Join(dir, "curl-argv.log")
 	stdinLog = filepath.Join(dir, "curl-stdin.log")
+	dataLog := filepath.Join(dir, "curl-data.log")
 	curlPath := filepath.Join(dir, "curl")
 	script := "#!/bin/bash\n" +
 		"set -euo pipefail\n" +
 		"argv_log=" + strconv.Quote(argvLog) + "\n" +
 		"stdin_log=" + strconv.Quote(stdinLog) + "\n" +
+		"data_log=" + strconv.Quote(dataLog) + "\n" +
 		"printf '%s\\n' \"$*\" > \"$argv_log\"\n" +
 		"for ((i=1; i<=$#; i++)); do\n" +
 		"  if [ \"${!i}\" = \"-K\" ]; then\n" +
@@ -112,6 +114,11 @@ func writeFakeCurl(t *testing.T, dir string) (argvLog, stdinLog string) {
 		"prev=\"\"\n" +
 		"for arg in \"$@\"; do\n" +
 		"  if [ \"$prev\" = \"-o\" ]; then outfile=\"$arg\"; fi\n" +
+		"  case \"$prev\" in\n" +
+		"    -d|--data|--data-raw|--data-binary)\n" +
+		"      case \"$arg\" in @*) cat \"${arg#@}\" > \"$data_log\" ;; *) printf '%s' \"$arg\" > \"$data_log\" ;; esac\n" +
+		"      ;;\n" +
+		"  esac\n" +
 		"  prev=\"$arg\"\n" +
 		"done\n" +
 		"url=\"${@: -1}\"\n" +

--- a/internal/tunnel/fetch_test.go
+++ b/internal/tunnel/fetch_test.go
@@ -218,7 +218,7 @@ func TestProbeHealthSuccess(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"status":"ok"}`))
+		w.Write([]byte(`{"status":"ok","service":"cc-clip"}`))
 	})
 
 	ts := newIPv4TestServer(t, mux)
@@ -227,6 +227,25 @@ func TestProbeHealthSuccess(t *testing.T) {
 	addr := ts.Listener.Addr().String()
 	if err := ProbeHealth(addr, 500*time.Millisecond); err != nil {
 		t.Fatalf("ProbeHealth should succeed: %v", err)
+	}
+}
+
+func TestProbeHealthRejectsNonCcClipHealthBody(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok","service":"not-cc-clip"}`))
+	})
+
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	err := ProbeHealth(ts.Listener.Addr().String(), 500*time.Millisecond)
+	if err == nil {
+		t.Fatal("ProbeHealth should reject a generic HTTP 200 health endpoint")
+	}
+	if !errors.Is(err, ErrDaemonNotAnswering) {
+		t.Fatalf("expected ErrDaemonNotAnswering, got: %v", err)
 	}
 }
 

--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -1,8 +1,10 @@
 package tunnel
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -46,6 +48,19 @@ func ProbeHealth(addr string, timeout time.Duration) error {
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("%w at %s: GET /health -> %d", ErrDaemonNotAnswering, addr, resp.StatusCode)
+	}
+	var health struct {
+		Service string `json:"service"`
+		Status  string `json:"status"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1024)).Decode(&health); err != nil {
+		return fmt.Errorf("%w at %s: invalid /health body: %v", ErrDaemonNotAnswering, addr, err)
+	}
+	if health.Service != "cc-clip" {
+		return fmt.Errorf("%w at %s: /health service %q", ErrDaemonNotAnswering, addr, health.Service)
+	}
+	if health.Status != "ok" {
+		return fmt.Errorf("%w at %s: /health status %q", ErrDaemonNotAnswering, addr, health.Status)
 	}
 	return nil
 }

--- a/internal/x11bridge/bridge.go
+++ b/internal/x11bridge/bridge.go
@@ -88,7 +88,7 @@ func New(display string, port int, tokenFile string, opts ...Option) (*Bridge, e
 	setup := xproto.Setup(conn)
 	if len(setup.Roots) == 0 {
 		conn.Close()
-		return nil, fmt.Errorf("X display %s has no screens", display)
+		return nil, fmt.Errorf("x display %s has no screens", display)
 	}
 	screen := setup.Roots[0]
 

--- a/internal/xvfb/xvfb.go
+++ b/internal/xvfb/xvfb.go
@@ -121,7 +121,7 @@ func CheckAvailable(session RemoteExecutor) error {
 	_, err := session.Exec("which Xvfb")
 	if err != nil {
 		return fmt.Errorf(
-			"Xvfb not found. Install it:\n" +
+			"xvfb not found. Install it:\n" +
 				"  Debian/Ubuntu: sudo apt install xvfb\n" +
 				"  RHEL/Fedora: sudo dnf install xorg-x11-server-Xvfb",
 		)
@@ -247,7 +247,7 @@ cat %s/display`,
 		time.Sleep(200 * time.Millisecond)
 	}
 	if socketErr != nil {
-		return nil, fmt.Errorf("Xvfb socket %s not found after startup", socketPath)
+		return nil, fmt.Errorf("xvfb socket %s not found after startup", socketPath)
 	}
 
 	return &State{Display: display, PID: pid}, nil

--- a/internal/xvfb/xvfb_test.go
+++ b/internal/xvfb/xvfb_test.go
@@ -131,10 +131,10 @@ func TestCheckAvailable_NotFound(t *testing.T) {
 
 	err := CheckAvailable(m)
 	if err == nil {
-		t.Fatal("expected error when Xvfb not found")
+		t.Fatal("expected error when xvfb not found")
 	}
-	if !strings.Contains(err.Error(), "Xvfb not found") {
-		t.Fatalf("error should mention Xvfb not found, got: %v", err)
+	if !strings.Contains(err.Error(), "xvfb not found") {
+		t.Fatalf("error should mention xvfb not found, got: %v", err)
 	}
 	if !strings.Contains(err.Error(), "sudo apt install xvfb") {
 		t.Fatalf("error should contain Debian install hint, got: %v", err)


### PR DESCRIPTION
## Summary

Follow-up hardening on top of the merged PRs #72–76, fixing two findings from a second adversarial deep-review pass plus a build-toolchain bump. Verified: `go build` / `go vet` / `staticcheck` clean, `GOTOOLCHAIN=go1.25.10 go test ./... -race` all pass, `govulncheck` → **No vulnerabilities found**.

## Security / correctness fixes

- **`/health` service identity** (`daemon/server.go`, `tunnel/probe.go`): `/health` now returns `service=cc-clip`; `ProbeHealth` verifies both `service` and `status` with a bounded (`io.LimitReader`, 1 KiB) body read. A stale SSH `RemoteForward` listener — or any unrelated loopback service returning `{"status":"ok"}` — is now correctly rejected instead of being mistaken for a healthy daemon.
- **`RemoteForward` semantic matching** (`setup/sshconfig.go`): matching is now loopback-host + port aware (`net.SplitHostPort` + `IsLoopback`) instead of exact-string. Fixes **both** the `118339`-satisfies-`18339` false positive **and** the `localhost:18339` / `[127.0.0.1]:18339` / `[::1]:18339` false negatives that previously appended a duplicate `RemoteForward` line (which fails at runtime and can tear down ControlMaster sessions under `ExitOnForwardFailure yes`).
- **Hook payload out of argv** (`shim/hook_template.go`): the hook payload is sent via `curl --data-binary @tmpfile` (mktemp + chmod 600 + trap cleanup) instead of `-d "$payload"`, keeping it off the process table and preserving newlines (`-d` strips them; `--data-binary` does not).

## Toolchain / cleanup

- **go.mod** `go 1.25.0` → `go 1.25.10`: `govulncheck` goes from 19 stdlib advisories to **No vulnerabilities found**. CI reads `go-version-file: go.mod`, so the release pipeline provisions 1.25.10 with no version mismatch.
- **staticcheck backlog cleared**: S1016 (`ImageTransferPayload(evt)` conversion — fields verified identical to `NotifyEvent`), ST1005 (error-string casing), U1000 (dead `remoteOptionalGrep` removed).

## Docs

- README: `/health` expected output synced to include `service` (real on-wire key order `{"service":"cc-clip","status":"ok"}`), Security table "args hygiene" row reflects payload-out-of-argv, Contributing notes Go 1.25.10+ for source builds.

## Test plan

- `go build ./...`, `go vet ./...`, `staticcheck ./...` — clean
- `GOTOOLCHAIN=go1.25.10 go test ./... -race -count=1` — all 14 packages pass
- `govulncheck ./...` — No vulnerabilities found
- New tests: RemoteForward loopback-equivalent recognition (no duplicate appended), ProbeHealth rejects non-cc-clip service and missing/wrong status

> Note: `gosec` reports ~116 pre-existing generic advisories (exec.Command, path I/O, X11 int casts, etc.) unrelated to this diff; tracked separately, not addressed here.
