### PR TITLE
ci: add PR-level CI (build, vet, test -race, staticcheck, govulncheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test (race)
+        run: go test ./... -race -count=1
+
+      - name: Staticcheck
+        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
+      - name: Govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
## Summary

Adds the repository's first **PR-level CI**. Until now the only workflow (`release.yml`) triggered on tags, so pull requests had **zero automated checks** — every one of PRs #72-78 relied solely on local verification. This closes that gap.

## What it runs (`on: pull_request` + `push: main`)

| Step | Command | Status on current main |
|------|---------|------------------------|
| Build | `go build ./...` | green |
| Vet | `go vet ./...` | green |
| Test (race) | `go test ./... -race -count=1` | green (14 pkgs) |
| Staticcheck | `staticcheck ./...` | green (0 findings) |
| Govulncheck | `govulncheck ./...` | green (0 vulns) |

## Design notes

- **`go-version-file: go.mod`** — CI and release share the same toolchain (Go 1.25.10); no version drift.
- **SHA-pinned actions** (`checkout`, `setup-go`) — matches `release.yml` supply-chain hygiene.
- **`permissions: contents: read`** — least privilege; `concurrency` cancels superseded runs.
- **`gofmt` and `gosec` deliberately excluded**: 7 pre-existing gofmt-dirty files and ~116 gosec advisories live in unrelated legacy code and would make the gate red on day one. Track those as separate cleanups so this gate stays trustworthy (green == real regression).

## Self-verifying

This PR introduces the workflow, so it runs **on this PR itself** — its green checks are the proof the gate works. `staticcheck`/`govulncheck` use `@latest` (matching the maintainer's local invocation); pin if drift becomes noisy.
