### PR TITLE
fix: run remote commands under POSIX /bin/sh regardless of login shell

### DIFF
--- a/cmd/cc-clip/send.go
+++ b/cmd/cc-clip/send.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/shunmei/cc-clip/internal/daemon"
+	"github.com/shunmei/cc-clip/internal/shim"
 )
 
 const defaultRemoteUploadDir = "~/.cache/cc-clip/uploads"
@@ -413,7 +414,7 @@ func sshNoForwardArgs(host, cmd string) []string {
 	return []string{
 		"-o", "ClearAllForwardings=yes",
 		"-o", "LogLevel=ERROR",
-		"--", host, cmd,
+		"--", host, shim.WrapRemoteShell(cmd),
 	}
 }
 

--- a/cmd/cc-clip/send_test.go
+++ b/cmd/cc-clip/send_test.go
@@ -5,6 +5,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/shunmei/cc-clip/internal/shim"
 )
 
 func TestParseSendArgsTreatsTrailingImagePathAsFileWithDefaultHost(t *testing.T) {
@@ -306,14 +308,16 @@ func TestRemoteHomeProbeCmdEmbedsSentinelsAndReadsHome(t *testing.T) {
 // TestSSHNoForwardArgsSuppressesBannerAndForwarding pins the shared ssh argv
 // builder used by every cc-clip ssh call. LogLevel=ERROR suppresses the
 // post-quantum banner (#80) at the source, ClearAllForwardings=yes keeps a
-// user's global RemoteForward from triggering, and `--` terminates option
-// parsing before the host so a dash-leading host can never be read as a flag.
+// user's global RemoteForward from triggering, `--` terminates option parsing
+// before the host so a dash-leading host can never be read as a flag, and the
+// remote command is wrapped in /bin/sh -c so a non-POSIX login shell (fish)
+// never parses sh syntax itself.
 func TestSSHNoForwardArgsSuppressesBannerAndForwarding(t *testing.T) {
 	got := sshNoForwardArgs("myserver", "echo hi")
 	want := []string{
 		"-o", "ClearAllForwardings=yes",
 		"-o", "LogLevel=ERROR",
-		"--", "myserver", "echo hi",
+		"--", "myserver", shim.WrapRemoteShell("echo hi"),
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("sshNoForwardArgs(\"myserver\", \"echo hi\") = %#v, want %#v", got, want)

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -117,7 +117,7 @@ func classifyRemoteTokenCheck(out string, err error) CheckResult {
 // Doctor checks should inspect the existing tunnel, not compete with it by opening a new one.
 func remoteExecNoForward(host string, args ...string) (string, error) {
 	cmdStr := strings.Join(args, " ")
-	cmd := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, cmdStr)
+	cmd := exec.Command("ssh", "-o", "ClearAllForwardings=yes", "--", host, shim.WrapRemoteShell(cmdStr))
 	hideConsoleWindow(cmd)
 	out, err := cmd.CombinedOutput()
 	return strings.TrimSpace(string(out)), err

--- a/internal/shim/connect.go
+++ b/internal/shim/connect.go
@@ -18,7 +18,7 @@ var noForwardPrefix = []string{"-o", "ClearAllForwardings=yes"}
 
 // detectRemoteArchArgs builds the ssh arg vector for DetectRemoteArch.
 func detectRemoteArchArgs(host string) []string {
-	return sshHostArgs(noForwardPrefix, host, "uname -sm")
+	return sshHostArgs(noForwardPrefix, host, WrapRemoteShell("uname -sm"))
 }
 
 // uploadBinaryScpArgs builds the scp arg vector for UploadBinary.
@@ -28,18 +28,18 @@ func uploadBinaryScpArgs(host, localBin, remoteBin string) []string {
 
 // uploadBinaryChmodArgs builds the ssh chmod arg vector for UploadBinary.
 func uploadBinaryChmodArgs(host, remoteBin string) []string {
-	return sshHostArgs(noForwardPrefix, host, fmt.Sprintf("chmod +x %s", remoteBin))
+	return sshHostArgs(noForwardPrefix, host, WrapRemoteShell(fmt.Sprintf("chmod +x %s", remoteBin)))
 }
 
 // remoteExecArgs builds the ssh arg vector for RemoteExec.
 func remoteExecArgs(host, cmdStr string) []string {
-	return sshHostArgs(noForwardPrefix, host, cmdStr)
+	return sshHostArgs(noForwardPrefix, host, WrapRemoteShell(cmdStr))
 }
 
 // writeRemoteTokenArgs builds the ssh arg vector for WriteRemoteToken.
 func writeRemoteTokenArgs(host string) []string {
 	return sshHostArgs(noForwardPrefix, host,
-		"mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token")
+		WrapRemoteShell("mkdir -p ~/.cache/cc-clip && cat > ~/.cache/cc-clip/session.token && chmod 600 ~/.cache/cc-clip/session.token"))
 }
 
 // DetectRemoteArch returns the remote system's GOARCH-compatible architecture string.

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -121,14 +121,36 @@ func sshHostArgs(prefix []string, host string, remoteArgs ...string) []string {
 	return args
 }
 
+// WrapRemoteShell wraps cmd so the remote always runs it under POSIX /bin/sh,
+// independent of the user's login shell. OpenSSH hands a remote command string
+// to the login shell; a non-POSIX login shell (notably fish) mis-parses sh
+// syntax such as `set -e`, `$(...)`, `[ ... ]`, and bare `var=val`, which makes
+// `connect` fail with exit 127. Every cc-clip remote command is POSIX sh, so
+// forcing /bin/sh is behavior-preserving on bash/zsh logins and fixes fish (and
+// any other) login shell. The single-quote escaping in shSingleQuote is
+// interpreted identically by POSIX shells and fish, so the wrapper line itself
+// parses correctly no matter which shell sshd invokes.
+func WrapRemoteShell(cmd string) string {
+	return "/bin/sh -c " + shSingleQuote(cmd)
+}
+
+// shSingleQuote renders s as a single single-quoted shell token, escaping any
+// embedded single quote via the portable '\'' close-escape-reopen idiom.
+func shSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
 func scpUploadArgs(prefix []string, localPath, host, remotePath string) []string {
 	args := append([]string{}, prefix...)
 	args = append(args, "--", localPath, fmt.Sprintf("%s:%s", host, remotePath))
 	return args
 }
 
-func (s *SSHSession) sshArgs(remoteArgs ...string) []string {
-	return sshHostArgs(s.connArgs(), s.host, remoteArgs...)
+// sshArgs builds the ssh arg vector for a remote command over the master
+// connection. cmd is wrapped in WrapRemoteShell so it runs under POSIX /bin/sh
+// regardless of the remote login shell.
+func (s *SSHSession) sshArgs(cmd string) []string {
+	return sshHostArgs(s.connArgs(), s.host, WrapRemoteShell(cmd))
 }
 
 // Exec runs a command on the remote host via the SSH master connection.

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -163,6 +163,56 @@ func TestSCPHostArgsInsertOptionSeparatorBeforePaths(t *testing.T) {
 	}
 }
 
+func TestWrapRemoteShell(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "simple command",
+			cmd:  "uname -sm",
+			want: `/bin/sh -c 'uname -sm'`,
+		},
+		{
+			name: "embedded single quotes use close-escape-reopen idiom",
+			cmd:  "echo 'hi'",
+			want: `/bin/sh -c 'echo '\''hi'\'''`,
+		},
+		{
+			// sh syntax that a fish login shell mis-parses (exit 127) must end up
+			// fully inside the single-quoted token, never bare on the command line.
+			name: "posix sh script is fully quoted",
+			cmd:  "set -e\n[ -L \"$HOME/x\" ] || exit 0",
+			want: "/bin/sh -c 'set -e\n[ -L \"$HOME/x\" ] || exit 0'",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WrapRemoteShell(tc.cmd); got != tc.want {
+				t.Errorf("WrapRemoteShell(%q)\n got: %q\nwant: %q", tc.cmd, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSSHArgsWrapsRemoteCommandInPosixShell(t *testing.T) {
+	// The command sshd forwards to the login shell must be a single
+	// `/bin/sh -c '...'` token, so a non-POSIX login shell (fish) never parses
+	// sh syntax itself. Regression guard for fish-login-shell connect failures.
+	s := &SSHSession{host: "myhost", controlPath: "/tmp/cc-clip-ssh-test"}
+	cmd := "set -e\nmkdir -p ~/.cache/cc-clip"
+	args := s.sshArgs(cmd)
+
+	last := args[len(args)-1]
+	if want := WrapRemoteShell(cmd); last != want {
+		t.Fatalf("sshArgs last element\n got: %q\nwant: %q", last, want)
+	}
+	if !strings.HasPrefix(last, "/bin/sh -c '") {
+		t.Errorf("remote command not wrapped in /bin/sh -c: %q", last)
+	}
+}
+
 func TestGenerateNotificationNonce(t *testing.T) {
 	nonce, err := GenerateNotificationNonce()
 	if err != nil {


### PR DESCRIPTION
## Summary

`cc-clip connect` (and the other remote-exec paths) fail on any host whose
login shell is **fish** — or any non-POSIX shell. cc-clip sends POSIX-sh
scripts as the ssh command, and sshd hands that string to the user's login
shell. fish mis-parses sh syntax (`set -e`, bare `var=val`, `$(...)`,
`[ ... ]`), so the first step dies with **exit 127**. In practice `connect`
aborts immediately at the N0 wrapper-corruption check.

This wraps every remote command in `/bin/sh -c '<cmd>'` (new `WrapRemoteShell`
helper) at all dispatch sites — `SSHSession.sshArgs`, the `connect.go`
host-based builders, `send.go`, and `doctor` — so the remote always runs the
command under POSIX sh no matter which shell sshd invokes. The single-quote
escaping uses the portable `'\''` close-escape-reopen idiom, which POSIX
shells and fish interpret identically, so the wrapper line itself parses
under either. Behavior on bash/zsh logins is unchanged (an extra `/bin/sh -c`
hop with the same result), and control-channel / deliberately-interactive
invocations are untouched.

Now possible: `connect`, `send`, and `doctor` work against remotes whose
login shell is fish without requiring the user to change their shell.

## Test Plan

- `make vet` and `make test` — all packages green.
- New unit tests in `internal/shim/ssh_test.go`: `TestWrapRemoteShell`
  (simple, embedded-single-quote, and multi-line sh-script cases) and
  `TestSSHArgsWrapsRemoteCommandInPosixShell` (asserts the forwarded command
  is a single `/bin/sh -c '...'` token). Updated `send_test.go` expectation
  for the wrapped form.
- Verified end-to-end against a real remote whose login shell is fish:
  feeding the raw sh script to fish reproduces `exit 127`
  (`Unsupported use of '='`), while the wrapped `/bin/sh -c '<script>'` form
  fish now receives runs cleanly with `exit 0`.
