### PR TITLE
P0: deploy-state schema guard + install rollback pin + cross-arch checksum (pre-v0.9.0)

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -482,6 +482,24 @@ func cmdUninstall() {
 	}
 }
 
+// shouldAbortUninstallCodexNewerSchema decides whether `uninstall --codex`
+// must refuse to proceed because the remote was deployed by a newer cc-clip
+// (deploy-state schema > this binary's). Extracted as a pure helper so the
+// abort decision and its operator-facing message are unit-testable without a
+// live SSH session. Returns (false, "") for a nil/legacy/current-schema state.
+//
+// Unlike the connect guard, there is intentionally NO --force escape hatch:
+// uninstall is not an emergency-recovery path, so an older binary must never
+// be allowed to tear down a newer-schema remote and clobber its deploy.json.
+func shouldAbortUninstallCodexNewerSchema(host string, remoteState *shim.DeployState) (bool, string) {
+	if !remoteState.IsNewerSchema() {
+		return false, ""
+	}
+	return true, fmt.Sprintf(
+		"remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); refusing to uninstall Codex from it and clobber its newer state. Upgrade this cc-clip first.",
+		host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion())
+}
+
 // cmdUninstallCodexRemote cleans up Codex support on a remote host via SSH.
 func cmdUninstallCodexRemote(host string) {
 	fmt.Printf("Uninstalling Codex support from %s...\n", host)
@@ -491,6 +509,17 @@ func cmdUninstallCodexRemote(host string) {
 		log.Fatalf("SSH connection failed: %v", err)
 	}
 	defer session.Close()
+
+	// Forward downgrade guard (before ANY teardown): if the remote was deployed
+	// by a newer cc-clip, refuse — tearing it down would rewrite deploy.json with
+	// this older binary's schema and silently drop unknown newer fields. A read
+	// error or nil/legacy state is NOT a newer schema, so normal uninstalls
+	// proceed unaffected.
+	if preState, perr := shim.ReadRemoteState(session); perr == nil {
+		if abort, msg := shouldAbortUninstallCodexNewerSchema(host, preState); abort {
+			log.Fatalf("      %s", msg)
+		}
+	}
 
 	var teardownError bool
 	var stateError bool

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -844,6 +844,18 @@ remote has a valid claude binary installed.
 			log.Fatalf("      failed to read remote state: %v\n      Re-run with --force only if you intend to ignore deploy.json.", err)
 		}
 	}
+	// Forward downgrade guard: if the remote was deployed by a newer cc-clip
+	// (deploy-state schema > this binary's), refuse to overwrite it unless the
+	// operator explicitly passes --force. Runs before any remote mutation.
+	if remoteState.IsNewerSchema() {
+		if force {
+			log.Printf("      warning: remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); --force given, overwriting anyway.",
+				host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion())
+		} else {
+			log.Fatalf("      remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); refusing to overwrite it.\n      Upgrade this cc-clip, or pass --force to override.",
+				host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion())
+		}
+	}
 	if remoteState != nil && !force {
 		fmt.Printf("      remote state: binary=%s shim=%v\n", remoteState.BinaryVersion, remoteState.ShimInstalled)
 	} else if force {

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -849,8 +849,8 @@ remote has a valid claude binary installed.
 	// operator explicitly passes --force. Runs before any remote mutation.
 	if remoteState.IsNewerSchema() {
 		if force {
-			log.Printf("      warning: remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); --force given, overwriting anyway.",
-				host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion())
+			log.Printf("      warning: remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); --force DISCARDS the newer remote's deploy-state fields and rewrites deploy.json with this older binary's schema v%d (data loss) — upgrade this cc-clip instead to preserve them.",
+				host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion(), shim.CurrentDeploySchemaVersion())
 		} else {
 			log.Fatalf("      remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); refusing to overwrite it.\n      Upgrade this cc-clip, or pass --force to override.",
 				host, remoteState.SchemaVersion, shim.CurrentDeploySchemaVersion())

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -877,7 +877,8 @@ remote has a valid claude binary installed.
 	}
 	// Forward downgrade guard: if the remote was deployed by a newer cc-clip
 	// (deploy-state schema > this binary's), refuse to overwrite it unless the
-	// operator explicitly passes --force. Runs before any remote mutation.
+	// operator explicitly passes --force. Runs before any deploy-state or
+	// binary write.
 	if remoteState.IsNewerSchema() {
 		if force {
 			log.Printf("      warning: remote %s was deployed by a newer cc-clip (deploy-state schema v%d > this binary's v%d); --force DISCARDS the newer remote's deploy-state fields and rewrites deploy.json with this older binary's schema v%d (data loss) — upgrade this cc-clip instead to preserve them.",

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -1842,6 +1844,27 @@ func downloadReleaseBinary(targetOS, targetArch string) (string, error) {
 		return "", fmt.Errorf("download failed (%s): %s", url, string(out))
 	}
 
+	// Verify the archive's sha256 against the release checksums.txt before
+	// extracting. This downloads a release binary and pushes it to a remote
+	// host, so an unverified archive is a supply-chain exposure. On any
+	// mismatch or missing entry, refuse to extract.
+	checksumsURL := fmt.Sprintf("https://github.com/ShunmeiCho/cc-clip/releases/download/v%s/checksums.txt", ver)
+	checksumsPath := filepath.Join(tmpDir, "checksums.txt")
+	csCmd := exec.Command("curl", "-fsSL", "--max-time", "30", "-o", checksumsPath, checksumsURL)
+	if out, err := csCmd.CombinedOutput(); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("checksums download failed (%s): %s", checksumsURL, string(out))
+	}
+	checksumsContent, err := os.ReadFile(checksumsPath)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("read checksums.txt: %w", err)
+	}
+	if err := verifyArchiveChecksum(archivePath, string(checksumsContent), archiveName); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", fmt.Errorf("checksum verification failed: %w", err)
+	}
+
 	extractCmd := exec.Command("tar", "-xzf", archivePath, "-C", tmpDir)
 	if out, err := extractCmd.CombinedOutput(); err != nil {
 		os.RemoveAll(tmpDir)
@@ -1855,6 +1878,42 @@ func downloadReleaseBinary(targetOS, targetArch string) (string, error) {
 	}
 
 	return binPath, nil
+}
+
+// verifyArchiveChecksum computes the sha256 of the file at archivePath and
+// compares it against the expected digest for archiveName as listed in a
+// goreleaser checksums.txt. The checksums format is "<sha256>  <filename>"
+// lines (two spaces). Returns an error on a missing entry or a mismatch so the
+// caller can refuse to use an unverified archive.
+func verifyArchiveChecksum(archivePath, checksumsContent, archiveName string) error {
+	expected := ""
+	for _, line := range strings.Split(checksumsContent, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == archiveName {
+			expected = fields[0]
+			break
+		}
+	}
+	if expected == "" {
+		return fmt.Errorf("checksum for %s not found in checksums.txt", archiveName)
+	}
+
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash archive: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", archiveName, expected, actual)
+	}
+	return nil
 }
 
 func findSourceDir() (string, error) {

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -285,6 +285,48 @@ func TestNewDeployStateReturnsHashError(t *testing.T) {
 	}
 }
 
+func TestShouldAbortUninstallCodexNewerSchema(t *testing.T) {
+	cur := shim.CurrentDeploySchemaVersion()
+
+	t.Run("newer schema aborts", func(t *testing.T) {
+		state := &shim.DeployState{SchemaVersion: cur + 1}
+		abort, msg := shouldAbortUninstallCodexNewerSchema("host-a", state)
+		if !abort {
+			t.Fatal("expected abort for a remote with a newer deploy-state schema")
+		}
+		// The message must be actionable: name the host, both versions, refusal,
+		// and the upgrade remedy. No --force escape hatch is offered for uninstall.
+		for _, want := range []string{"host-a", "newer cc-clip", "refusing", "Upgrade this cc-clip"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("abort message missing %q; got: %q", want, msg)
+			}
+		}
+		if strings.Contains(msg, "--force") {
+			t.Errorf("uninstall abort message must NOT offer --force; got: %q", msg)
+		}
+	})
+
+	t.Run("current schema proceeds", func(t *testing.T) {
+		state := &shim.DeployState{SchemaVersion: cur}
+		if abort, _ := shouldAbortUninstallCodexNewerSchema("host-b", state); abort {
+			t.Fatal("must not abort for a remote stamped at the current schema")
+		}
+	})
+
+	t.Run("legacy schema proceeds", func(t *testing.T) {
+		state := &shim.DeployState{SchemaVersion: 0}
+		if abort, _ := shouldAbortUninstallCodexNewerSchema("host-c", state); abort {
+			t.Fatal("must not abort for a legacy (SchemaVersion==0) remote")
+		}
+	})
+
+	t.Run("nil state proceeds", func(t *testing.T) {
+		if abort, _ := shouldAbortUninstallCodexNewerSchema("host-d", nil); abort {
+			t.Fatal("must not abort when there is no deploy state to read")
+		}
+	})
+}
+
 func TestNewDeployStatePreservesCodexWhenNotRequested(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "cc-clip")

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http/httptest"
@@ -447,6 +449,72 @@ func TestReleaseVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestVerifyArchiveChecksum(t *testing.T) {
+	content := []byte("hello cc-clip")
+	archiveName := "cc-clip_0.6.0_linux_amd64.tar.gz"
+
+	// Compute the real digest for the fixture so the test is self-contained.
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, archiveName)
+	if err := os.WriteFile(archivePath, content, 0o600); err != nil {
+		t.Fatalf("write archive fixture: %v", err)
+	}
+	realSum := sha256Hex(t, content)
+
+	otherName := "cc-clip_0.6.0_darwin_arm64.tar.gz"
+
+	tests := []struct {
+		name        string
+		checksums   string
+		archiveName string
+		wantErr     bool
+	}{
+		{
+			name: "matching checksum passes",
+			checksums: realSum + "  " + archiveName + "\n" +
+				"0000000000000000000000000000000000000000000000000000000000000000  " + otherName + "\n",
+			archiveName: archiveName,
+			wantErr:     false,
+		},
+		{
+			name:        "mismatched checksum fails",
+			checksums:   "deadbeef00000000000000000000000000000000000000000000000000000000  " + archiveName + "\n",
+			archiveName: archiveName,
+			wantErr:     true,
+		},
+		{
+			name:        "missing entry fails",
+			checksums:   realSum + "  " + otherName + "\n",
+			archiveName: archiveName,
+			wantErr:     true,
+		},
+		{
+			name:        "empty checksums fails",
+			checksums:   "",
+			archiveName: archiveName,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyArchiveChecksum(archivePath, tt.checksums, tt.archiveName)
+			if tt.wantErr && err == nil {
+				t.Fatalf("verifyArchiveChecksum() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("verifyArchiveChecksum() = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func sha256Hex(t *testing.T, b []byte) string {
+	t.Helper()
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 func TestNotifyFromCodexParsesLastAssistantMessage(t *testing.T) {

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -233,9 +233,14 @@ There are two flavours of rollback, and they are **not** equally safe:
   do not yet have `cc-clip update`:
 
     ```sh
-    CC_CLIP_VERSION=v0.5.0 \
-      curl -fsSL https://raw.githubusercontent.com/ShunmeiCho/cc-clip/main/scripts/install.sh | sh
+    curl -fsSL https://raw.githubusercontent.com/ShunmeiCho/cc-clip/main/scripts/install.sh \
+      | CC_CLIP_VERSION=v0.5.0 sh
     ```
+
+    The env var must be set on the **right-hand side of the pipe** (the `sh` that
+    runs the script), not on `curl`. `CC_CLIP_VERSION=v0.5.0 curl ... | sh` would
+    export the pin only into the `curl` process and the piped `sh` would still
+    install `/latest`.
 
   The value must be a full tag (for example `v0.5.0`); a missing `v` prefix is
   accepted. An invalid value aborts the install with an actionable error.
@@ -291,10 +296,24 @@ So do **not** rely on a fail-closed here — the protection is forward-only by
 design. If you must cross the v0.9 boundary downward, expect to clean up and
 redeploy those adapters by hand:
 
-1. From a machine still running v0.9.0+, tear down the v0.9-only adapters on the
-   remote you are about to downgrade (for example `cc-clip uninstall <host>
-   --opencode` / `--agy`, or whichever you enabled) so no orphaned hook entries
-   are left behind.
+1. **Manually tear down the v0.9-only adapters** on the remote you are about to
+   downgrade, so no orphaned plugin / hook entries are left behind. There is **no**
+   `cc-clip uninstall <host> --opencode` / `--agy` command today — symmetric
+   uninstall for those targets is not yet implemented (`cc-clip uninstall`
+   currently supports only `--codex` and `--host`). Clean them up over SSH by hand,
+   only for whichever adapters you actually enabled:
+
+    ```sh
+    # opencode notify plugin (the dropped .js is removed by hand):
+    ssh <host> 'rm -f "$HOME/.config/opencode/plugins/cc-clip-notify.js"'
+
+    # Antigravity (agy) notify plugin (use agy's own uninstall on the remote;
+    # agy's managed plugins dir is version-specific, so let the CLI find it):
+    ssh <host> 'agy plugin uninstall cc-clip-notify'
+    ```
+
+    (Future cc-clip versions may add `cc-clip uninstall --opencode` / `--agy` to
+    automate this; until then the manual cleanup above is the supported path.)
 2. Roll the remote back by deploying the pre-v0.9 binary from the older local
    cc-clip (`connect --force`), accepting that `deploy.json` will be rewritten
    in the old format.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -196,7 +196,9 @@ The install script does not support Windows. Upgrade is manual.
 - **Remote cache says "unchanged":** `cc-clip connect` tracks the remote
   binary hash in `~/.cache/cc-clip/deploy.json` on the remote. If that
   file claims the binary is already current, `connect` will skip the upload.
-  Use `--force` on upgrade runs.
+  Use `--force` on upgrade runs. (`deploy.json` also carries a
+  `schema_version` that drives the forward-downgrade guard — see
+  [Rollback](#rollback).)
 - **Token vs binary upgrade:** If you only rotated the daemon token and did
   not change the binary, run `cc-clip connect myserver --token-only`
   instead — it syncs the token without a full redeploy.
@@ -207,20 +209,98 @@ The install script does not support Windows. Upgrade is manual.
 
 ## Rollback
 
-cc-clip version upgrades are reversible — just install an older version the
-same way.
+There are two flavours of rollback, and they are **not** equally safe:
+
+- **Same-generation rollback** (for example `v0.9.1 -> v0.9.0`): the normal,
+  lossless path. Both binaries speak the same deploy-state schema and know the
+  same deployment targets (`--codex`, `--opencode`, `--agy`), so re-running
+  `connect --force` simply re-syncs the older binary. This is what the runbook
+  below covers.
+- **Cross-v0.9 downgrade** (to a pre-`v0.9.0` binary): **not lossless** — see
+  the [Cross-v0.9 downgrade](#cross-v09-downgrade-pre-v090) subsection before
+  you attempt it.
+
+### Pin a version (forward or backward)
 
 - **`cc-clip update --to v0.5.0`** (cc-clip 0.6.2+): same semantics as a
   forward upgrade — checksum-verify, swap, restart, verify — but against
   the pinned release tag instead of `/latest`.
 
-- **Via install script, pinned to a specific tag:** `install.sh` always
-  fetches `/releases/latest`. To install a specific older version
-  manually, use the Option C commands above with `V=` set to the version
-  you want (for example `V=0.5.0` downgrades to `v0.5.0`).
+- **Via install script, pinned with `CC_CLIP_VERSION`** (curl-install rollback
+  channel, mirrors `cc-clip update --to`): `install.sh` fetches
+  `/releases/latest` by default, but if `CC_CLIP_VERSION` is set it installs
+  that exact tag instead. This is the recommended one-liner for machines that
+  do not yet have `cc-clip update`:
 
-- **After downgrading, re-run `cc-clip connect <host> --force`** for each
-  remote you use, so the remote side also goes back in sync.
+    ```sh
+    CC_CLIP_VERSION=v0.5.0 \
+      curl -fsSL https://raw.githubusercontent.com/ShunmeiCho/cc-clip/main/scripts/install.sh | sh
+    ```
+
+  The value must be a full tag (for example `v0.5.0`); a missing `v` prefix is
+  accepted. An invalid value aborts the install with an actionable error.
+
+- **Via install script, the manual way:** you can also skip `CC_CLIP_VERSION`
+  and use the Option C manual-download commands above with `V=` set to the
+  version you want (for example `V=0.5.0` downgrades to `v0.5.0`).
+
+### Rollback runbook
+
+For a **same-generation** rollback, after the local binary is replaced:
+
+1. **Restart the daemon** (`cc-clip service uninstall && cc-clip service
+   install`) so launchd stops holding the old binary — same as a forward
+   upgrade.
+
+2. **List the remotes that need re-syncing.** The local host registry knows
+   every machine you have deployed to and the version it last received:
+
+    ```sh
+    cc-clip hosts list
+    # HOST      VERSION  CODEX  LAST CONNECTED
+    # myserver  0.9.1    no     2026-06-01T10:22:04+09:00
+    # venus     0.9.1    yes    2026-05-30T18:05:11+09:00
+    ```
+
+3. **Re-run `cc-clip connect <host> --force`** for each remote in that list, so
+   the remote side goes back in sync with the downgraded local binary. `--force`
+   bypasses the hash-based "binary unchanged, skipping" optimization.
+
+    Note the new guard (v0.9.0+): if the remote's `deploy.json` was last written
+    by a **newer** cc-clip than the one you just rolled back to, `connect`
+    **refuses** to overwrite it and tells you to upgrade this cc-clip or pass
+    `--force`. This protects you from a stale local binary silently clobbering a
+    remote that a newer machine deployed. It is a *forward* guard only — see the
+    caveat below for what it does and does not cover.
+
+### Cross-v0.9 downgrade (pre-v0.9.0)
+
+Downgrading a remote to a **pre-`v0.9.0`** binary is **not lossless**, and there
+is no automatic guard that will stop you. Two things go wrong:
+
+- A pre-`v0.9.0` binary does not understand the v0.9 deployment-target model
+  (`--opencode`, `--agy`, and the per-adapter `Notify.Adapters` map in
+  `deploy.json`). It only knows the original Claude-Code shim + hook layout.
+- Being a *pre-guard* binary, it has no `schema_version` awareness. The
+  forward-downgrade guard described above only exists in binaries that **ship**
+  it (v0.9.0 and later). An older binary will happily **overwrite**
+  `~/.cache/cc-clip/deploy.json` on the remote, dropping the `Adapters` map and
+  the `agy-notify` / `opencode-notify` entries.
+
+So do **not** rely on a fail-closed here — the protection is forward-only by
+design. If you must cross the v0.9 boundary downward, expect to clean up and
+redeploy those adapters by hand:
+
+1. From a machine still running v0.9.0+, tear down the v0.9-only adapters on the
+   remote you are about to downgrade (for example `cc-clip uninstall <host>
+   --opencode` / `--agy`, or whichever you enabled) so no orphaned hook entries
+   are left behind.
+2. Roll the remote back by deploying the pre-v0.9 binary from the older local
+   cc-clip (`connect --force`), accepting that `deploy.json` will be rewritten
+   in the old format.
+3. When you later move forward across v0.9 again, re-enable the adapters you
+   want (`connect <host> --opencode` / `--agy` / `--all`); v0.9.0+ will
+   re-stamp `deploy.json` with the current `schema_version`.
 
 If a release was published in error by the maintainer, they will mark it
 `prerelease` on GitHub. `install.sh` will then skip it automatically and

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -114,12 +114,19 @@ func stampSchemaVersion(state *DeployState) {
 	if state == nil {
 		return
 	}
-	// Never LOWER an existing schema version. An older binary re-writing a
-	// state deployed by a NEWER cc-clip (e.g. `uninstall --codex`, or
-	// `connect --force`) must not silently downgrade schema_version — that
-	// would mask the very newer-schema condition IsNewerSchema/the connect
-	// guard exist to surface. Stamp forward only when the existing value is
-	// older than this binary's.
+	// Never LOWER an existing schema version. This clause only protects write
+	// paths that PRESERVE an existing remoteState (e.g. `uninstall --codex`,
+	// which reads the remote state and rewrites it in place): an older binary
+	// re-writing a state deployed by a NEWER cc-clip must not silently downgrade
+	// schema_version, since that would mask the newer-schema condition
+	// IsNewerSchema/the connect guard exist to surface.
+	//
+	// It does NOT cover `connect --force`. That path intentionally sets
+	// remoteState=nil and builds a FRESH state (SchemaVersion=0), so there is no
+	// preserved newer value to keep — --force is an explicit operator override
+	// that DISCARDS the remote's deploy-state and rewrites deploy.json with this
+	// binary's schema by design. The fresh state stamps forward from 0 to
+	// currentDeploySchemaVersion here, which is the honest --force outcome.
 	if state.SchemaVersion < currentDeploySchemaVersion {
 		state.SchemaVersion = currentDeploySchemaVersion
 	}

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -70,9 +70,17 @@ type ClaudeWrapperState struct {
 	OriginTarget string `json:"origin_target,omitempty"` // resolved path when OriginKind=="symlink"
 }
 
+// currentDeploySchemaVersion is the deploy-state schema version this binary
+// writes. v1 is the v0.9.0 per-adapter Notify schema. A state stamped with a
+// HIGHER version was written by a newer cc-clip; the connect path refuses to
+// overwrite it (see DeployState.IsNewerSchema). A state with SchemaVersion==0
+// (legacy / pre-guard) is NOT newer — it migrates normally via migrateNotifyState.
+const currentDeploySchemaVersion = 1
+
 // DeployState represents the state of a cc-clip deployment on a remote host.
 // It is stored as ~/.cache/cc-clip/deploy.json on the remote.
 type DeployState struct {
+	SchemaVersion int                 `json:"schema_version,omitempty"`
 	BinaryHash    string              `json:"binary_hash"`
 	BinaryVersion string              `json:"binary_version"`
 	ShimInstalled bool                `json:"shim_installed"`
@@ -81,6 +89,32 @@ type DeployState struct {
 	Notify        *NotifyDeployState  `json:"notify,omitempty"`
 	Codex         *CodexDeployState   `json:"codex,omitempty"`
 	ClaudeWrapper *ClaudeWrapperState `json:"claude_wrapper,omitempty"`
+}
+
+// CurrentDeploySchemaVersion returns the deploy-state schema version this
+// binary writes. Exposed so the connect path can render an actionable
+// "this binary's vN" message in the forward-downgrade guard.
+func CurrentDeploySchemaVersion() int { return currentDeploySchemaVersion }
+
+// IsNewerSchema reports whether this state was written by a cc-clip with a
+// HIGHER deploy-state schema version than the running binary. Only
+// SchemaVersion strictly greater than currentDeploySchemaVersion counts as
+// newer; SchemaVersion==0 (legacy / pre-guard) is treated as older and
+// migrates normally. The connect path uses this to refuse clobbering a remote
+// deployed by a newer cc-clip unless --force is given. A nil receiver is safe
+// and reports false.
+func (s *DeployState) IsNewerSchema() bool {
+	return s != nil && s.SchemaVersion > currentDeploySchemaVersion
+}
+
+// stampSchemaVersion sets state.SchemaVersion to the version this binary
+// writes. Applied by WriteRemoteState before marshaling so every state this
+// binary persists carries its schema version forward.
+func stampSchemaVersion(state *DeployState) {
+	if state == nil {
+		return
+	}
+	state.SchemaVersion = currentDeploySchemaVersion
 }
 
 const remoteDeployPath = "~/.cache/cc-clip/deploy.json"
@@ -179,6 +213,8 @@ func AdapterInstalled(remote *DeployState, id AdapterID) bool {
 
 // WriteRemoteState writes the deploy state to the remote host via the SSH session.
 func WriteRemoteState(session *SSHSession, state *DeployState) error {
+	stampSchemaVersion(state)
+
 	data, err := json.MarshalIndent(state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal deploy state: %w", err)

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -114,7 +114,15 @@ func stampSchemaVersion(state *DeployState) {
 	if state == nil {
 		return
 	}
-	state.SchemaVersion = currentDeploySchemaVersion
+	// Never LOWER an existing schema version. An older binary re-writing a
+	// state deployed by a NEWER cc-clip (e.g. `uninstall --codex`, or
+	// `connect --force`) must not silently downgrade schema_version — that
+	// would mask the very newer-schema condition IsNewerSchema/the connect
+	// guard exist to surface. Stamp forward only when the existing value is
+	// older than this binary's.
+	if state.SchemaVersion < currentDeploySchemaVersion {
+		state.SchemaVersion = currentDeploySchemaVersion
+	}
 }
 
 const remoteDeployPath = "~/.cache/cc-clip/deploy.json"

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -1061,6 +1061,24 @@ func TestStampSchemaVersionRoundTrip(t *testing.T) {
 	}
 }
 
+// TestStampSchemaVersionNeverLowers verifies stampSchemaVersion preserves a
+// HIGHER existing schema version (never downgrades). An older binary re-writing
+// a state deployed by a newer cc-clip (uninstall --codex / connect --force) must
+// not silently lower schema_version below what the remote already carries.
+func TestStampSchemaVersionNeverLowers(t *testing.T) {
+	newer := &DeployState{SchemaVersion: currentDeploySchemaVersion + 1}
+	stampSchemaVersion(newer)
+	if newer.SchemaVersion != currentDeploySchemaVersion+1 {
+		t.Fatalf("stampSchemaVersion lowered a newer schema: got %d, want %d", newer.SchemaVersion, currentDeploySchemaVersion+1)
+	}
+
+	legacy := &DeployState{SchemaVersion: 0}
+	stampSchemaVersion(legacy)
+	if legacy.SchemaVersion != currentDeploySchemaVersion {
+		t.Fatalf("stampSchemaVersion failed to bump legacy state: got %d, want %d", legacy.SchemaVersion, currentDeploySchemaVersion)
+	}
+}
+
 // TestSchemaVersionOmittedWhenZero verifies the omitempty tag keeps legacy
 // JSON byte-clean: a state that was never stamped writes no schema_version key.
 func TestSchemaVersionOmittedWhenZero(t *testing.T) {

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -1027,6 +1027,123 @@ func TestNeedsNotifySetup_BackwardCompat(t *testing.T) {
 	}
 }
 
+// --- P0a: deploy-state SchemaVersion + forward downgrade guard ---
+
+// TestStampSchemaVersionRoundTrip verifies the stamp helper sets
+// SchemaVersion=currentDeploySchemaVersion and that it survives a
+// marshal/unmarshal round-trip. WriteRemoteState applies the same stamp before
+// writing, so this exercises the on-the-wire encoding path WriteRemoteState uses.
+func TestStampSchemaVersionRoundTrip(t *testing.T) {
+	state := &DeployState{BinaryHash: "sha256:abc"}
+	if state.SchemaVersion != 0 {
+		t.Fatalf("precondition: fresh state SchemaVersion = %d, want 0", state.SchemaVersion)
+	}
+
+	stampSchemaVersion(state)
+	if state.SchemaVersion != currentDeploySchemaVersion {
+		t.Fatalf("stampSchemaVersion set SchemaVersion = %d, want %d", state.SchemaVersion, currentDeploySchemaVersion)
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"schema_version"`) {
+		t.Fatalf("marshaled JSON missing schema_version key: %s", data)
+	}
+
+	var decoded DeployState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if decoded.SchemaVersion != currentDeploySchemaVersion {
+		t.Fatalf("round-trip SchemaVersion = %d, want %d", decoded.SchemaVersion, currentDeploySchemaVersion)
+	}
+}
+
+// TestSchemaVersionOmittedWhenZero verifies the omitempty tag keeps legacy
+// JSON byte-clean: a state that was never stamped writes no schema_version key.
+func TestSchemaVersionOmittedWhenZero(t *testing.T) {
+	data, err := json.Marshal(&DeployState{BinaryHash: "x"})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(data), "schema_version") {
+		t.Fatalf("unstamped state should omit schema_version, got: %s", data)
+	}
+}
+
+// TestIsNewerSchema_LegacyStillMigrates verifies that a legacy state (no
+// schema_version => 0) is NOT considered newer and still migrates to the
+// per-adapter schema. SchemaVersion==0 means "pre-guard", not "from the future".
+func TestIsNewerSchema_LegacyStillMigrates(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeRemoteDeployState(t, s.home, `{
+  "binary_hash": "sha256:legacy",
+  "shim_installed": true,
+  "notify": {"enabled": true, "hook_installed": true, "codex_injected": false, "health_verified": false}
+}`)
+
+	state, err := ReadRemoteState(s)
+	if err != nil {
+		t.Fatalf("ReadRemoteState error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if state.SchemaVersion != 0 {
+		t.Fatalf("legacy state SchemaVersion = %d, want 0", state.SchemaVersion)
+	}
+	if state.IsNewerSchema() {
+		t.Fatal("legacy state (SchemaVersion==0) must NOT report IsNewerSchema()==true")
+	}
+	// Still migrates: Adapters populated from legacy booleans.
+	if state.Notify == nil || state.Notify.Adapters == nil {
+		t.Fatalf("legacy state should migrate to per-adapter schema, got %+v", state.Notify)
+	}
+	if !AdapterInstalled(state, AdapterClaudeNotify) {
+		t.Fatal("legacy migration should mark claude-notify installed")
+	}
+}
+
+// TestIsNewerSchema_NewerStateDetected verifies that a state stamped with a
+// SchemaVersion greater than this binary's is reported as newer.
+func TestIsNewerSchema_NewerStateDetected(t *testing.T) {
+	s := &localSession{home: t.TempDir()}
+	writeRemoteDeployState(t, s.home, `{
+  "binary_hash": "sha256:future",
+  "schema_version": 2,
+  "shim_installed": true
+}`)
+
+	state, err := ReadRemoteState(s)
+	if err != nil {
+		t.Fatalf("ReadRemoteState error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if state.SchemaVersion != currentDeploySchemaVersion+1 {
+		t.Fatalf("SchemaVersion = %d, want %d", state.SchemaVersion, currentDeploySchemaVersion+1)
+	}
+	if !state.IsNewerSchema() {
+		t.Fatal("a state with SchemaVersion > current must report IsNewerSchema()==true")
+	}
+}
+
+// TestIsNewerSchema_CurrentAndNil verifies edge cases: a state stamped at
+// exactly the current version is NOT newer, and a nil receiver is safe + false.
+func TestIsNewerSchema_CurrentAndNil(t *testing.T) {
+	current := &DeployState{SchemaVersion: currentDeploySchemaVersion}
+	if current.IsNewerSchema() {
+		t.Errorf("state at currentDeploySchemaVersion must not be newer")
+	}
+	var nilState *DeployState
+	if nilState.IsNewerSchema() {
+		t.Errorf("nil DeployState must not report IsNewerSchema()==true")
+	}
+}
+
 func TestClipboardTransportPreserved(t *testing.T) {
 	s := &localSession{home: t.TempDir()}
 	writeRemoteDeployState(t, s.home, `{

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -1079,6 +1079,30 @@ func TestStampSchemaVersionNeverLowers(t *testing.T) {
 	}
 }
 
+// TestStampSchemaVersionForceDiscardWritesCurrent documents the `connect --force`
+// outcome at the unit level. The --force branch in cmdConnect sets remoteState=nil
+// and builds a FRESH DeployState (SchemaVersion=0, the zero value) — it does NOT
+// preserve the newer remote's schema. WriteRemoteState then stamps that fresh
+// state to currentDeploySchemaVersion. This is the honest, by-design downgrade:
+// --force discards the newer remote's deploy-state fields and rewrites deploy.json
+// with THIS binary's schema. The never-lower clause in stampSchemaVersion does NOT
+// rescue this path because there is no preserved older->newer value to compare
+// against — the fresh state starts at 0.
+func TestStampSchemaVersionForceDiscardWritesCurrent(t *testing.T) {
+	// Mirror the --force build: newDeployState(..., remoteState=nil) yields a
+	// state whose SchemaVersion is the zero value, regardless of what the remote
+	// (possibly newer) actually carried.
+	fresh := &DeployState{BinaryHash: "sha256:force"}
+	if fresh.SchemaVersion != 0 {
+		t.Fatalf("precondition: fresh --force-derived state SchemaVersion = %d, want 0", fresh.SchemaVersion)
+	}
+
+	stampSchemaVersion(fresh)
+	if fresh.SchemaVersion != currentDeploySchemaVersion {
+		t.Fatalf("--force write stamped SchemaVersion = %d, want current %d", fresh.SchemaVersion, currentDeploySchemaVersion)
+	}
+}
+
 // TestSchemaVersionOmittedWhenZero verifies the omitempty tag keeps legacy
 // JSON byte-clean: a state that was never stamped writes no schema_version key.
 func TestSchemaVersionOmittedWhenZero(t *testing.T) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -38,6 +38,31 @@ get_latest_version() {
     fi
 }
 
+# Resolve the release tag to install.
+#
+# Default: fetch the latest published release (/releases/latest).
+# Override: if CC_CLIP_VERSION is set and non-empty, pin that tag instead
+# (rollback channel). Accepts both "0.9.0" and "v0.9.0"; normalizes to a
+# leading "v" and validates a semver-like shape before use. Garbage is
+# rejected with a clear error rather than silently falling back to latest.
+#
+# Diagnostics go to stderr so the resolved tag stays clean on stdout.
+resolve_version() {
+    if [ -n "${CC_CLIP_VERSION:-}" ]; then
+        ver="v${CC_CLIP_VERSION#v}"
+        # vMAJOR.MINOR.PATCH with an optional prerelease/build suffix.
+        if ! echo "$ver" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "Error: CC_CLIP_VERSION='${CC_CLIP_VERSION}' is not a valid version tag (expected e.g. v0.9.0)" >&2
+            exit 1
+        fi
+        echo "Installing cc-clip ${ver} (pinned via CC_CLIP_VERSION)" >&2
+        echo "$ver"
+        return
+    fi
+
+    get_latest_version
+}
+
 download() {
     local url="$1" dest="$2"
     if command -v curl >/dev/null 2>&1; then
@@ -76,7 +101,7 @@ verify_checksum() {
 
 main() {
     PLATFORM=$(detect_platform)
-    VERSION=$(get_latest_version)
+    VERSION=$(resolve_version)
 
     if [ -z "$VERSION" ]; then
         echo "Error: could not determine latest version"

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -2,6 +2,7 @@ package scripts_test
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -67,4 +68,55 @@ func TestInstallScriptSupportsCCClipVersionPin(t *testing.T) {
 	if !strings.Contains(script, "releases/latest") {
 		t.Fatalf("install.sh must keep the /releases/latest default path")
 	}
+}
+
+// TestUpgradingDocPipesPinEnvToSh locks the docs/upgrading.md CC_CLIP_VERSION
+// pin example into the correct "env-to-sh" form. The pin must reach the `sh`
+// that runs the script (right-hand side of the pipe), not `curl`. The broken
+// form `CC_CLIP_VERSION=... curl ... | sh` exports the pin only into curl, so
+// the piped sh still installs /latest. This is a doc-regression guard, not a
+// runtime test.
+func TestUpgradingDocPipesPinEnvToSh(t *testing.T) {
+	data, err := os.ReadFile("../docs/upgrading.md")
+	if err != nil {
+		t.Fatalf("read docs/upgrading.md: %v", err)
+	}
+	doc := string(data)
+
+	// The doc must show the env var on the right-hand side of the pipe, either
+	// piping into `CC_CLIP_VERSION=... sh` or exporting it before the pipe.
+	hasPipeToShPin := strings.Contains(doc, "| CC_CLIP_VERSION=") &&
+		regexp.MustCompile(`\|\s*CC_CLIP_VERSION=\S+\s+sh\b`).MatchString(doc)
+	hasExportBeforePipe := regexp.MustCompile(`export\s+CC_CLIP_VERSION=`).MatchString(doc)
+	if !hasPipeToShPin && !hasExportBeforePipe {
+		t.Fatalf("docs/upgrading.md must pass CC_CLIP_VERSION to the piped sh " +
+			"(e.g. `curl ... | CC_CLIP_VERSION=v0.5.0 sh`) or export it before the pipe")
+	}
+
+	// Guard against regressing to the broken form where the env var is attached
+	// to curl and the script body is piped to a bare `sh` — that pin never
+	// reaches the script. Detect `CC_CLIP_VERSION=... curl ...` on one logical
+	// command that then pipes to `sh` without re-setting the env on the pipe.
+	brokenInline := regexp.MustCompile(`CC_CLIP_VERSION=\S+\s+curl\b[^\n]*\|\s*sh\b`)
+	brokenMultiline := regexp.MustCompile(`CC_CLIP_VERSION=\S+\s*\\\s*\n\s*curl\b`)
+	for _, code := range extractFencedCode(doc) {
+		if brokenInline.MatchString(code) || brokenMultiline.MatchString(code) {
+			t.Fatalf("docs/upgrading.md has a broken CC_CLIP_VERSION pin that "+
+				"sets the env on curl instead of the piped sh:\n%s", code)
+		}
+	}
+}
+
+// extractFencedCode returns the contents of every ```...``` fenced block in the
+// markdown doc, so the regression guard only inspects runnable command examples
+// and not the surrounding prose (which deliberately names the broken pattern as
+// a counter-example).
+func extractFencedCode(doc string) []string {
+	var blocks []string
+	parts := strings.Split(doc, "```")
+	// Fenced blocks are the odd-indexed segments (1, 3, 5, ...).
+	for i := 1; i < len(parts); i += 2 {
+		blocks = append(blocks, parts[i])
+	}
+	return blocks
 }

--- a/scripts/install_test.go
+++ b/scripts/install_test.go
@@ -30,3 +30,41 @@ func TestInstallScriptVerifiesReleaseChecksumBeforeExtraction(t *testing.T) {
 		t.Fatalf("install.sh must verify the archive checksum before extraction")
 	}
 }
+
+func TestInstallScriptSupportsCCClipVersionPin(t *testing.T) {
+	data, err := os.ReadFile("install.sh")
+	if err != nil {
+		t.Fatalf("read install.sh: %v", err)
+	}
+	script := string(data)
+
+	for _, needle := range []string{
+		// Reads the pin env var.
+		"CC_CLIP_VERSION",
+		// Normalizes a leading 'v' (accepts both 0.9.0 and v0.9.0).
+		"resolve_version()",
+		// Validates a semver-like tag before use.
+		"^v[0-9]+\\.[0-9]+\\.[0-9]+",
+		// Tells the user the pinned tag is being installed.
+		"pinned via CC_CLIP_VERSION",
+		// Rejects garbage instead of silently falling back to latest.
+		"is not a valid version tag",
+	} {
+		if !strings.Contains(script, needle) {
+			t.Fatalf("install.sh must contain %q for CC_CLIP_VERSION pinning", needle)
+		}
+	}
+
+	// The pin must still route through the existing asset-naming + checksum
+	// contract: VERSION is consumed by ARCHIVE_NAME and the download URLs.
+	resolveIdx := strings.Index(script, "resolve_version")
+	archiveIdx := strings.Index(script, "ARCHIVE_NAME=")
+	if resolveIdx == -1 || archiveIdx == -1 || resolveIdx > archiveIdx {
+		t.Fatalf("install.sh must resolve the version before building ARCHIVE_NAME")
+	}
+
+	// The default (no env) path must remain /releases/latest.
+	if !strings.Contains(script, "releases/latest") {
+		t.Fatalf("install.sh must keep the /releases/latest default path")
+	}
+}


### PR DESCRIPTION
## Purpose

v0.9.0 is a large deployment/setup refactor (multi-target connect split, settings-first Claude hooks, per-adapter deploy-state, BREAKING `--codex`). This PR adds deployment-resilience guards **before the public tag**, to shrink the blast radius when existing users upgrade or roll back.

## Changes (8 commits, 7 files +645/-10)

- `feat(deploy)`: deploy-state gains `SchemaVersion` + a forward-downgrade guard on connect. When the remote carries a higher schema than this binary writes, connect aborts unless `--force` is given.
- `feat(install)`: `install.sh` honors `CC_CLIP_VERSION` to pin a release (rollback channel), with semver validation; default behavior unchanged.
- `fix(deploy)`: `stampSchemaVersion` never lowers an existing schema (protects PRESERVING write paths such as `uninstall --codex`).
- `fix(deploy)`: corrected `--force` semantics — `--force` = **explicit overwrite/downgrade**. It discards the newer remote's deploy-state fields and rewrites `deploy.json` with this binary's schema; the warning states the data loss explicitly.
- `fix(uninstall)`: `uninstall --codex` aborts against a newer-schema remote with **no `--force` override**, avoiding a silent clobber.
- `fix(security)`: cross-arch `downloadReleaseBinary` verifies the `checksums.txt` sha256 **before** `tar -xzf` (P1 supply-chain hardening).
- `docs(upgrading)`: cross-v0.9 rollback runbook + `CC_CLIP_VERSION` usage + schema-guard notes.

## Locked semantics

- `--force` is an explicit operator override that rewrites to the current schema (an acknowledged data-loss behavior, NOT "never-lower even under --force").
- `uninstall --codex` has **no** `--force` escape for a newer-schema remote — intentional; the operator should upgrade their local cc-clip first.

## Verification (honest disclosure)

Tested (unit / disk-verified, passing):
- Pure helpers: `IsNewerSchema`, `stampSchemaVersion` (round-trip / never-lower / force-discard), `shouldAbortUninstallCodexNewerSchema`, `verifyArchiveChecksum` (match/mismatch/missing/empty, offline).
- `install.sh` `CC_CLIP_VERSION` pinning + the upgrading-doc command (a regression test locks the env-to-sh form).
- `go build` / `go vet` / `staticcheck` pass; changed-package `go test` passes.
- PR CI is green on the exact head SHA.

Live-SSH smoke (real remote, x86_64, working v0.8.0 deployment):
- `uninstall --codex --host <remote>` against a remote with a planted newer schema (`schema_version: 2` > this binary's `1`) **aborts before any teardown**: it prints the "refusing ... Upgrade this cc-clip first" message, exits 1, leaves `deploy.json` untouched, and leaves the running Xvfb / x11-bridge alive. Full backup + restore; the remote was returned byte-for-byte to its original state. This exercises the real-SSH `ReadRemoteState` + `IsNewerSchema` + abort-before-teardown wiring end-to-end.

Not smoke-tested on a live remote:
- `connect --force` against a newer-schema remote was NOT run on a live host (doing so would deploy this dev build over a working deployment). It is covered transitively: it shares the same `ReadRemoteState` + `IsNewerSchema` wiring verified above, and its `--force` branch adds only local "log warning + reset state" logic, which is unit-tested.
- Closing even this remaining gap fully would need an `SSHSession` interface seam to unit-test the orchestration (P1 testability work).

## Review

One adversarial deep-review round (found + fixed 6 items A–F) plus an independent reviewer's second pass; both converged on pass.

## Test plan

- [x] CI: build / vet / test -race / staticcheck / govulncheck green on head SHA
- [x] live-remote smoke: `uninstall --codex` aborts against a newer-schema remote (verified on an x86_64 v0.8.0 box; backup+restore, no teardown, no `deploy.json` mutation)
- [ ] (optional, post-merge) `connect --force` warning path on a throwaway remote — transitively covered today
