### PR TITLE
docs(readme): add v0.9.0-beta.1 prerelease banner (en/zh/ja)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <b>Beta（テスト版）：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in プレリリース）—— マルチターゲット設定（Claude / Codex / opencode / Antigravity）に加え、opencode・Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">リリースノートとインストール →</a>
+  <b>Beta（テスト版）：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in プレリリース）—— Claude / Codex / opencode / Antigravity の各ターゲットのセットアップに加え、opencode・Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">リリースノートとインストール →</a>
 </p>
 
 > これは英語版 README の日本語訳です。内容に差異がある場合は [English README](README.md) を正とします。この翻訳は英語版のメインラインより遅れている場合があります。

--- a/README.ja.md
+++ b/README.ja.md
@@ -26,6 +26,10 @@
   <em>インストール → セットアップ → 貼り付け。クリップボードが SSH 越しに動きます。</em>
 </p>
 
+<p align="center">
+  <b>Beta（テスト版）：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in プレリリース）—— マルチターゲット設定（Claude / Codex / opencode / Antigravity）に加え、opencode・Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">リリースノートとインストール →</a>
+</p>
+
 > これは英語版 README の日本語訳です。内容に差異がある場合は [English README](README.md) を正とします。この翻訳は英語版のメインラインより遅れている場合があります。
 >
 > *This is the Japanese translation of the English README. If any content differs, the [English README](README.md) is authoritative. This translation may lag behind the English main line.*

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
   <em>Install → setup → paste. Clipboard works over SSH.</em>
 </p>
 
+<p align="center">
+  <b>Beta available:</b> <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a> (opt-in prerelease) — multi-target setup (Claude / Codex / opencode / Antigravity) plus opencode &amp; Antigravity notifications. <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">Release notes &amp; install →</a>
+</p>
+
 ---
 
 <details>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 </p>
 
 <p align="center">
-  <b>Beta available:</b> <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a> (opt-in prerelease) — multi-target setup (Claude / Codex / opencode / Antigravity) plus opencode &amp; Antigravity notifications. <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">Release notes &amp; install →</a>
+  <b>Beta available:</b> <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a> (opt-in prerelease) — setup targets for Claude / Codex / opencode / Antigravity, plus opencode &amp; Antigravity notifications. <a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">Release notes &amp; install →</a>
 </p>
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,7 +27,7 @@
 </p>
 
 <p align="center">
-  <b>Beta 测试版：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in 预发布）—— 多目标安装（Claude / Codex / opencode / Antigravity），并新增 opencode 与 Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">发布说明与安装 →</a>
+  <b>Beta 测试版：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in 预发布）—— 支持 Claude / Codex / opencode / Antigravity 各目标的安装，并新增 opencode 与 Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">发布说明与安装 →</a>
 </p>
 
 > 这是英文 README 的简体中文翻译。如果翻译版与 [English README](README.md) 存在差异，以英文原版为准。翻译版本可能晚于英文主线更新。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,6 +26,10 @@
   <em>安装 → 初始化 → 粘贴。剪贴板可跨 SSH 工作。</em>
 </p>
 
+<p align="center">
+  <b>Beta 测试版：</b><a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">v0.9.0-beta.1</a>（opt-in 预发布）—— 多目标安装（Claude / Codex / opencode / Antigravity），并新增 opencode 与 Antigravity 通知。<a href="https://github.com/ShunmeiCho/cc-clip/releases/tag/v0.9.0-beta.1">发布说明与安装 →</a>
+</p>
+
 > 这是英文 README 的简体中文翻译。如果翻译版与 [English README](README.md) 存在差异，以英文原版为准。翻译版本可能晚于英文主线更新。
 >
 > *This is the Simplified Chinese translation of the English README. If any content differs, the [English README](README.md) is authoritative. This translation may lag behind the English main line.*


### PR DESCRIPTION
## Summary

Adds a prominent banner at the top of all three READMEs (en / zh-CN / ja) linking
to the `v0.9.0-beta.1` opt-in prerelease, so visitors discover the beta. Without it,
the beta is only reachable via the Releases page (it is not the `latest` release).

## Change

- One centered banner line under the demo GIF in `README.md`, `README.zh-CN.md`,
  `README.ja.md`, linking to the prerelease tag.
- Wording matches the release notes' honest framing (opt-in prerelease; multi-target
  setup; opencode + Antigravity notifications). No decorative emoji.

## Notes

- Docs-only, +12 lines, no code.
- The `<!-- i18n-source -->` hash in the localized READMEs is left unchanged; the same
  banner is added to all three in lockstep, so content stays in sync.
