### PR TITLE
feat: configurable notification sound tiers and terminal-notifier app icon (#92)

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -99,6 +99,67 @@ ssh myserver "mkdir -p ~/.cache/cc-clip && echo '$NONCE' > ~/.cache/cc-clip/noti
 
 > **Note:** `cc-clip connect` handles steps 2-4 automatically. Manual setup is only needed if you use plain `ssh` instead of `cc-clip connect`.
 
+## Customizing sound & icon (macOS)
+
+Notification **sound** and the **app icon** are configured with local
+environment variables read by the daemon (`cc-clip serve`). They are read on the
+local Mac only — never from the remote payload — so a remote agent cannot change
+your local sound or icon.
+
+> **Note:** These settings apply to the **native macOS notification path**
+> (`terminal-notifier` / osascript). If `cmux` is installed, the delivery chain
+> tries it first and — when it succeeds — sound and icon are skipped, because the
+> `cmux` (tmux) path only carries a title and body.
+
+Set them in the environment the daemon runs in:
+
+- **Foreground** (`cc-clip serve` in a shell): `export` the variable before starting.
+- **launchd service**: `launchctl setenv NAME value`, then restart the service
+  (`cc-clip service uninstall && cc-clip service install`). Note that
+  `launchctl setenv` is **session/bootstrap-scoped** — it is inherited by the
+  service the next time it starts, but it is *not* written into the cc-clip
+  `plist`, so reapply it after a reboot or re-login (or `export` the vars in the
+  shell that launches `cc-clip serve`).
+
+### Sound
+
+By default only **tool-approval** prompts play a sound (`Glass`); completion and
+idle notifications are silent. Override per urgency tier:
+
+| Variable | Applies to | Default |
+|----------|-----------|---------|
+| `CC_CLIP_SOUND_CRITICAL` | Tool approval needed (urgency 2) | `Glass` |
+| `CC_CLIP_SOUND_ATTENTION` | Idle / interrupted / Codex / opencode / Antigravity (urgency 1) | silent |
+| `CC_CLIP_SOUND_CALM` | "Claude finished" at end of turn (urgency 0) | silent |
+
+Values are macOS system sound names: `Basso`, `Blow`, `Bottle`, `Frog`, `Funk`,
+`Glass`, `Hero`, `Morse`, `Ping`, `Pop`, `Purr`, `Sosumi`, `Submarine`, `Tink`.
+Use `none` / `off` / `silent` to mute a tier; unrecognized names are treated as
+silent. A per-notification `sound` field in a `cc-clip notify` / `/notify`
+payload still overrides these tier defaults.
+
+```bash
+# Gentle end-of-turn chime, distinct approval sound
+launchctl setenv CC_CLIP_SOUND_CALM Tink
+launchctl setenv CC_CLIP_SOUND_CRITICAL Sosumi
+```
+
+### App icon
+
+`CC_CLIP_NOTIFY_APP_ICON` sets a custom notification icon, pointing at a local
+`.png`/`.icns` file:
+
+```bash
+launchctl setenv CC_CLIP_NOTIFY_APP_ICON "$HOME/.config/cc-clip/icon.png"
+```
+
+Limitations:
+
+- Honored **only on the `terminal-notifier` path** (`brew install terminal-notifier`).
+  The osascript fallback cannot set a custom app icon — macOS derives it from the
+  calling process — so without `terminal-notifier` the icon is unchanged.
+- A missing file or a directory is ignored silently (no icon, no error).
+
 ## Troubleshooting
 
 ### Notifications don't appear

--- a/internal/daemon/classifier.go
+++ b/internal/daemon/classifier.go
@@ -39,7 +39,10 @@ func ClassifyHookPayload(hookType string, raw map[string]any) *NotifyEnvelope {
 		case "permission_prompt":
 			env.GenericMessage.Title = "Tool approval needed"
 			env.GenericMessage.Urgency = 2
-			env.GenericMessage.Sound = defaultCriticalSound
+			// Sound is intentionally left unset here. The critical-tier
+			// default (and any CC_CLIP_SOUND_CRITICAL override) is applied at
+			// delivery time by defaultSoundForUrgency, keeping all
+			// sound-selection logic in one configurable place.
 		case "idle_prompt":
 			env.GenericMessage.Title = "Claude is idle"
 			env.GenericMessage.Urgency = 1

--- a/internal/daemon/classifier_test.go
+++ b/internal/daemon/classifier_test.go
@@ -231,7 +231,7 @@ func TestClassifyNotificationUsesMessageFallbackBody(t *testing.T) {
 	}
 }
 
-func TestClassifyPermissionPromptGetsDefaultSound(t *testing.T) {
+func TestClassifyPermissionPromptDelegatesSoundToDeliveryPolicy(t *testing.T) {
 	env := ClassifyHookPayload("notification", map[string]any{
 		"type": "permission_prompt",
 		"body": "Approve tool",
@@ -239,8 +239,19 @@ func TestClassifyPermissionPromptGetsDefaultSound(t *testing.T) {
 	if env == nil || env.GenericMessage == nil {
 		t.Fatalf("expected generic message envelope, got %#v", env)
 	}
-	if env.GenericMessage.Sound != defaultCriticalSound {
-		t.Fatalf("expected sound %q, got %q", defaultCriticalSound, env.GenericMessage.Sound)
+	// The classifier no longer hardcodes a sound; sound selection moved to the
+	// delivery layer so it can be configured via CC_CLIP_SOUND_CRITICAL.
+	if env.GenericMessage.Sound != "" {
+		t.Fatalf("classifier should delegate sound to delivery policy, got %q", env.GenericMessage.Sound)
+	}
+	if env.GenericMessage.Urgency != 2 {
+		t.Fatalf("permission prompt should be urgency 2, got %d", env.GenericMessage.Urgency)
+	}
+	// By default (no override) the delivery layer turns urgency 2 into the
+	// critical default sound, preserving the historical behaviour.
+	t.Setenv("CC_CLIP_SOUND_CRITICAL", "")
+	if got := notificationSound(*env); got != defaultCriticalSound {
+		t.Fatalf("delivery default for permission prompt = %q, want %q", got, defaultCriticalSound)
 	}
 }
 

--- a/internal/daemon/deliver.go
+++ b/internal/daemon/deliver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 )
 
@@ -122,20 +123,52 @@ func formatNotification(env NotifyEnvelope) (title, body string) {
 
 const defaultCriticalSound = "Glass"
 
+// notificationSound resolves the macOS sound name for an envelope.
+//
+// Precedence:
+//  1. An explicit per-notification Sound (e.g. from a generic /notify payload)
+//     always wins. An unrecognized explicit name normalizes to silence, so a
+//     caller can opt out with "none" / "off" / "silent".
+//  2. Otherwise a configurable default-sound policy applies, keyed by urgency
+//     tier (see defaultSoundForUrgency).
 func notificationSound(env NotifyEnvelope) string {
 	if env.GenericMessage == nil {
 		return ""
 	}
-	if sound := normalizeNotificationSound(env.GenericMessage.Sound); sound != "" {
-		return sound
-	}
 	if strings.TrimSpace(env.GenericMessage.Sound) != "" {
-		return ""
+		return normalizeNotificationSound(env.GenericMessage.Sound)
 	}
-	if env.GenericMessage.Urgency == 2 {
-		return defaultCriticalSound
+	return defaultSoundForUrgency(env.GenericMessage.Urgency)
+}
+
+// defaultSoundForUrgency picks the default sound for a notification that did
+// not carry an explicit sound. Each urgency tier reads a local environment
+// override so users can configure sounds without redeploying the remote
+// agents, then falls back to a built-in default. Built-in defaults preserve
+// historical behaviour: only the critical tier (permission prompts) makes a
+// sound; attention/calm stay silent unless configured.
+//
+// An override of none/off/silent (or any unrecognized name) suppresses the
+// tier's sound — the user asked for something specific, so we never
+// second-guess it with a different built-in sound.
+//
+// The environment is read on the local daemon (where Deliver runs), not from
+// the remote /notify payload, so a remote agent cannot change local sound
+// settings.
+func defaultSoundForUrgency(urgency int) string {
+	var envKey, builtin string
+	switch {
+	case urgency >= 2:
+		envKey, builtin = "CC_CLIP_SOUND_CRITICAL", defaultCriticalSound
+	case urgency == 1:
+		envKey, builtin = "CC_CLIP_SOUND_ATTENTION", ""
+	default:
+		envKey, builtin = "CC_CLIP_SOUND_CALM", ""
 	}
-	return ""
+	if override := strings.TrimSpace(os.Getenv(envKey)); override != "" {
+		return normalizeNotificationSound(override)
+	}
+	return builtin
 }
 
 func normalizeNotificationSound(sound string) string {

--- a/internal/daemon/deliver_test.go
+++ b/internal/daemon/deliver_test.go
@@ -343,6 +343,11 @@ func TestFormatNotificationToolAttention(t *testing.T) {
 }
 
 func TestNotificationSoundAllowlistAndCriticalDefault(t *testing.T) {
+	// Isolate from the host/CI environment: the delivery sound policy now reads
+	// these CC_CLIP_SOUND_* vars, so clear them to assert the built-in defaults.
+	t.Setenv("CC_CLIP_SOUND_CRITICAL", "")
+	t.Setenv("CC_CLIP_SOUND_ATTENTION", "")
+	t.Setenv("CC_CLIP_SOUND_CALM", "")
 	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2}}); got != defaultCriticalSound {
 		t.Fatalf("critical default sound = %q, want %q", got, defaultCriticalSound)
 	}
@@ -354,6 +359,82 @@ func TestNotificationSoundAllowlistAndCriticalDefault(t *testing.T) {
 	}
 	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2, Sound: "none"}}); got != "" {
 		t.Fatalf("sound=none should suppress critical default, got %q", got)
+	}
+}
+
+func TestDefaultSoundPolicyByUrgency(t *testing.T) {
+	// With no explicit sound and no env override, only the critical tier
+	// (urgency >= 2) makes a sound; attention/calm tiers stay silent so the
+	// historical completion/idle UX is unchanged.
+	t.Setenv("CC_CLIP_SOUND_CRITICAL", "")
+	t.Setenv("CC_CLIP_SOUND_ATTENTION", "")
+	t.Setenv("CC_CLIP_SOUND_CALM", "")
+	cases := []struct {
+		urgency int
+		want    string
+	}{
+		{3, defaultCriticalSound},
+		{2, defaultCriticalSound},
+		{1, ""},
+		{0, ""},
+		{-1, ""},
+	}
+	for _, c := range cases {
+		got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: c.urgency}})
+		if got != c.want {
+			t.Fatalf("urgency %d default sound = %q, want %q", c.urgency, got, c.want)
+		}
+	}
+}
+
+func TestDefaultSoundPolicyEnvOverridesEachTier(t *testing.T) {
+	t.Setenv("CC_CLIP_SOUND_CRITICAL", "Sosumi")
+	t.Setenv("CC_CLIP_SOUND_ATTENTION", "Pop")
+	t.Setenv("CC_CLIP_SOUND_CALM", "Tink")
+	cases := []struct {
+		urgency int
+		want    string
+	}{
+		{2, "Sosumi"},
+		{1, "Pop"},
+		{0, "Tink"},
+	}
+	for _, c := range cases {
+		got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: c.urgency}})
+		if got != c.want {
+			t.Fatalf("urgency %d with env override = %q, want %q", c.urgency, got, c.want)
+		}
+	}
+}
+
+func TestDefaultSoundPolicyEnvCanSilenceCriticalTier(t *testing.T) {
+	t.Setenv("CC_CLIP_SOUND_CRITICAL", "off")
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 2}}); got != "" {
+		t.Fatalf("CC_CLIP_SOUND_CRITICAL=off should silence the critical default, got %q", got)
+	}
+}
+
+func TestDefaultSoundPolicyEnvUnknownNameIsSilent(t *testing.T) {
+	// An unrecognized env sound name resolves to silence rather than a
+	// surprising fallback to the built-in default.
+	t.Setenv("CC_CLIP_SOUND_ATTENTION", "not-a-real-sound")
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 1}}); got != "" {
+		t.Fatalf("unknown env sound should be silent, got %q", got)
+	}
+}
+
+func TestNotificationSoundExplicitPayloadBeatsEnvPolicy(t *testing.T) {
+	// A per-notification Sound (e.g. from a generic /notify payload) wins over
+	// the env tier policy.
+	t.Setenv("CC_CLIP_SOUND_ATTENTION", "Pop")
+	if got := notificationSound(NotifyEnvelope{GenericMessage: &GenericMessagePayload{Urgency: 1, Sound: "ping"}}); got != "Ping" {
+		t.Fatalf("explicit payload sound should win over env policy, got %q", got)
+	}
+}
+
+func TestNotificationSoundNilGenericMessageIsSilent(t *testing.T) {
+	if got := notificationSound(NotifyEnvelope{}); got != "" {
+		t.Fatalf("nil generic message should be silent, got %q", got)
 	}
 }
 

--- a/internal/daemon/notify_darwin.go
+++ b/internal/daemon/notify_darwin.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -173,6 +174,14 @@ func (n *DarwinNotifier) Notify(_ context.Context, evt NotifyEvent) error {
 }
 
 func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePath, sound string) error {
+	args := buildTerminalNotifierArgs(title, subtitle, body, imagePath, sound, notifyAppIcon())
+	return exec.Command(n.terminalNotifier, args...).Run()
+}
+
+// buildTerminalNotifierArgs assembles the terminal-notifier argv. It is
+// extracted as a pure function so the flag wiring (-sound, -appIcon,
+// -contentImage) is unit-tested without executing the binary.
+func buildTerminalNotifierArgs(title, subtitle, body, imagePath, sound, appIcon string) []string {
 	args := []string{
 		"-title", title,
 		"-subtitle", subtitle,
@@ -182,11 +191,33 @@ func (n *DarwinNotifier) sendViaTerminalNotifier(title, subtitle, body, imagePat
 	if sound != "" {
 		args = append(args, "-sound", sound)
 	}
+	// -appIcon brands the notification with a custom icon. This is honored
+	// only on the terminal-notifier path; the osascript fallback cannot set a
+	// custom app icon (macOS derives it from the calling process's bundle).
+	if appIcon != "" {
+		args = append(args, "-appIcon", appIcon)
+	}
 	if imagePath != "" {
 		args = append(args, "-contentImage", imagePath)
 		args = append(args, "-open", "file://"+imagePath)
 	}
-	return exec.Command(n.terminalNotifier, args...).Run()
+	return args
+}
+
+// notifyAppIcon resolves the optional notification app icon from the local
+// CC_CLIP_NOTIFY_APP_ICON environment variable. The path is read only from the
+// local daemon's environment — never from a remote /notify payload — so a
+// remote agent cannot point the notifier at an arbitrary local file. A missing
+// file or a directory is treated as "no icon" and skipped silently.
+func notifyAppIcon() string {
+	p := strings.TrimSpace(os.Getenv("CC_CLIP_NOTIFY_APP_ICON"))
+	if p == "" {
+		return ""
+	}
+	if info, err := os.Stat(p); err != nil || info.IsDir() {
+		return ""
+	}
+	return p
 }
 
 func (n *DarwinNotifier) sendViaOsascript(title, subtitle, body, sound string) error {

--- a/internal/daemon/notify_darwin_test.go
+++ b/internal/daemon/notify_darwin_test.go
@@ -59,3 +59,76 @@ func TestDarwinNotifierDoesNotCleanupPreviewsOnDeliverHotPath(t *testing.T) {
 		t.Fatalf("Deliver synchronously pruned previews; got %d files, want >= %d", got, minExpected)
 	}
 }
+
+func TestBuildTerminalNotifierArgs(t *testing.T) {
+	t.Run("sound, appIcon and contentImage included when set", func(t *testing.T) {
+		args := buildTerminalNotifierArgs("T", "S", "B", "/tmp/p.png", "Ping", "/tmp/icon.png")
+		assertArgPair(t, args, "-title", "T")
+		assertArgPair(t, args, "-sound", "Ping")
+		assertArgPair(t, args, "-appIcon", "/tmp/icon.png")
+		assertArgPair(t, args, "-contentImage", "/tmp/p.png")
+	})
+	t.Run("optional flags omitted when empty", func(t *testing.T) {
+		args := buildTerminalNotifierArgs("T", "S", "B", "", "", "")
+		for _, flag := range []string{"-sound", "-appIcon", "-contentImage"} {
+			if containsArg(args, flag) {
+				t.Fatalf("expected no %s flag, got %v", flag, args)
+			}
+		}
+	})
+}
+
+func TestNotifyAppIcon(t *testing.T) {
+	t.Run("unset returns empty", func(t *testing.T) {
+		t.Setenv("CC_CLIP_NOTIFY_APP_ICON", "")
+		if got := notifyAppIcon(); got != "" {
+			t.Fatalf("unset icon should be empty, got %q", got)
+		}
+	})
+	t.Run("nonexistent path is ignored", func(t *testing.T) {
+		t.Setenv("CC_CLIP_NOTIFY_APP_ICON", filepath.Join(t.TempDir(), "missing.png"))
+		if got := notifyAppIcon(); got != "" {
+			t.Fatalf("missing icon path should be ignored, got %q", got)
+		}
+	})
+	t.Run("directory path is ignored", func(t *testing.T) {
+		t.Setenv("CC_CLIP_NOTIFY_APP_ICON", t.TempDir())
+		if got := notifyAppIcon(); got != "" {
+			t.Fatalf("directory should be ignored, got %q", got)
+		}
+	})
+	t.Run("existing file path is returned", func(t *testing.T) {
+		icon := filepath.Join(t.TempDir(), "icon.png")
+		if err := os.WriteFile(icon, []byte("png"), 0600); err != nil {
+			t.Fatalf("write icon: %v", err)
+		}
+		t.Setenv("CC_CLIP_NOTIFY_APP_ICON", icon)
+		if got := notifyAppIcon(); got != icon {
+			t.Fatalf("existing icon should be returned, got %q want %q", got, icon)
+		}
+	})
+}
+
+// containsArg reports whether flag appears as a standalone token in args.
+func containsArg(args []string, flag string) bool {
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+// assertArgPair asserts that flag is immediately followed by value in args.
+func assertArgPair(t *testing.T, args []string, flag, value string) {
+	t.Helper()
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag {
+			if args[i+1] != value {
+				t.Fatalf("flag %s = %q, want %q (args=%v)", flag, args[i+1], value, args)
+			}
+			return
+		}
+	}
+	t.Fatalf("flag %s not found in args=%v", flag, args)
+}


### PR DESCRIPTION
Partially addresses #92 (first step).

## What

Local, opt-in macOS notification settings, read by the daemon's environment (never from the remote payload):

- **Sound** — per-urgency-tier defaults via `CC_CLIP_SOUND_CRITICAL` / `_ATTENTION` / `_CALM`, applied at the delivery chokepoint (`deliver.go:notificationSound`) so all sources (Claude / Codex / opencode / Antigravity) are covered without a remote redeploy. Defaults preserve prior behavior: only tool-approval prompts make a sound.
- **App icon** — `CC_CLIP_NOTIFY_APP_ICON` → terminal-notifier `-appIcon`.

## Honest limitations

- The icon only works on the `terminal-notifier` path. The osascript fallback cannot set a custom app icon (macOS derives it from the calling process).
- The cmux (tmux) delivery path is tried first and only carries title/body, so sound + icon are skipped there.

## Tests

- New unit tests: urgency-tier sound policy, env overrides, silence opt-out, nil-safety, and terminal-notifier argv (incl. `-appIcon` + icon-path validation). The classifier's hardcoded permission sound moved to the delivery layer so all sound selection lives in one configurable place.
- `go test ./... -race` green; `go vet ./...` clean.

## Follow-up (does NOT close #92)

Per the #92 discussion, the requested end-state is **profile-based, per-tool** settings — each CLI (Claude / Codex / Gemini …) with its own sound and icon, so you can tell which tool needs attention — plus a customizable `icon_key` mapped to custom SVG icons. This PR is the first step (global, env-tier config); the per-tool profile model and `icon_key`/SVG mapping are deferred to a follow-up. #92 stays open.

## Note

Both this branch and #94 touched `docs/notifications.md` (different regions). #94 is already merged; this remains mergeable.
