### PR TITLE
fix(daemon): deduplicate image transfer notifications

### DIFF
--- a/internal/daemon/dedup.go
+++ b/internal/daemon/dedup.go
@@ -44,15 +44,25 @@ func (d *Deduper) AllowAt(env NotifyEnvelope, now time.Time) (bool, *NotifyEnvel
 		return true, nil
 	}
 	msg := env.GenericMessage
-	if msg == nil {
-		return true, nil
-	}
 
-	key := DedupKey{
-		Source:   env.Source,
-		Type:     dedupType(env),
-		Title:    msg.Title,
-		BodyHash: md5.Sum([]byte(msg.Body)),
+	var key DedupKey
+	switch {
+	case env.ImageTransfer != nil:
+		key = DedupKey{
+			Source:   env.Source,
+			Type:     string(KindImageTransfer),
+			Title:    env.ImageTransfer.SessionID,
+			BodyHash: md5.Sum([]byte(env.ImageTransfer.Fingerprint)),
+		}
+	case msg != nil:
+		key = DedupKey{
+			Source:   env.Source,
+			Type:     dedupType(env),
+			Title:    msg.Title,
+			BodyHash: md5.Sum([]byte(msg.Body)),
+		}
+	default:
+		return true, nil
 	}
 
 	d.mu.Lock()
@@ -79,6 +89,9 @@ func (d *Deduper) AllowAt(env NotifyEnvelope, now time.Time) (bool, *NotifyEnvel
 	entry.SeenAt = now
 	d.items[key] = entry
 
+	if msg == nil {
+		return false, nil
+	}
 	merged := env
 	clone := *msg
 	clone.DedupCount = entry.Count

--- a/internal/daemon/dedup_test.go
+++ b/internal/daemon/dedup_test.go
@@ -153,7 +153,7 @@ func TestDeduperDifferentMessagesNotMerged(t *testing.T) {
 	}
 }
 
-func TestDeduperNilGenericMessagePassesThrough(t *testing.T) {
+func TestDeduperImageTransferDedup(t *testing.T) {
 	d := NewDeduper(15 * time.Second)
 	now := time.Unix(1000, 0)
 
@@ -161,21 +161,28 @@ func TestDeduperNilGenericMessagePassesThrough(t *testing.T) {
 		Kind:   KindImageTransfer,
 		Source: "clipboard",
 		ImageTransfer: &ImageTransferPayload{
-			SessionID: "abc",
-			Seq:       1,
-			Format:    "png",
+			SessionID:   "abc",
+			Seq:         1,
+			Fingerprint: "deadbeef",
+			Format:      "png",
 		},
 	}
 
 	allowed, merged := d.AllowAt(env, now)
 	if !allowed || merged != nil {
-		t.Fatal("envelope without GenericMessage should always pass")
+		t.Fatal("first image transfer should pass")
 	}
 
-	// Second identical should also pass (no GenericMessage to dedup on)
-	allowed, merged = d.AllowAt(env, now.Add(1*time.Second))
+	// Second identical fingerprint within window should be suppressed
+	allowed, _ = d.AllowAt(env, now.Add(1*time.Second))
+	if allowed {
+		t.Fatal("repeated image transfer with same fingerprint should be suppressed within dedup window")
+	}
+
+	// After the window expires, same fingerprint should pass again
+	allowed, merged = d.AllowAt(env, now.Add(17*time.Second))
 	if !allowed || merged != nil {
-		t.Fatal("envelope without GenericMessage should always pass, even repeated")
+		t.Fatal("image transfer should pass after dedup window expires")
 	}
 }
 

--- a/internal/daemon/notify_test.go
+++ b/internal/daemon/notify_test.go
@@ -431,20 +431,20 @@ func TestDuplicateDetectionViaNotification(t *testing.T) {
 		srv.mux.ServeHTTP(w, req)
 	}
 
+	// Only the first fetch should produce a notification; the second
+	// has the same fingerprint within the dedup window and is suppressed.
 	deadline := time.Now().Add(2 * time.Second)
-	for notifier.count.Load() < 2 && time.Now().Before(deadline) {
+	for notifier.count.Load() < 1 && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
+	time.Sleep(100 * time.Millisecond)
 
-	if notifier.count.Load() != 2 {
-		t.Fatalf("expected 2 notifications, got %d", notifier.count.Load())
+	if notifier.count.Load() != 1 {
+		t.Fatalf("expected 1 notification (duplicate suppressed), got %d", notifier.count.Load())
 	}
 
 	evt := notifier.last.Load().(NotifyEvent)
-	if evt.Seq != 2 {
-		t.Errorf("expected seq 2, got %d", evt.Seq)
-	}
-	if evt.DuplicateOf != 1 {
-		t.Errorf("expected duplicate of seq 1, got %d", evt.DuplicateOf)
+	if evt.Seq != 1 {
+		t.Errorf("expected seq 1, got %d", evt.Seq)
 	}
 }


### PR DESCRIPTION
## Problem

When connected to a remote machine via SSH, clipboard image fetches trigger repeated macOS notifications:

<img width="349" height="85" alt="image" src="https://github.com/user-attachments/assets/169569dd-1b10-4f52-b206-15a1ba385935" />

Example: `cc-clip #2848 — 7de9adb894b27c61 · 220x220 · png — Duplicate of #2846`

The remote shim can fetch the same clipboard image multiple times in rapid succession (clipboard managers, agent retries, or the agent re-checking clipboard type after reading). Each fetch fires a new notification with no suppression.

## Root Cause

Image transfer envelopes (`KindImageTransfer`) bypass the `Deduper` entirely because they have no `GenericMessage` payload — the dedup logic returns early with `return true, nil` when `msg == nil`.

## Fix

Extend `Deduper.AllowAt()` to handle image transfer envelopes using `(SessionID, Fingerprint)` as the dedup key, applying the same 12-second suppression window used for other notification types. Repeated fetches of the same image within the window are silently suppressed.

## Test plan

- [x] Updated `TestDeduperImageTransferDedup` — verifies first image passes, duplicate within window is suppressed, and same fingerprint passes again after window expires
- [x] Updated `TestDuplicateDetectionViaNotification` — integration test now expects duplicate suppression
- [x] All 142 daemon tests pass
- [x] Verified manually: notification spam stops after reinstalling and restarting the service