### PR TITLE
fix: skip N0 detection instead of fatal-exiting when remote lacks tools

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -764,7 +764,12 @@ func runConnect(opts connectOpts) {
 	fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
 	state, diag, err := shim.DetectV070State(session)
 	if err != nil {
-		log.Fatalf("      N0 detection failed: %v", err)
+		// Detection failed (e.g. minimal container missing head/readlink/grep).
+		// The v0.7.0 bug only affects existing installs — a fresh remote can't
+		// be corrupted. Warn and continue rather than blocking setup entirely.
+		fmt.Printf("      N0 detection skipped: %v\n", err)
+		state = shim.V070NotCorrupted
+		diag = "detection_skipped"
 	}
 	switch state {
 	case shim.V070NotCorrupted:

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -723,6 +723,17 @@ func cmdConnect() {
 	})
 }
 
+// decideN0SkipOnDetectError reports whether the N0 v0.7.0 gate may be safely
+// skipped after DetectV070State returned an error. Skipping is safe ONLY when
+// the remote has no existing claude install (claudeExists == false) AND that
+// fact was determined reliably (probeErr == nil): with nothing installed, a
+// v0.7.0 wrapper corruption is impossible. In every other case — claude is
+// present, or its presence could not be probed — the gate fails closed because
+// the remote cannot be proven uncorrupted.
+func decideN0SkipOnDetectError(claudeExists bool, probeErr error) bool {
+	return probeErr == nil && !claudeExists
+}
+
 func runConnect(opts connectOpts) {
 	host := opts.host
 	port := opts.port
@@ -764,12 +775,29 @@ func runConnect(opts connectOpts) {
 	fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
 	state, diag, err := shim.DetectV070State(session)
 	if err != nil {
-		// Detection failed (e.g. minimal container missing head/readlink/grep).
-		// The v0.7.0 bug only affects existing installs — a fresh remote can't
-		// be corrupted. Warn and continue rather than blocking setup entirely.
-		fmt.Printf("      N0 detection skipped: %v\n", err)
-		state = shim.V070NotCorrupted
-		diag = "detection_skipped"
+		// Detection could not run — most often coreutils missing from the
+		// non-interactive SSH PATH (DetectV070State now hardens PATH, so this is
+		// rare). Skipping the gate is safe ONLY when the remote has no existing
+		// claude install: a fresh remote cannot be in a v0.7.0 corrupted state.
+		// If claude IS present (or we cannot probe it), fail closed — we must not
+		// layer a wrapper onto a remote we cannot prove is uncorrupted.
+		exists, probeErr := shim.RemoteClaudeProbe(session)
+		if decideN0SkipOnDetectError(exists, probeErr) {
+			fmt.Fprintf(os.Stderr, "      WARN: N0 detection could not run (%v); remote has no existing claude install — continuing\n", err)
+			state = shim.V070NotCorrupted
+			diag = "detection_skipped_fresh"
+		} else {
+			fmt.Fprintf(os.Stderr, `
+error: N0 v0.7.0 detection could not run on remote (%v), and cc-clip could not
+       confirm the remote has no existing claude install, so it will not
+       continue — a present install might be in a corrupted v0.7.0 state.
+       Ensure POSIX coreutils (readlink, head, grep, wc, tr) are available on
+       the non-interactive SSH PATH, then retry:
+
+    cc-clip connect %s
+`, err, host)
+			os.Exit(3)
+		}
 	}
 	switch state {
 	case shim.V070NotCorrupted:

--- a/cmd/cc-clip/n0_test.go
+++ b/cmd/cc-clip/n0_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestDecideN0SkipOnDetectError pins the fail-closed policy: the N0 v0.7.0 gate
+// may be skipped after a detection error ONLY when the remote is provably
+// fresh (no claude install) AND the presence probe itself succeeded.
+func TestDecideN0SkipOnDetectError(t *testing.T) {
+	probeBoom := errors.New("probe failed")
+	cases := []struct {
+		name     string
+		exists   bool
+		probeErr error
+		want     bool
+	}{
+		{"fresh_no_install_skips", false, nil, true},
+		{"install_present_fails_closed", true, nil, false},
+		{"probe_error_absent_fails_closed", false, probeBoom, false},
+		{"probe_error_present_fails_closed", true, probeBoom, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decideN0SkipOnDetectError(tc.exists, tc.probeErr); got != tc.want {
+				t.Errorf("decideN0SkipOnDetectError(%v, %v) = %v, want %v", tc.exists, tc.probeErr, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -790,6 +790,12 @@ func (s V070State) String() string {
 // after C1+C2 hold do C3/C4/C5 distinguish recoverable from non-recoverable.
 func DetectV070State(s SessionExecutor) (V070State, string, error) {
 	out, err := s.Exec(`set -e
+# Non-interactive SSH often runs with a minimal PATH that omits the standard
+# coreutils locations, making readlink/head/grep/wc/tr resolve to "command not
+# found" (exit 127) even though the tools are installed. Prepend the canonical
+# bin dirs so detection works on minimal containers (e.g. Coder workspaces)
+# instead of fatally aborting connect.
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 claude="$HOME/.local/bin/claude"
 bak="$HOME/.local/bin/claude.cc-clip-bak"
 # C1: claude is a symlink.
@@ -824,6 +830,20 @@ echo recoverable`)
 	default:
 		return V070NotCorrupted, diag, fmt.Errorf("detect v0.7.0 state: unexpected diag %q", diag)
 	}
+}
+
+// RemoteClaudeProbe reports whether ~/.local/bin/claude exists on the remote
+// (as a regular file, directory, or symlink — including a broken symlink). It
+// uses only POSIX shell builtins (`[`, `echo`), so it still works when the full
+// DetectV070State detector cannot run because coreutils are absent from the
+// non-interactive PATH. It is the fail-safe classifier for the N0 gate: if no
+// claude install is present, a v0.7.0 wrapper corruption is impossible.
+func RemoteClaudeProbe(s SessionExecutor) (bool, error) {
+	out, err := s.Exec(`if [ -e "$HOME/.local/bin/claude" ] || [ -L "$HOME/.local/bin/claude" ]; then echo present; else echo absent; fi`)
+	if err != nil {
+		return false, fmt.Errorf("probe claude presence: %w", err)
+	}
+	return strings.TrimSpace(out) == "present", nil
 }
 
 // DetectV070Corruption is the boolean compat wrapper kept for RecoverV070Corruption's

--- a/internal/shim/v070_probe_test.go
+++ b/internal/shim/v070_probe_test.go
@@ -1,0 +1,76 @@
+package shim
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// probeErrExecutor is a SessionExecutor whose calls always fail. It exists
+// because errorExecutor (pathfix_test.go) implements only Exec, not the full
+// SessionExecutor interface that RemoteClaudeProbe accepts.
+type probeErrExecutor struct{ err error }
+
+func (e *probeErrExecutor) Exec(string) (string, error) { return "", e.err }
+
+func (e *probeErrExecutor) ExecWithStdin(string, io.Reader) (string, error) { return "", e.err }
+
+// TestRemoteClaudeProbe verifies the tool-free presence probe used as the
+// fail-safe classifier for the N0 gate. It must report "present" for any
+// existing claude (regular file or even a broken symlink) so a remote that
+// merely cannot run the full detector is never mistaken for a fresh one.
+func TestRemoteClaudeProbe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+
+	t.Run("absent", func(t *testing.T) {
+		home, _ := setupFakeHome(t)
+		exists, err := RemoteClaudeProbe(&localSession{home: home})
+		if err != nil {
+			t.Fatalf("probe: %v", err)
+		}
+		if exists {
+			t.Fatal("expected absent on a fresh home")
+		}
+	})
+
+	t.Run("present_regular_file", func(t *testing.T) {
+		home, _ := setupFakeHome(t)
+		bin := filepath.Join(home, ".local", "bin", "claude")
+		if err := os.WriteFile(bin, []byte("x"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		exists, err := RemoteClaudeProbe(&localSession{home: home})
+		if err != nil {
+			t.Fatalf("probe: %v", err)
+		}
+		if !exists {
+			t.Fatal("expected present for a regular claude file")
+		}
+	})
+
+	t.Run("present_broken_symlink", func(t *testing.T) {
+		home, _ := setupFakeHome(t)
+		link := filepath.Join(home, ".local", "bin", "claude")
+		if err := os.Symlink(filepath.Join(home, "does-not-exist"), link); err != nil {
+			t.Fatal(err)
+		}
+		exists, err := RemoteClaudeProbe(&localSession{home: home})
+		if err != nil {
+			t.Fatalf("probe: %v", err)
+		}
+		if !exists {
+			t.Fatal("expected present for a broken symlink (must not be treated as fresh)")
+		}
+	})
+
+	t.Run("exec_error_propagates", func(t *testing.T) {
+		if _, err := RemoteClaudeProbe(&probeErrExecutor{err: errors.New("ssh down")}); err == nil {
+			t.Fatal("expected error to propagate when Exec fails")
+		}
+	})
+}


### PR DESCRIPTION
`cc-clip setup` was failing hard at the N0 corruption-check step on Coder workspaces (and likely other minimal Docker containers) with:

N0 detection failed: detect v0.7.0 state: 
```sh
exit status 127
```

Exit 127 = command not found. The N0 detection script uses `head`, `readlink -f`, `grep`, `wc`, and `tr`; at least one of these isn't in PATH during a non-interactive SSH session on minimal images.

Root cause: `log.Fatalf` on detection failure treated a "couldn't run the check"
situation the same as "found actual corruption."

Fix: If the detection script exits non-zero, we warn the user instead of fatal exit.

This is safe because the v0.7.0 wrapper-corruption bug only affects machines that had a previous cc-clip install; a fresh remote can't be in a corrupted state.

---

Previously, i cannot setup on my coder machine because of this step. But even if this detection fails, it still works after this PR addition.