### PR TITLE
fix(send): isolate SSH stderr and sentinel-parse remote $HOME (#80)

### DIFF
--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"flag"
@@ -300,16 +301,59 @@ func uploadLocalFile(host, remoteDir, localFile string) (*uploadResult, error) {
 	}, nil
 }
 
+// Sentinel markers wrap the remote $HOME value so parseRemoteHome can extract
+// it even when SSH banners (e.g. the Windows OpenSSH post-quantum warning) or a
+// login shell's profile output land on the same stream. See issue #80.
+const (
+	remoteHomeMarkerStart = "__CCHOME_BEGIN__"
+	remoteHomeMarkerEnd   = "__CCHOME_END__"
+)
+
 func remoteHomeDir(host string) (string, error) {
-	out, err := remoteExecNoForward(host, `sh -lc 'printf %s "$HOME"'`)
+	out, err := remoteExecNoForward(host, remoteHomeProbeCmd())
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve remote home: %w", err)
 	}
-	out = strings.TrimSpace(out)
-	if out == "" {
+	home, err := parseRemoteHome(out)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve remote home: %w", err)
+	}
+	return home, nil
+}
+
+// remoteHomeProbeCmd prints $HOME wrapped in sentinel markers and nothing else.
+// printf emits no trailing newline, so the text between the markers is exactly
+// $HOME. The markers let parseRemoteHome discard any banner lines emitted by
+// SSH or the remote login shell on the same stream.
+func remoteHomeProbeCmd() string {
+	return "sh -lc 'printf " + remoteHomeMarkerStart + "%s" + remoteHomeMarkerEnd + ` "$HOME"'`
+}
+
+// parseRemoteHome extracts the remote $HOME from probe output, tolerating
+// banner/warning lines before or after the sentinels, and validates that the
+// result is a single absolute POSIX path. It fails loudly rather than return a
+// polluted value that would corrupt the remote upload path (issue #80).
+func parseRemoteHome(raw string) (string, error) {
+	start := strings.Index(raw, remoteHomeMarkerStart)
+	if start < 0 {
+		return "", fmt.Errorf("remote home start marker not found in output: %q", raw)
+	}
+	rest := raw[start+len(remoteHomeMarkerStart):]
+	end := strings.Index(rest, remoteHomeMarkerEnd)
+	if end < 0 {
+		return "", fmt.Errorf("remote home end marker not found in output: %q", raw)
+	}
+	home := strings.TrimSpace(rest[:end])
+	if home == "" {
 		return "", fmt.Errorf("remote home directory is empty")
 	}
-	return out, nil
+	if strings.ContainsAny(home, "\r\n") {
+		return "", fmt.Errorf("remote home directory spans multiple lines: %q", home)
+	}
+	if !strings.HasPrefix(home, "/") {
+		return "", fmt.Errorf("remote home directory is not an absolute path: %q", home)
+	}
+	return home, nil
 }
 
 func resolveRemoteDir(homeDir, remoteDir string) string {
@@ -356,14 +400,42 @@ func writeTempImage(data []byte, ext string) (string, error) {
 	return f.Name(), nil
 }
 
-func remoteExecNoForward(host, cmd string) (string, error) {
-	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, cmd)
-	hideConsoleWindow(c)
-	out, err := c.CombinedOutput()
-	if err != nil {
-		return strings.TrimSpace(string(out)), fmt.Errorf("ssh failed: %s: %w", strings.TrimSpace(string(out)), err)
+// sshNoForwardArgs builds the argv for cc-clip's ssh invocations.
+//
+//   - ClearAllForwardings=yes stops a user's global RemoteForward in ssh_config
+//     from triggering on these one-shot connections.
+//   - LogLevel=ERROR suppresses connection banners such as Windows OpenSSH's
+//     post-quantum key-exchange warning, which otherwise reaches the client and
+//     used to pollute the remote home lookup (issue #80).
+//   - "--" terminates option parsing so a host beginning with "-" can never be
+//     interpreted as a flag.
+func sshNoForwardArgs(host, cmd string) []string {
+	return []string{
+		"-o", "ClearAllForwardings=yes",
+		"-o", "LogLevel=ERROR",
+		"--", host, cmd,
 	}
-	return strings.TrimSpace(string(out)), nil
+}
+
+// remoteExecNoForward runs an SSH command and returns only its stdout. stderr
+// is captured separately and surfaced solely in the error message, so banner
+// or warning text on stderr never pollutes the returned value (issue #80).
+func remoteExecNoForward(host, cmd string) (string, error) {
+	c := exec.Command("ssh", sshNoForwardArgs(host, cmd)...)
+	hideConsoleWindow(c)
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	out := strings.TrimSpace(stdout.String())
+	if err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = out
+		}
+		return out, fmt.Errorf("ssh failed: %s: %w", detail, err)
+	}
+	return out, nil
 }
 
 func sshUploadNoForward(host, localPath, remotePath string) error {
@@ -389,7 +461,7 @@ func sshUploadNoForward(host, localPath, remotePath string) error {
 		return fmt.Errorf("local file is empty: %s", localPath)
 	}
 
-	c := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, sshUploadRemoteCmd(remotePath))
+	c := exec.Command("ssh", sshNoForwardArgs(host, sshUploadRemoteCmd(remotePath))...)
 	c.Stdin = f
 	hideConsoleWindow(c)
 	if out, err := c.CombinedOutput(); err != nil {

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -226,5 +227,95 @@ func TestParseRemoteUploadSize(t *testing.T) {
 	}
 	if _, err := parseRemoteUploadSize("no byte count here"); err == nil {
 		t.Fatal("expected non-numeric size output to fail")
+	}
+}
+
+// TestParseRemoteHomeStripsSSHWarningPollution reproduces issue #80. Windows
+// OpenSSH emits a post-quantum key-exchange banner on every connection. Under
+// the old CombinedOutput()-based remote home lookup, that banner was
+// concatenated into $HOME, so the remote upload path became
+// "/root/** WARNING.../root/.cache/cc-clip/uploads/clip-*.png" and the file
+// landed at a wrong, deeply nested path while `send` still exited 0. Wrapping
+// the value in sentinels and extracting only the text between them must yield
+// the clean home regardless of any banner lines before or after it.
+func TestParseRemoteHomeStripsSSHWarningPollution(t *testing.T) {
+	pqBanner := "** WARNING: connection is not using a post-quantum key exchange algorithm.\n" +
+		"** This session may be vulnerable to \"store now, decrypt later\" attacks.\n" +
+		"** The server may need to be upgraded. See https://openssh.com/pq.html\n"
+
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"banner before", pqBanner + remoteHomeMarkerStart + "/root" + remoteHomeMarkerEnd},
+		{"banner after", remoteHomeMarkerStart + "/root" + remoteHomeMarkerEnd + "\n" + pqBanner},
+		{"banner both sides", pqBanner + remoteHomeMarkerStart + "/root" + remoteHomeMarkerEnd + "\n" + pqBanner},
+		{"clean", remoteHomeMarkerStart + "/root" + remoteHomeMarkerEnd},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRemoteHome(tc.raw)
+			if err != nil {
+				t.Fatalf("parseRemoteHome(%q) returned error: %v", tc.raw, err)
+			}
+			if got != "/root" {
+				t.Fatalf("parseRemoteHome(%q) = %q, want %q", tc.raw, got, "/root")
+			}
+		})
+	}
+}
+
+// TestParseRemoteHomeRejectsInvalid pins the loud-failure contract: anything
+// that is not a single absolute POSIX path between the sentinels must error
+// instead of silently producing a corrupt remote path.
+func TestParseRemoteHomeRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"no markers", "/root"},
+		{"only start marker", remoteHomeMarkerStart + "/root"},
+		{"only end marker", "/root" + remoteHomeMarkerEnd},
+		{"empty home", remoteHomeMarkerStart + remoteHomeMarkerEnd},
+		{"whitespace home", remoteHomeMarkerStart + "   " + remoteHomeMarkerEnd},
+		{"relative path", remoteHomeMarkerStart + "relative/dir" + remoteHomeMarkerEnd},
+		{"multiline home", remoteHomeMarkerStart + "/root\n/evil" + remoteHomeMarkerEnd},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := parseRemoteHome(tc.raw); err == nil {
+				t.Fatalf("parseRemoteHome(%q) = %q, want error", tc.raw, got)
+			}
+		})
+	}
+}
+
+// TestRemoteHomeProbeCmdEmbedsSentinelsAndReadsHome pins the probe command so
+// the sentinels wrap exactly the $HOME value and parseRemoteHome can extract
+// it. The %s must sit between the two markers.
+func TestRemoteHomeProbeCmdEmbedsSentinelsAndReadsHome(t *testing.T) {
+	cmd := remoteHomeProbeCmd()
+	if !strings.Contains(cmd, `"$HOME"`) {
+		t.Fatalf("probe cmd must read $HOME: %q", cmd)
+	}
+	if !strings.Contains(cmd, remoteHomeMarkerStart+"%s"+remoteHomeMarkerEnd) {
+		t.Fatalf("probe cmd must place %%s between the markers: %q", cmd)
+	}
+}
+
+// TestSSHNoForwardArgsSuppressesBannerAndForwarding pins the shared ssh argv
+// builder used by every cc-clip ssh call. LogLevel=ERROR suppresses the
+// post-quantum banner (#80) at the source, ClearAllForwardings=yes keeps a
+// user's global RemoteForward from triggering, and `--` terminates option
+// parsing before the host so a dash-leading host can never be read as a flag.
+func TestSSHNoForwardArgsSuppressesBannerAndForwarding(t *testing.T) {
+	got := sshNoForwardArgs("myserver", "echo hi")
+	want := []string{
+		"-o", "ClearAllForwardings=yes",
+		"-o", "LogLevel=ERROR",
+		"--", "myserver", "echo hi",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sshNoForwardArgs(\"myserver\", \"echo hi\") = %#v, want %#v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Windows OpenSSH prints a post-quantum key-exchange banner on every connection. `remoteHomeDir()` resolved `$HOME` with `CombinedOutput()`, so the banner was merged into the home value and `resolveRemoteDir()` built the upload path under a "warning-text" directory. The file uploaded with the correct size but to the **wrong path**, while `cc-clip send` still exited 0 — v0.8.0's post-upload size verification cannot catch a wrong-*path* success. Root cause confirmed by the reporter's `find` output in #80.

## Changes

- **`remoteExecNoForward`** — capture stdout/stderr separately and return only stdout; stderr is surfaced solely in error messages, so no banner can reach the returned value.
- **`remoteHomeProbeCmd` + `parseRemoteHome`** — wrap `$HOME` in sentinel markers and extract only the text between them, then validate it is a single absolute POSIX path, failing loudly instead of building a corrupt path. Tolerates banner lines before/after on stdout (e.g. login-shell profile noise).
- **`sshNoForwardArgs`** — shared ssh argv builder adding `-o LogLevel=ERROR` (suppresses the banner at the source) alongside `-o ClearAllForwardings=yes`; used by both `send` ssh call sites.

Defense in depth: layer 1 (stderr isolation) fixes the reporter's exact case, layer 2 (sentinel + validation) covers stdout pollution, layer 3 (`LogLevel=ERROR`) suppresses at the source.

Out of scope: `internal/doctor/remote.go` has a separate same-named `remoteExecNoForward` still using `CombinedOutput()` (read-only diagnostics, not the upload path), left for a follow-up hardening pass.

## Test plan

- [x] `make test` passes (`go test ./... -count=1`, run with `-race`)
- [x] `make vet` passes (`go vet ./...`, exit 0); `staticcheck ./cmd/cc-clip/` clean
- [x] New unit tests (TDD, written failing first): `parseRemoteHome` strips PQ-banner pollution (before/after/both sides) and rejects empty/whitespace/relative/multiline/missing-marker; `remoteHomeProbeCmd` places `%s` between the sentinels; `sshNoForwardArgs` pins `ClearAllForwardings=yes` + `LogLevel=ERROR` + `--`
- [ ] Manual E2E (reporter offered to verify on a Windows -> Linux v0.8.1 build)

## Related issues

Refs #80 — kept open until the reporter verifies the v0.8.1 build on Windows -> Linux, then closed.
