### PR TITLE
fix(send,notify,shim): harden upload verify, durable notify nonces, robust hook injection (#80 #81 #82)

### DIFF
--- a/cmd/cc-clip/cli_flag_test.go
+++ b/cmd/cc-clip/cli_flag_test.go
@@ -13,16 +13,29 @@ import (
 // message rather than an SSH connection failure for the fake host.
 func TestCLIMutex(t *testing.T) {
 	cases := []struct {
-		name string
-		args []string
+		name    string
+		args    []string
+		wantErr string
 	}{
 		{
-			name: "connect_auto_recover_with_token_only",
-			args: []string{"connect", "fakehost.invalid", "--auto-recover", "--token-only"},
+			name:    "connect_auto_recover_with_token_only",
+			args:    []string{"connect", "fakehost.invalid", "--auto-recover", "--token-only"},
+			wantErr: "--auto-recover cannot be combined with --token-only",
 		},
 		{
-			name: "setup_auto_recover_with_token_only",
-			args: []string{"setup", "fakehost.invalid", "--auto-recover", "--token-only"},
+			name:    "setup_auto_recover_with_token_only",
+			args:    []string{"setup", "fakehost.invalid", "--auto-recover", "--token-only"},
+			wantErr: "--auto-recover cannot be combined with --token-only",
+		},
+		{
+			name:    "connect_no_hooks_with_token_only",
+			args:    []string{"connect", "fakehost.invalid", "--token-only", "--no-hooks"},
+			wantErr: "--no-hooks/--hooks cannot be combined with --token-only",
+		},
+		{
+			name:    "connect_hooks_with_token_only",
+			args:    []string{"connect", "fakehost.invalid", "--token-only", "--hooks"},
+			wantErr: "--no-hooks/--hooks cannot be combined with --token-only",
 		},
 	}
 	for _, tc := range cases {
@@ -35,7 +48,7 @@ func TestCLIMutex(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected non-zero exit on flag conflict")
 			}
-			if !strings.Contains(stderr.String(), "--auto-recover cannot be combined with --token-only") {
+			if !strings.Contains(stderr.String(), tc.wantErr) {
 				t.Fatalf("missing mutex error in stderr: %s", stderr.String())
 			}
 		})

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -145,6 +145,8 @@ Deploy (local -> remote):
     --local-bin      Path to pre-downloaded remote binary
     --force          Ignore remote state, full redeploy
     --token-only     Only sync token, skip binary/shim deploy
+    --no-hooks       Persistently disable Claude wrapper hook injection
+    --hooks          Re-enable Claude wrapper hook injection
     --auto-recover   Recover from v0.7.0 wrapper corruption (mutex with --token-only)
 
 Codex support (extends connect/setup/uninstall):
@@ -164,6 +166,8 @@ Notifications:
     --title              Notification title
     --body               Notification body
     --urgency            Urgency level (default: 1)
+    --sound              macOS notification sound (allowlisted)
+    --trusted            Suppress [unverified] prefix for trusted local config
     --from-codex         Parse Codex JSON payload (extracts last-assistant-message)
     --from-codex-stdin   Read Codex JSON payload from stdin (mutually exclusive with --from-codex)
     --port               Daemon port (default: 18339, env: CC_CLIP_PORT)
@@ -275,6 +279,12 @@ func cmdServe() {
 	clipboard := daemon.NewClipboardReader()
 	store := session.NewStore(12 * time.Hour)
 	srv := daemon.NewServer(addr, clipboard, tm, store)
+	srv.EnableNoncePersistence()
+	if loaded, err := srv.LoadPersistedNonces(); err != nil {
+		log.Printf("WARN: failed to load notification nonces: %v", err)
+	} else if loaded > 0 {
+		log.Printf("Notification nonces restored: %d", loaded)
+	}
 
 	log.Printf("Token written to: %s", tokenPath)
 	log.Printf("Token expires at: %s", sess.ExpiresAt.Format(time.RFC3339))
@@ -566,6 +576,8 @@ type connectOpts struct {
 	tokenOnly   bool
 	codex       bool
 	noNotify    bool
+	noHooks     bool
+	hooks       bool
 	autoRecover bool
 }
 
@@ -592,13 +604,32 @@ func rejectAutoRecoverWithTokenOnly(cmdName string, autoRecover, tokenOnly bool)
 	os.Exit(2)
 }
 
+func rejectHookControlWithTokenOnly(noHooks, hooks, tokenOnly bool) {
+	if tokenOnly && (noHooks || hooks) {
+		fmt.Fprintln(os.Stderr, `error: --no-hooks/--hooks cannot be combined with --token-only
+       --token-only only syncs remote credentials and does not reinstall or
+       update the Claude wrapper hook marker.
+       Re-run without --token-only:
+           cc-clip connect <host> --no-hooks
+       Or re-enable hook injection with:
+           cc-clip connect <host> --hooks`)
+		os.Exit(2)
+	}
+}
+
 func cmdConnect() {
 	if len(os.Args) < 3 {
-		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify]")
+		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify] [--no-hooks|--hooks]")
 	}
 	autoRecover := hasFlag("auto-recover")
 	tokenOnly := hasFlag("token-only")
+	noHooks := hasFlag("no-hooks")
+	hooks := hasFlag("hooks")
+	if noHooks && hooks {
+		log.Fatal("usage: --no-hooks and --hooks are mutually exclusive")
+	}
 	rejectAutoRecoverWithTokenOnly("connect", autoRecover, tokenOnly)
+	rejectHookControlWithTokenOnly(noHooks, hooks, tokenOnly)
 	runConnect(connectOpts{
 		host:        os.Args[2],
 		port:        getPort(),
@@ -606,6 +637,8 @@ func cmdConnect() {
 		tokenOnly:   tokenOnly,
 		codex:       hasFlag("codex"),
 		noNotify:    hasFlag("no-notify"),
+		noHooks:     noHooks,
+		hooks:       hooks,
 		autoRecover: autoRecover,
 	})
 }
@@ -726,6 +759,18 @@ remote has a valid claude binary installed.
 			log.Printf("      warning: failed to write session ID: %v", writeErr)
 		} else {
 			fmt.Printf("      session ID: %s\n", sid[:16])
+		}
+
+		if !opts.noNotify {
+			fmt.Println("      syncing notification nonce")
+			notifyNonce, err := syncNotificationNonce(session, port, daemonToken, host)
+			if err != nil {
+				log.Printf("      warning: failed to sync notification nonce: %v", err)
+			} else if err := runNotificationHealthProbe(port, notifyNonce); err != nil {
+				log.Printf("      warning: notification health probe failed: %v", err)
+			} else {
+				fmt.Println("      notification nonce synced")
+			}
 		}
 
 		connectVerifyTunnel(session, port, host)
@@ -889,7 +934,7 @@ remote has a valid claude binary installed.
 
 	// Notification bridge setup (unless --no-notify)
 	if !opts.noNotify {
-		connectNotifySetup(session, port, daemonToken, host, newState)
+		connectNotifySetup(session, port, daemonToken, host, newState, opts)
 		if err := shim.WriteRemoteState(session, newState); err != nil {
 			log.Printf("      warning: could not write remote deploy state: %v", err)
 		}
@@ -948,31 +993,15 @@ func newDeployState(localBin, binaryVersion, shimTarget string, pathFixed bool, 
 // 4. Print Claude Code hook config
 // 5. Detect and configure Codex notify (if ~/.codex exists)
 // 6. Run health probe
-func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host string, state *shim.DeployState) {
+func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host string, state *shim.DeployState, opts connectOpts) {
 	fmt.Println()
 	fmt.Println("Notification bridge setup:")
 
 	// Step N1: Generate nonce
 	fmt.Println("  [N1] Generating notification nonce...")
-	notifyNonce, err := shim.GenerateNotificationNonce()
+	notifyNonce, err := syncNotificationNonce(session, port, daemonToken, host)
 	if err != nil {
-		log.Printf("      warning: failed to generate notification nonce: %v", err)
-		return
-	}
-
-	// Register nonce with the local daemon via HTTP. host binds this
-	// nonce to the SSH target so a reconnect immediately revokes the
-	// previously issued nonce instead of waiting on TTL or FIFO cap.
-	if err := registerNonceWithDaemon(port, daemonToken, notifyNonce, host); err != nil {
-		log.Printf("      warning: failed to register nonce with daemon: %v", err)
-		return
-	}
-	fmt.Printf("      nonce: %s...\n", notifyNonce[:16])
-
-	// Step N2: Write nonce to remote
-	fmt.Println("  [N2] Writing nonce to remote...")
-	if err := shim.WriteRemoteNotificationNonce(session, notifyNonce); err != nil {
-		log.Printf("      warning: failed to write remote nonce: %v", err)
+		log.Printf("      warning: failed to sync notification nonce: %v", err)
 		return
 	}
 	fmt.Println("      nonce synced")
@@ -987,8 +1016,22 @@ func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host st
 
 	hookInstalled := true
 
-	// Step N4: Install claude wrapper (auto-injects hooks via --settings)
+	// Step N4: Install claude wrapper (auto-injects hooks via --settings
+	// unless the persistent no-hooks marker is present).
 	fmt.Println("  [N4] Installing claude wrapper...")
+	if opts.noHooks {
+		if err := shim.SetRemoteClaudeHooksEnabled(session, false); err != nil {
+			log.Printf("      warning: failed to disable claude wrapper hooks: %v", err)
+		} else {
+			fmt.Println("      claude wrapper hook injection disabled by ~/.cache/cc-clip/no-hooks")
+		}
+	} else {
+		if opts.hooks {
+			if err := shim.SetRemoteClaudeHooksEnabled(session, true); err != nil {
+				log.Printf("      warning: failed to re-enable claude wrapper hooks: %v", err)
+			}
+		}
+	}
 	if err := shim.InstallRemoteClaudeWrapper(session, port); err != nil {
 		log.Printf("      warning: failed to install claude wrapper: %v", err)
 		fmt.Println("      Falling back to manual hook config:")
@@ -999,7 +1042,7 @@ func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host st
 		fmt.Println()
 	} else {
 		fmt.Println("      claude wrapper installed to ~/.local/bin/claude")
-		fmt.Println("      Hooks will be auto-injected when tunnel is alive")
+		fmt.Println("      Hooks will be auto-injected unless disabled by ~/.cache/cc-clip/no-hooks")
 	}
 
 	// Step N5: Detect and configure Codex notify
@@ -1036,6 +1079,20 @@ func connectNotifySetup(session *shim.SSHSession, port int, daemonToken, host st
 		CodexInjected:  codexInjected,
 		HealthVerified: healthVerified,
 	}
+}
+
+func syncNotificationNonce(session *shim.SSHSession, port int, daemonToken, host string) (string, error) {
+	notifyNonce, err := shim.GenerateNotificationNonce()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate notification nonce: %w", err)
+	}
+	if err := registerNonceWithDaemon(port, daemonToken, notifyNonce, host); err != nil {
+		return "", fmt.Errorf("failed to register nonce with daemon: %w", err)
+	}
+	if err := shim.WriteRemoteNotificationNonce(session, notifyNonce); err != nil {
+		return "", fmt.Errorf("failed to write remote nonce: %w", err)
+	}
+	return notifyNonce, nil
 }
 
 // registerNonceWithDaemon sends the notification nonce to the local daemon
@@ -1766,14 +1823,18 @@ func cmdNotify() {
 	title := fs.String("title", "", "notification title")
 	body := fs.String("body", "", "notification body")
 	urgency := fs.Int("urgency", 1, "notification urgency (0=low, 1=normal, 2=critical)")
+	sound := fs.String("sound", "", "macOS notification sound")
+	trusted := fs.Bool("trusted", false, "mark this notification as trusted")
 	fromCodex := fs.String("from-codex", "", "Codex notify JSON payload")
 	fromCodexStdin := fs.Bool("from-codex-stdin", false, "read Codex notify JSON payload from stdin")
 	_ = fs.Parse(os.Args[2:])
 
 	msg := daemon.GenericMessagePayload{
-		Title:   *title,
-		Body:    *body,
-		Urgency: *urgency,
+		Title:    *title,
+		Body:     *body,
+		Urgency:  *urgency,
+		Sound:    *sound,
+		Verified: *trusted,
 	}
 
 	switch {
@@ -1797,6 +1858,13 @@ func cmdNotify() {
 		msg = parsed
 	}
 
+	if *sound != "" {
+		msg.Sound = *sound
+	}
+	if *trusted {
+		msg.Verified = true
+	}
+
 	port := getPort()
 	if err := postGenericNotification(port, msg); err != nil {
 		log.Fatalf("notify failed: %v", err)
@@ -1815,9 +1883,10 @@ func parseCodexNotifyPayload(payload string) (daemon.GenericMessagePayload, erro
 	lastMsg, _ := raw["last-assistant-message"].(string)
 
 	return daemon.GenericMessagePayload{
-		Title:   "Codex",
-		Body:    lastMsg,
-		Urgency: 1,
+		Title:    "Codex",
+		Body:     lastMsg,
+		Urgency:  1,
+		Verified: true,
 	}, nil
 }
 
@@ -1840,10 +1909,14 @@ func postGenericNotification(port int, msg daemon.GenericMessagePayload) error {
 		Title   string `json:"title"`
 		Body    string `json:"body"`
 		Urgency int    `json:"urgency"`
+		Sound   string `json:"sound,omitempty"`
+		Trusted bool   `json:"trusted,omitempty"`
 	}{
 		Title:   msg.Title,
 		Body:    msg.Body,
 		Urgency: msg.Urgency,
+		Sound:   msg.Sound,
+		Trusted: msg.Verified,
 	}
 
 	body, err := json.Marshal(payload)

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -250,6 +250,9 @@ func TestNotifyFromCodexParsesLastAssistantMessage(t *testing.T) {
 	if msg.Title != "Codex" {
 		t.Fatalf("expected title %q, got %q", "Codex", msg.Title)
 	}
+	if !msg.Verified {
+		t.Fatal("Codex notify payload should be treated as trusted local config")
+	}
 }
 
 func TestNotifyFromCodexRejectsInvalidJSON(t *testing.T) {
@@ -408,9 +411,11 @@ func TestPostGenericNotificationDeliversExpectedPayload(t *testing.T) {
 	}()
 
 	msg := daemon.GenericMessagePayload{
-		Title:   "Build complete",
-		Body:    "All tests passed",
-		Urgency: 1,
+		Title:    "Build complete",
+		Body:     "All tests passed",
+		Urgency:  1,
+		Sound:    "Ping",
+		Verified: true,
 	}
 	if err := postGenericNotification(port, msg); err != nil {
 		t.Fatalf("postGenericNotification failed: %v", err)
@@ -429,6 +434,12 @@ func TestPostGenericNotificationDeliversExpectedPayload(t *testing.T) {
 		}
 		if env.GenericMessage.Urgency != msg.Urgency {
 			t.Fatalf("expected urgency %d, got %d", msg.Urgency, env.GenericMessage.Urgency)
+		}
+		if env.GenericMessage.Sound != msg.Sound {
+			t.Fatalf("expected sound %q, got %q", msg.Sound, env.GenericMessage.Sound)
+		}
+		if !env.GenericMessage.Verified {
+			t.Fatal("expected trusted notification to be verified")
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected notification to be enqueued")

--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -380,11 +381,22 @@ func sshUploadNoForward(host, localPath, remotePath string) error {
 	}
 	defer f.Close()
 
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat local file %s: %w", localPath, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("local file is empty: %s", localPath)
+	}
+
 	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, sshUploadRemoteCmd(remotePath))
 	c.Stdin = f
 	hideConsoleWindow(c)
 	if out, err := c.CombinedOutput(); err != nil {
 		return fmt.Errorf("ssh upload failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	if err := verifyRemoteUploadSize(host, remotePath, info.Size()); err != nil {
+		return err
 	}
 	return nil
 }
@@ -399,6 +411,48 @@ func sshUploadNoForward(host, localPath, remotePath string) error {
 // must not be readable by other users on the remote host.
 func sshUploadRemoteCmd(remotePath string) string {
 	return "umask 077; cat > " + shQuote(remotePath)
+}
+
+func verifyRemoteUploadSize(host, remotePath string, wantBytes int64) error {
+	out, err := remoteExecNoForward(host, remoteUploadSizeCmd(remotePath))
+	if err != nil {
+		return fmt.Errorf("remote upload verification failed for %s: %w", remotePath, err)
+	}
+	gotBytes, err := parseRemoteUploadSize(out)
+	if err != nil {
+		return fmt.Errorf("remote upload verification returned invalid size for %s: %q: %w", remotePath, out, err)
+	}
+	if gotBytes != wantBytes {
+		return fmt.Errorf("remote upload size mismatch for %s: local=%d remote=%d", remotePath, wantBytes, gotBytes)
+	}
+	return nil
+}
+
+func remoteUploadSizeCmd(remotePath string) string {
+	q := shQuote(remotePath)
+	return "sh -lc " + shQuote("test -s "+q+" && wc -c < "+q)
+}
+
+func parseRemoteUploadSize(out string) (int64, error) {
+	fields := strings.Fields(out)
+	for i := len(fields) - 1; i >= 0; i-- {
+		if isDecimalDigits(fields[i]) {
+			return strconv.ParseInt(fields[i], 10, 64)
+		}
+	}
+	return 0, fmt.Errorf("no decimal byte count found")
+}
+
+func isDecimalDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func shQuote(s string) string {

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -197,3 +197,34 @@ func TestSSHUploadRemoteCmdQuotesPath(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoteUploadSizeCmdQuotesPathAndRejectsEmpty(t *testing.T) {
+	remotePath := "/tmp/a; rm -rf /.png"
+	got := remoteUploadSizeCmd(remotePath)
+	want := "sh -lc 'test -s '\\''/tmp/a; rm -rf /.png'\\'' && wc -c < '\\''/tmp/a; rm -rf /.png'\\'''"
+	if got != want {
+		t.Fatalf("remoteUploadSizeCmd(%q) = %q, want %q", remotePath, got, want)
+	}
+}
+
+func TestParseRemoteUploadSize(t *testing.T) {
+	for _, input := range []string{
+		"12345\n",
+		"zshenv banner\n12345\n",
+		"debug 2026\n   12345\n",
+	} {
+		got, err := parseRemoteUploadSize(input)
+		if err != nil {
+			t.Fatalf("parseRemoteUploadSize(%q) returned error: %v", input, err)
+		}
+		if got != 12345 {
+			t.Fatalf("parseRemoteUploadSize(%q) = %d, want 12345", input, got)
+		}
+	}
+	if _, err := parseRemoteUploadSize(""); err == nil {
+		t.Fatal("expected empty size output to fail")
+	}
+	if _, err := parseRemoteUploadSize("no byte count here"); err == nil {
+		t.Fatal("expected non-numeric size output to fail")
+	}
+}

--- a/internal/daemon/classifier.go
+++ b/internal/daemon/classifier.go
@@ -29,12 +29,17 @@ func ClassifyHookPayload(hookType string, raw map[string]any) *NotifyEnvelope {
 		notifType, _ := raw["type"].(string)
 		title, _ := raw["title"].(string)
 		body, _ := raw["body"].(string)
+		if body == "" {
+			body, _ = raw["message"].(string)
+		}
 		env.ToolAttention.NotifType = notifType
+		env.ToolAttention.Message = truncate(body, 280)
 		env.GenericMessage.Body = body
 		switch notifType {
 		case "permission_prompt":
 			env.GenericMessage.Title = "Tool approval needed"
 			env.GenericMessage.Urgency = 2
+			env.GenericMessage.Sound = defaultCriticalSound
 		case "idle_prompt":
 			env.GenericMessage.Title = "Claude is idle"
 			env.GenericMessage.Urgency = 1

--- a/internal/daemon/classifier_test.go
+++ b/internal/daemon/classifier_test.go
@@ -211,6 +211,33 @@ func TestClassifyNotificationFallsBackWhenTypeAndTitleEmpty(t *testing.T) {
 	}
 }
 
+func TestClassifyNotificationUsesMessageFallbackBody(t *testing.T) {
+	env := ClassifyHookPayload("notification", map[string]any{
+		"hook_event_name": "Notification",
+		"type":            "progress_update",
+		"message":         "Script Editor text",
+	})
+	if env == nil || env.GenericMessage == nil {
+		t.Fatalf("expected generic message envelope, got %#v", env)
+	}
+	if env.GenericMessage.Body != "Script Editor text" {
+		t.Fatalf("expected message fallback body, got %q", env.GenericMessage.Body)
+	}
+}
+
+func TestClassifyPermissionPromptGetsDefaultSound(t *testing.T) {
+	env := ClassifyHookPayload("notification", map[string]any{
+		"type": "permission_prompt",
+		"body": "Approve tool",
+	})
+	if env == nil || env.GenericMessage == nil {
+		t.Fatalf("expected generic message envelope, got %#v", env)
+	}
+	if env.GenericMessage.Sound != defaultCriticalSound {
+		t.Fatalf("expected sound %q, got %q", defaultCriticalSound, env.GenericMessage.Sound)
+	}
+}
+
 // TestStringifyMapSkipsInternalKeys verifies that internal cc-clip keys
 // (prefixed "_cc_clip_") are not leaked into the displayed notification body
 // via the default classifier branch.

--- a/internal/daemon/deliver.go
+++ b/internal/daemon/deliver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 )
 
 // Deliverer sends a notification envelope through a specific transport.
@@ -117,4 +118,59 @@ func formatNotification(env NotifyEnvelope) (title, body string) {
 		body = string(env.Kind)
 	}
 	return title, body
+}
+
+const defaultCriticalSound = "Glass"
+
+func notificationSound(env NotifyEnvelope) string {
+	if env.GenericMessage == nil {
+		return ""
+	}
+	if sound := normalizeNotificationSound(env.GenericMessage.Sound); sound != "" {
+		return sound
+	}
+	if strings.TrimSpace(env.GenericMessage.Sound) != "" {
+		return ""
+	}
+	if env.GenericMessage.Urgency == 2 {
+		return defaultCriticalSound
+	}
+	return ""
+}
+
+func normalizeNotificationSound(sound string) string {
+	switch strings.ToLower(strings.TrimSpace(sound)) {
+	case "", "none", "off", "silent":
+		return ""
+	case "basso":
+		return "Basso"
+	case "blow":
+		return "Blow"
+	case "bottle":
+		return "Bottle"
+	case "frog":
+		return "Frog"
+	case "funk":
+		return "Funk"
+	case "glass":
+		return "Glass"
+	case "hero":
+		return "Hero"
+	case "morse":
+		return "Morse"
+	case "ping":
+		return "Ping"
+	case "pop":
+		return "Pop"
+	case "purr":
+		return "Purr"
+	case "sosumi":
+		return "Sosumi"
+	case "submarine":
+		return "Submarine"
+	case "tink":
+		return "Tink"
+	default:
+		return ""
+	}
 }

--- a/internal/daemon/deliver_test.go
+++ b/internal/daemon/deliver_test.go
@@ -342,6 +342,21 @@ func TestFormatNotificationToolAttention(t *testing.T) {
 	}
 }
 
+func TestNotificationSoundAllowlistAndCriticalDefault(t *testing.T) {
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2}}); got != defaultCriticalSound {
+		t.Fatalf("critical default sound = %q, want %q", got, defaultCriticalSound)
+	}
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 1, Sound: "ping"}}); got != "Ping" {
+		t.Fatalf("allowlisted sound = %q, want Ping", got)
+	}
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2, Sound: "not-a-sound"}}); got != "" {
+		t.Fatalf("unknown explicit sound should be silent, got %q", got)
+	}
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2, Sound: "none"}}); got != "" {
+		t.Fatalf("sound=none should suppress critical default, got %q", got)
+	}
+}
+
 func TestDeliveryChainNotifyBridgesEvent(t *testing.T) {
 	recorder := &fakeDeliverer{name: "test"}
 	chain := &DeliveryChain{adapters: []Deliverer{recorder}}

--- a/internal/daemon/envelope.go
+++ b/internal/daemon/envelope.go
@@ -56,6 +56,7 @@ type GenericMessagePayload struct {
 	Body       string
 	Urgency    int
 	Verified   bool
+	Sound      string
 	Subtitle   string
 	DedupCount int
 }

--- a/internal/daemon/nonce_store.go
+++ b/internal/daemon/nonce_store.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/token"
+)
+
+const nonceStoreFile = "notify-nonces.json"
+
+type persistedNonceStore struct {
+	Version int              `json:"version"`
+	Nonces  []persistedNonce `json:"nonces"`
+}
+
+type persistedNonce struct {
+	Nonce     string    `json:"nonce"`
+	Host      string    `json:"host,omitempty"`
+	IssuedAt  time.Time `json:"issued_at"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+func nonceStorePath() (string, error) {
+	dir, err := token.TokenDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, nonceStoreFile), nil
+}
+
+// LoadPersistedNonces restores the notification nonce registry from disk.
+// Expired entries are skipped so a stale store cannot resurrect old credentials.
+func (s *Server) LoadPersistedNonces() (int, error) {
+	path, err := nonceStorePath()
+	if err != nil {
+		return 0, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("read nonce store: %w", err)
+	}
+
+	var store persistedNonceStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return 0, fmt.Errorf("decode nonce store: %w", err)
+	}
+
+	now := time.Now()
+	next := make(map[string]nonceEntry)
+	order := make([]string, 0, len(store.Nonces))
+	for _, item := range store.Nonces {
+		if item.Nonce == "" || !now.Before(item.ExpiresAt) {
+			continue
+		}
+		if _, exists := next[item.Nonce]; exists {
+			continue
+		}
+		next[item.Nonce] = nonceEntry{
+			Host:      item.Host,
+			IssuedAt:  item.IssuedAt,
+			ExpiresAt: item.ExpiresAt,
+		}
+		order = append(order, item.Nonce)
+	}
+	for len(next) > maxNonces && len(order) > 0 {
+		oldest := order[0]
+		order = order[1:]
+		delete(next, oldest)
+	}
+
+	s.noncesMu.Lock()
+	s.notifyNonces = next
+	s.notifyNoncesOrder = order
+	s.noncesMu.Unlock()
+
+	return len(next), nil
+}
+
+// persistNoncesLocked writes the current nonce registry to disk atomically.
+// Caller must hold s.noncesMu.
+func (s *Server) persistNoncesLocked() error {
+	path, err := nonceStorePath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	store := persistedNonceStore{
+		Version: 1,
+		Nonces:  make([]persistedNonce, 0, len(s.notifyNonces)),
+	}
+	seen := make(map[string]struct{}, len(s.notifyNonces))
+	for _, nonce := range s.notifyNoncesOrder {
+		entry, ok := s.notifyNonces[nonce]
+		if !ok {
+			continue
+		}
+		store.Nonces = append(store.Nonces, persistedNonce{
+			Nonce:     nonce,
+			Host:      entry.Host,
+			IssuedAt:  entry.IssuedAt,
+			ExpiresAt: entry.ExpiresAt,
+		})
+		seen[nonce] = struct{}{}
+	}
+	for nonce, entry := range s.notifyNonces {
+		if _, ok := seen[nonce]; ok {
+			continue
+		}
+		store.Nonces = append(store.Nonces, persistedNonce{
+			Nonce:     nonce,
+			Host:      entry.Host,
+			IssuedAt:  entry.IssuedAt,
+			ExpiresAt: entry.ExpiresAt,
+		})
+	}
+
+	data, err := json.Marshal(store)
+	if err != nil {
+		return fmt.Errorf("encode nonce store: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(dir, nonceStoreFile+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp nonce store: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp nonce store: %w", err)
+	}
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp nonce store: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("fsync temp nonce store: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp nonce store: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("rename nonce store into place: %w", err)
+	}
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+	return nil
+}
+
+func cloneNonceMap(src map[string]nonceEntry) map[string]nonceEntry {
+	dst := make(map[string]nonceEntry, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/daemon/notify_darwin.go
+++ b/internal/daemon/notify_darwin.go
@@ -15,8 +15,8 @@ import (
 // DarwinNotifier delivers macOS notifications with image thumbnails
 // via terminal-notifier, falling back to osascript (text-only) if unavailable.
 type DarwinNotifier struct {
-	previewDir         string
-	terminalNotifier   string // path to terminal-notifier binary, empty if not found
+	previewDir       string
+	terminalNotifier string // path to terminal-notifier binary, empty if not found
 }
 
 // maxPreviewFiles limits the number of preview images retained on disk.
@@ -96,6 +96,7 @@ func (n *DarwinNotifier) Name() string { return "darwin" }
 // via terminal-notifier (with image preview for image_transfer) or osascript.
 func (n *DarwinNotifier) Deliver(_ context.Context, env NotifyEnvelope) error {
 	title, body := formatNotification(env)
+	sound := notificationSound(env)
 	subtitle := ""
 	imagePath := ""
 
@@ -132,9 +133,9 @@ func (n *DarwinNotifier) Deliver(_ context.Context, env NotifyEnvelope) error {
 	}
 
 	if n.terminalNotifier != "" {
-		return n.sendViaTerminalNotifier(title, subtitle, body, imagePath)
+		return n.sendViaTerminalNotifier(title, subtitle, body, imagePath, sound)
 	}
-	return n.sendViaOsascript(title, subtitle, body)
+	return n.sendViaOsascript(title, subtitle, body, sound)
 }
 
 func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
@@ -166,17 +167,20 @@ func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
 	}
 
 	if n.terminalNotifier != "" {
-		return n.sendViaTerminalNotifier(title, subtitle, body, previewPath)
+		return n.sendViaTerminalNotifier(title, subtitle, body, previewPath, "")
 	}
-	return n.sendViaOsascript(title, subtitle, body)
+	return n.sendViaOsascript(title, subtitle, body, "")
 }
 
-func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePath string) error {
+func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePath, sound string) error {
 	args := []string{
 		"-title", title,
 		"-subtitle", subtitle,
 		"-message", body,
 		"-group", "cc-clip",
+	}
+	if sound != "" {
+		args = append(args, "-sound", sound)
 	}
 	if imagePath != "" {
 		args = append(args, "-contentImage", imagePath)
@@ -185,10 +189,10 @@ func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePat
 	return exec.Command(n.terminalNotifier, args...).Run()
 }
 
-func (n *DarwinNotifier) sendViaOsascript(title, subtitle, body string) error {
-	script := fmt.Sprintf(
-		`display notification %q with title %q subtitle %q`,
-		body, title, subtitle,
-	)
+func (n *DarwinNotifier) sendViaOsascript(title, subtitle, body, sound string) error {
+	script := fmt.Sprintf(`display notification %q with title %q subtitle %q`, body, title, subtitle)
+	if sound != "" {
+		script += fmt.Sprintf(` sound name %q`, sound)
+	}
 	return exec.Command("osascript", "-e", script).Run()
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -49,6 +49,7 @@ type Server struct {
 	notifyNonces      map[string]nonceEntry
 	notifyNoncesOrder []string // insertion order for FIFO eviction when cap is exceeded
 	noncesMu          sync.RWMutex
+	persistNonces     bool
 	addr              string
 	mux               *http.ServeMux
 }
@@ -72,6 +73,15 @@ func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, se
 	s.mux.HandleFunc("POST /notify", s.handleNotify)
 	s.mux.HandleFunc("POST /register-nonce", s.authMiddleware(s.handleRegisterNonce))
 	return s
+}
+
+// EnableNoncePersistence makes notification nonce mutations durable across
+// daemon restarts. Tests leave this disabled unless they are exercising the
+// persistence contract directly.
+func (s *Server) EnableNoncePersistence() {
+	s.noncesMu.Lock()
+	s.persistNonces = true
+	s.noncesMu.Unlock()
 }
 
 // nonceEntry tracks metadata for a registered notification nonce.
@@ -113,6 +123,8 @@ func (s *Server) RegisterNotificationNonceForHost(nonce, host string) error {
 	now := time.Now()
 	s.noncesMu.Lock()
 	defer s.noncesMu.Unlock()
+	prevNonces := cloneNonceMap(s.notifyNonces)
+	prevOrder := append([]string(nil), s.notifyNoncesOrder...)
 	// Revoke previous nonce for the same host. We must update both the
 	// map AND the order slice so same-host re-registrations cannot grow
 	// notifyNoncesOrder unbounded (which would defeat the entire cap).
@@ -140,6 +152,13 @@ func (s *Server) RegisterNotificationNonceForHost(nonce, host string) error {
 		oldest := s.notifyNoncesOrder[0]
 		s.notifyNoncesOrder = s.notifyNoncesOrder[1:]
 		delete(s.notifyNonces, oldest)
+	}
+	if s.persistNonces {
+		if err := s.persistNoncesLocked(); err != nil {
+			s.notifyNonces = prevNonces
+			s.notifyNoncesOrder = prevOrder
+			return fmt.Errorf("persist notification nonce registry: %w", err)
+		}
 	}
 	return nil
 }
@@ -191,6 +210,11 @@ func (s *Server) CleanupExpiredNonces() {
 		if now.After(v.ExpiresAt) {
 			delete(s.notifyNonces, k)
 			s.removeFromNoncesOrder(k)
+		}
+	}
+	if s.persistNonces {
+		if err := s.persistNoncesLocked(); err != nil {
+			log.Printf("WARN: failed to persist notification nonce cleanup: %v", err)
 		}
 	}
 }
@@ -570,6 +594,8 @@ func (s *Server) parseGenericJSON(body []byte) (NotifyEnvelope, error) {
 		Body    string `json:"body"`
 		Urgency int    `json:"urgency"`
 		Host    string `json:"host"`
+		Sound   string `json:"sound"`
+		Trusted bool   `json:"trusted"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
 		return NotifyEnvelope{}, fmt.Errorf("invalid JSON: %w", err)
@@ -587,7 +613,8 @@ func (s *Server) parseGenericJSON(body []byte) (NotifyEnvelope, error) {
 			Title:    payload.Title,
 			Body:     payload.Body,
 			Urgency:  payload.Urgency,
-			Verified: false,
+			Verified: payload.Trusted,
+			Sound:    payload.Sound,
 		},
 	}, nil
 }

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -37,6 +38,17 @@ func newTestServer(clip ClipboardReader) (*Server, string) {
 	store := session.NewStore(12 * time.Hour)
 	srv := NewServer("127.0.0.1:0", clip, tm, store)
 	return srv, s.Token
+}
+
+func withTokenDirOverride(t *testing.T) string {
+	t.Helper()
+	old := token.TokenDirOverride
+	dir := t.TempDir()
+	token.TokenDirOverride = dir
+	t.Cleanup(func() {
+		token.TokenDirOverride = old
+	})
+	return dir
 }
 
 type staticAddrListener struct {
@@ -207,6 +219,84 @@ func TestCleanupExpiredNoncesShrinksOrderSlice(t *testing.T) {
 	}
 	if got := len(srv.notifyNoncesOrder); got != 0 {
 		t.Fatalf("notifyNoncesOrder must be cleared by CleanupExpiredNonces; got %d entries", got)
+	}
+}
+
+func TestNotificationNoncesPersistAndReload(t *testing.T) {
+	withTokenDirOverride(t)
+	srv, _ := newTestServer(&mockClipboard{})
+	srv.EnableNoncePersistence()
+
+	if err := srv.RegisterNotificationNonceForHost("nonce-persist", "venus"); err != nil {
+		t.Fatalf("RegisterNotificationNonceForHost failed: %v", err)
+	}
+
+	path, err := nonceStorePath()
+	if err != nil {
+		t.Fatalf("nonceStorePath failed: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected nonce store to exist: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("nonce store mode = %o, want 0600", got)
+	}
+
+	reloaded, _ := newTestServer(&mockClipboard{})
+	reloaded.EnableNoncePersistence()
+	loaded, err := reloaded.LoadPersistedNonces()
+	if err != nil {
+		t.Fatalf("LoadPersistedNonces failed: %v", err)
+	}
+	if loaded != 1 {
+		t.Fatalf("loaded %d nonces, want 1", loaded)
+	}
+	host, ok := reloaded.lookupValidNonce("nonce-persist")
+	if !ok {
+		t.Fatal("persisted nonce should authenticate after reload")
+	}
+	if host != "venus" {
+		t.Fatalf("reloaded host = %q, want venus", host)
+	}
+}
+
+func TestLoadPersistedNoncesSkipsExpiredEntries(t *testing.T) {
+	withTokenDirOverride(t)
+	path, err := nonceStorePath()
+	if err != nil {
+		t.Fatalf("nonceStorePath failed: %v", err)
+	}
+	now := time.Now()
+	store := persistedNonceStore{
+		Version: 1,
+		Nonces: []persistedNonce{
+			{Nonce: "expired", Host: "old", IssuedAt: now.Add(-8 * 24 * time.Hour), ExpiresAt: now.Add(-time.Hour)},
+			{Nonce: "live", Host: "new", IssuedAt: now, ExpiresAt: now.Add(time.Hour)},
+		},
+	}
+	data, err := json.Marshal(store)
+	if err != nil {
+		t.Fatalf("marshal store: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write store: %v", err)
+	}
+
+	srv, _ := newTestServer(&mockClipboard{})
+	srv.EnableNoncePersistence()
+	loaded, err := srv.LoadPersistedNonces()
+	if err != nil {
+		t.Fatalf("LoadPersistedNonces failed: %v", err)
+	}
+	if loaded != 1 {
+		t.Fatalf("loaded %d nonces, want 1", loaded)
+	}
+	if srv.validNotificationNonce("expired") {
+		t.Fatal("expired nonce should not be restored")
+	}
+	if !srv.validNotificationNonce("live") {
+		t.Fatal("live nonce should be restored")
 	}
 }
 
@@ -571,6 +661,43 @@ func TestNotifyKeepsBodyHostWhenNonceUnbound(t *testing.T) {
 	case env := <-srv.notifyCh:
 		if env.Host != "host-from-body" {
 			t.Fatalf("expected body host preserved for unbound nonce, got %q", env.Host)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected an envelope to be enqueued")
+	}
+}
+
+func TestNotifyParsesTrustedAndSoundFromGenericPayload(t *testing.T) {
+	clip := &mockClipboard{}
+	tm := token.NewManager(time.Hour)
+	_, _ = tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", clip, tm, store)
+	if err := srv.RegisterNotificationNonce("nonce-trusted"); err != nil {
+		t.Fatalf("register nonce: %v", err)
+	}
+
+	body := strings.NewReader(`{"title":"hi","body":"there","trusted":true,"sound":"Ping"}`)
+	req := httptest.NewRequest("POST", "/notify", body)
+	req.Header.Set("Authorization", "Bearer nonce-trusted")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d; body: %s", w.Code, w.Body.String())
+	}
+
+	select {
+	case env := <-srv.notifyCh:
+		if env.GenericMessage == nil {
+			t.Fatal("expected generic message")
+		}
+		if !env.GenericMessage.Verified {
+			t.Fatal("trusted=true should mark message verified")
+		}
+		if env.GenericMessage.Sound != "Ping" {
+			t.Fatalf("sound = %q, want Ping", env.GenericMessage.Sound)
 		}
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("expected an envelope to be enqueued")

--- a/internal/shim/claude_wrapper.go
+++ b/internal/shim/claude_wrapper.go
@@ -1,7 +1,5 @@
 package shim
 
-import "fmt"
-
 const claudeWrapperTemplate = `#!/usr/bin/env bash
 # cc-clip claude wrapper — auto-inject notification hooks
 # Installed by: cc-clip connect
@@ -13,6 +11,7 @@ const claudeWrapperTemplate = `#!/usr/bin/env bash
 _REAL_CLAUDE=""
 _SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 _SIDECAR="$_SELF_DIR/claude.cc-clip-real"
+_NO_HOOKS_FILE="${HOME}/.cache/cc-clip/no-hooks"
 
 if [ -x "$_SIDECAR" ]; then
     _REAL_CLAUDE="$_SIDECAR"
@@ -29,9 +28,11 @@ if [ -z "$_REAL_CLAUDE" ]; then
     exit 1
 fi
 
-# Only inject hooks if cc-clip tunnel is alive
-if curl -sf --connect-timeout 1 --max-time 2 "http://127.0.0.1:${CC_CLIP_PORT:-%d}/health" >/dev/null 2>&1; then
-    exec "$_REAL_CLAUDE" --settings '{
+if [ -f "$_NO_HOOKS_FILE" ]; then
+    exec "$_REAL_CLAUDE" "$@"
+fi
+
+exec "$_REAL_CLAUDE" --settings '{
   "hooks": {
     "Stop": [
       {
@@ -47,18 +48,14 @@ if curl -sf --connect-timeout 1 --max-time 2 "http://127.0.0.1:${CC_CLIP_PORT:-%
     ]
   }
 }' "$@"
-else
-    # Tunnel not available — run claude without hook injection
-    exec "$_REAL_CLAUDE" "$@"
-fi
 `
 
 // ClaudeWrapperScript returns the claude wrapper bash script with the
 // given port baked in. This script is installed to ~/.local/bin/claude
-// on the remote. When the cc-clip tunnel is alive, it injects Stop and
-// Notification hooks via --settings so users don't need to manually
-// configure hooks in ~/.claude/settings.json. When the tunnel is down,
-// it transparently passes through to the real claude binary.
+// on the remote. It injects Stop and Notification hooks via --settings so
+// users don't need to manually configure hooks in ~/.claude/settings.json.
+// The hook script itself is fail-soft when the tunnel is unavailable.
 func ClaudeWrapperScript(port int) string {
-	return fmt.Sprintf(claudeWrapperTemplate, port)
+	_ = port
+	return claudeWrapperTemplate
 }

--- a/internal/shim/claude_wrapper_install_test.go
+++ b/internal/shim/claude_wrapper_install_test.go
@@ -130,10 +130,11 @@ func TestInstall_RegularFileOrigin(t *testing.T) {
 	if !strings.Contains(string(data), "# cc-clip claude wrapper") {
 		t.Fatal("claude is not the cc-clip wrapper after install")
 	}
-	// Port-substitution assertion (per T6 review note): wrapper must reference
-	// the port we passed to InstallRemoteClaudeWrapper.
-	if !strings.Contains(string(data), "18339") {
-		t.Fatal("installed wrapper does not contain expected port 18339")
+	if strings.Contains(string(data), "%!(EXTRA") {
+		t.Fatal("installed wrapper contains fmt extra-argument artifact")
+	}
+	if !strings.Contains(string(data), "--settings") || !strings.Contains(string(data), "cc-clip-hook") {
+		t.Fatal("installed wrapper does not contain hook injection")
 	}
 
 	// claude must be a regular file (not a symlink).
@@ -205,16 +206,17 @@ func TestInstall_ReinstallOverCcWrapper(t *testing.T) {
 		t.Fatalf("re-install: %v", err)
 	}
 
-	// Wrapper must be updated (port baked in is 19999 now).
+	// Wrapper must be updated while remaining independent from the legacy
+	// port argument. The hook script, not the wrapper, owns the daemon port.
 	data, err := os.ReadFile(filepath.Join(binDir, "claude"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "19999") {
-		t.Fatal("wrapper port was not updated")
+	if strings.Contains(string(data), "19999") || strings.Contains(string(data), "18339") {
+		t.Fatal("wrapper should not contain daemon port after startup health gate removal")
 	}
-	if strings.Contains(string(data), "18339") {
-		t.Fatal("wrapper still contains old port")
+	if !strings.Contains(string(data), "--settings") || !strings.Contains(string(data), "cc-clip-hook") {
+		t.Fatal("reinstalled wrapper does not contain hook injection")
 	}
 
 	// Sidecar must be untouched (we don't displace re-install over our own wrapper).

--- a/internal/shim/claude_wrapper_test.go
+++ b/internal/shim/claude_wrapper_test.go
@@ -14,7 +14,6 @@ func TestClaudeWrapperContainsHookInjection(t *testing.T) {
 		`"Notification"`,
 		`"matcher": ""`,
 		"cc-clip-hook",
-		"CC_CLIP_PORT:-18339",
 		"exec \"$_REAL_CLAUDE\"",
 	} {
 		if !strings.Contains(got, needle) {
@@ -79,8 +78,8 @@ func assertClaudeV2HookSchema(t *testing.T, cfg string) {
 
 func TestClaudeWrapperPortSubstitution(t *testing.T) {
 	got := ClaudeWrapperScript(9999)
-	if !strings.Contains(got, "CC_CLIP_PORT:-9999") {
-		t.Error("expected port 9999 in health check URL")
+	if strings.Contains(got, "%!(EXTRA") {
+		t.Fatal("wrapper should ignore the legacy port argument without fmt artifacts")
 	}
 }
 
@@ -91,23 +90,25 @@ func TestClaudeWrapperSkipsOwnDirectory(t *testing.T) {
 	}
 }
 
-func TestClaudeWrapperFallsBackWhenTunnelDown(t *testing.T) {
+func TestClaudeWrapperDoesNotGateInjectionOnStartupHealth(t *testing.T) {
 	got := ClaudeWrapperScript(18339)
-	if !strings.Contains(got, "# Tunnel not available") {
-		t.Error("expected fallback comment for tunnel-down case")
+	if strings.Contains(got, "/health") || strings.Contains(got, "curl ") {
+		t.Fatal("wrapper must not skip hook injection based on a startup tunnel probe")
 	}
-	// The else branch should exec without --settings
-	lines := strings.Split(got, "\n")
-	foundElseExec := false
-	for _, line := range lines {
-		if strings.Contains(line, `exec "$_REAL_CLAUDE" "$@"`) &&
-			!strings.Contains(line, "--settings") {
-			foundElseExec = true
-			break
-		}
+	if !strings.Contains(got, `exec "$_REAL_CLAUDE" --settings`) {
+		t.Fatal("wrapper should inject hooks unconditionally when no opt-out marker is present")
 	}
-	if !foundElseExec {
-		t.Error("expected fallback exec without --settings flag")
+}
+
+func TestClaudeWrapperHonorsNoHooksMarker(t *testing.T) {
+	got := ClaudeWrapperScript(18339)
+	if !strings.Contains(got, `.cache/cc-clip/no-hooks`) {
+		t.Fatal("wrapper should check persistent no-hooks marker")
+	}
+	markerIdx := strings.Index(got, `_NO_HOOKS_FILE`)
+	settingsIdx := strings.Index(got, `--settings`)
+	if markerIdx == -1 || settingsIdx == -1 || markerIdx >= settingsIdx {
+		t.Fatal("no-hooks marker check must run before --settings injection")
 	}
 }
 

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -277,6 +277,21 @@ func WriteRemoteNotificationNonce(session *SSHSession, nonce string) error {
 	return nil
 }
 
+// SetRemoteClaudeHooksEnabled toggles the persistent wrapper opt-out marker.
+// The wrapper checks this file at runtime before injecting --settings hooks, so
+// the choice survives future wrapper reinstalls and --force connects.
+func SetRemoteClaudeHooksEnabled(session SessionExecutor, enabled bool) error {
+	cmd := `mkdir -p ~/.cache/cc-clip && rm -f ~/.cache/cc-clip/no-hooks`
+	if !enabled {
+		cmd = `mkdir -p ~/.cache/cc-clip && : > ~/.cache/cc-clip/no-hooks && chmod 600 ~/.cache/cc-clip/no-hooks`
+	}
+	out, err := session.Exec(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to update remote claude hook marker: %s: %w", strings.TrimSpace(out), err)
+	}
+	return nil
+}
+
 // InstallRemoteHookScript writes the cc-clip-hook bash script to
 // ~/.local/bin/cc-clip-hook on the remote with chmod +x.
 func InstallRemoteHookScript(session *SSHSession, port int) error {
@@ -540,11 +555,11 @@ func codexNotifyManagedBlock(markerStart, markerEnd string, port int) string {
 	// Include port in CC_CLIP_PORT env so non-default ports work.
 	if port == 18339 {
 		return markerStart + "\n" +
-			`notify = ["cc-clip", "notify", "--from-codex-stdin"]` + "\n" +
+			`notify = ["cc-clip", "notify", "--trusted", "--from-codex-stdin"]` + "\n" +
 			markerEnd
 	}
 	return markerStart + "\n" +
-		fmt.Sprintf(`notify = ["env", "CC_CLIP_PORT=%d", "cc-clip", "notify", "--from-codex-stdin"]`, port) + "\n" +
+		fmt.Sprintf(`notify = ["env", "CC_CLIP_PORT=%d", "cc-clip", "notify", "--trusted", "--from-codex-stdin"]`, port) + "\n" +
 		markerEnd
 }
 

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -209,9 +209,31 @@ func TestGenerateNotificationNonceDistinctFromSessionID(t *testing.T) {
 	}
 }
 
+func TestSetRemoteClaudeHooksEnabledTogglesMarker(t *testing.T) {
+	home := t.TempDir()
+	s := &localSession{home: home}
+	marker := filepath.Join(home, ".cache", "cc-clip", "no-hooks")
+
+	if err := SetRemoteClaudeHooksEnabled(s, false); err != nil {
+		t.Fatalf("disable hooks failed: %v", err)
+	}
+	if info, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected no-hooks marker: %v", err)
+	} else if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("marker mode = %o, want 0600", got)
+	}
+
+	if err := SetRemoteClaudeHooksEnabled(s, true); err != nil {
+		t.Fatalf("enable hooks failed: %v", err)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("expected marker removed, got err=%v", err)
+	}
+}
+
 func TestCodexNotifyManagedBlockUsesConfigArray(t *testing.T) {
 	block := codexNotifyManagedBlock("start", "end", 18339)
-	if !strings.Contains(block, `notify = ["cc-clip", "notify", "--from-codex-stdin"]`) {
+	if !strings.Contains(block, `notify = ["cc-clip", "notify", "--trusted", "--from-codex-stdin"]`) {
 		t.Fatalf("expected notify array config, got %q", block)
 	}
 	if strings.Contains(block, "[notify]") {
@@ -264,7 +286,7 @@ func TestEnsureRemoteCodexNotifyConfigAppendsManagedBlock(t *testing.T) {
 	}
 
 	config := readTestCodexConfig(t, s.home)
-	if !strings.Contains(config, `notify = ["env", "CC_CLIP_PORT=9999", "cc-clip", "notify", "--from-codex-stdin"]`) {
+	if !strings.Contains(config, `notify = ["env", "CC_CLIP_PORT=9999", "cc-clip", "notify", "--trusted", "--from-codex-stdin"]`) {
 		t.Fatalf("config missing managed notify block: %q", config)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the issues reported in #80, #81, and #82 (clipboard-over-SSH `send` + the notification bridge). Each change was verified line-by-line against the current code and adversarially reviewed; build, `go vet`, and `go test -race` are green.

## Changes

### `cc-clip send` — kill silent upload success (#80)
- After the `ssh ... 'cat >'` upload, verify the remote file size (`test -s` + `wc -c`, wrapped in `sh -lc`) against the local size; any empty/missing/mismatch now fails loudly with a non-zero exit instead of printing a remote path on a no-op.
- Parse the byte count defensively (last all-digit field) so a remote shell rc-file that prints to stdout cannot corrupt the check.
- Note: the originally reported "exit 0, no error, no file" triad was **not reproducible** from the current error-handling path (errors already propagate; the path is printed only on success; the send code is byte-identical to v0.7.7). This change is mechanism-agnostic defense-in-depth so the symptom cannot recur regardless of the underlying Windows transport quirk.

### Notification sound + clean custom notifications (#81, #82.5)
- `cc-clip notify --sound <name>` with an allowlist of macOS system sounds (Glass, Ping, Basso, …); unknown names are ignored (never passed raw to `osascript`/`terminal-notifier`).
- `--urgency 2` (critical) plays a default `Glass` chime, including on the hook path (permission prompts).
- `cc-clip notify --trusted` suppresses the `[unverified]` prefix for nonce-authenticated local callers; the `Notification` hook path now renders the `message` field as the body, so custom-text notifications are no longer empty.

### Notification reliability over remote SSH (#82.1–#82.4)
- **#82.1** — the claude wrapper now injects Stop/Notification hooks **unconditionally** (the launch-time `/health` gate is gone). The hook script is already fail-soft when the tunnel is down, so a slow/late tunnel no longer silences the entire session.
- **#82.2 / #82.3** — the daemon's notification-nonce registry is now **persisted to disk atomically** (mode 0600, temp+fsync+rename) and **reloaded on startup**, so a reboot/daemon restart no longer invalidates notifications with HTTP 401. In-memory state rolls back if the persist write fails. `--token-only` now also re-syncs the notification nonce.
- **#82.4** — a persistent opt-out marker `~/.cache/cc-clip/no-hooks` (toggled by `cc-clip connect --no-hooks` / `--hooks`) lets users who manage their own hooks disable wrapper injection; it survives wrapper reinstalls and `--force`. `--no-hooks/--hooks` combined with `--token-only` is rejected at parse time (it would otherwise be a silent no-op).

### Security / hygiene
- `connect` no longer prints a partial notification nonce to stdout.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./... -race -count=1`
- [ ] Manual: macOS `cc-clip notify --sound Glass` and `--urgency 2` produce an audible chime
- [ ] Manual: reboot the Mac, confirm notifications still deliver (no 401) without re-running `connect`
- [ ] Manual (#80): reproduce on Windows 10 → CentOS 7.6 with the reporter's exact version and confirm the new verification surfaces any real upload failure

## Linked issues
Addresses #80, #81, #82.
