### PR TITLE
fix: v0.9.1 closing patches (update GITHUB_TOKEN auth, Codex notify reason, redeploy --all, docs)

### DIFF
--- a/cmd/cc-clip/update.go
+++ b/cmd/cc-clip/update.go
@@ -445,13 +445,39 @@ func displayVersion(v string) string {
 	return v
 }
 
-func fetchLatestReleaseTag(ctx context.Context) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", updateAPIURL+"/latest", nil)
+// newReleaseRequest builds a GET request for the GitHub releases API with the
+// standard Accept and User-Agent headers. When a GitHub token is present in the
+// environment it adds an Authorization header, lifting the unauthenticated
+// 60/hr rate limit to 5000/hr so repeated `cc-clip update` runs (common behind
+// a shared NAT) do not hit 403s. GITHUB_TOKEN takes priority over GH_TOKEN; an
+// empty/unset token leaves the request unauthenticated (unchanged behavior).
+func newReleaseRequest(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "cc-clip-updater")
+	if token := githubToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req, nil
+}
+
+// githubToken returns the GitHub API token from the environment, preferring
+// GITHUB_TOKEN over GH_TOKEN, or "" when neither is set to a non-empty value.
+func githubToken() string {
+	if t := os.Getenv("GITHUB_TOKEN"); t != "" {
+		return t
+	}
+	return os.Getenv("GH_TOKEN")
+}
+
+func fetchLatestReleaseTag(ctx context.Context) (string, error) {
+	req, err := newReleaseRequest(ctx, updateAPIURL+"/latest")
+	if err != nil {
+		return "", err
+	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", err
@@ -852,11 +878,21 @@ func printPostUpdateReminders(targetTag, binaryPath string, serviceRestarted boo
 	// never regress into silence.
 	printed := printPerHostRedeployReminders()
 	if !printed {
-		fmt.Println("* Redeploy to every remote host you use with cc-clip:")
-		fmt.Println("    cc-clip connect <host> --force")
-		fmt.Println("    cc-clip connect <host> --codex --force   # if you use Codex CLI there")
+		fallbackRedeployReminder(os.Stdout)
 	}
 
 	fmt.Println()
 	fmt.Printf("cc-clip %s installed at %s.\n", strings.TrimPrefix(targetTag, "v"), binaryPath)
+}
+
+// fallbackRedeployReminder writes the generic post-update redeploy block used
+// when the host registry is empty (fresh install, or `cc-clip update` from a
+// pre-registry build). Since v0.9.0 `--codex` is Codex-ONLY and no longer
+// installs the Claude shim, so the Codex line defaults to `--all --force` to
+// preserve the Claude shim, noting that Codex-only users can use
+// `--codex --force` instead.
+func fallbackRedeployReminder(w io.Writer) {
+	fmt.Fprintln(w, "* Redeploy to every remote host you use with cc-clip:")
+	fmt.Fprintln(w, "    cc-clip connect <host> --force")
+	fmt.Fprintln(w, "    cc-clip connect <host> --all --force   # if you use Codex CLI there (Codex-only: --codex --force)")
 }

--- a/cmd/cc-clip/update_test.go
+++ b/cmd/cc-clip/update_test.go
@@ -1,12 +1,31 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 	"time"
 )
+
+// TestFallbackRedeployReminder pins the generic redeploy block printed when the
+// host registry is empty. Since v0.9.0 `--codex` is Codex-ONLY (it no longer
+// installs the Claude shim), so the Codex line must default to `--all --force`
+// to preserve the Claude shim, with a note that Codex-only users can use
+// `--codex --force` instead.
+func TestFallbackRedeployReminder(t *testing.T) {
+	var buf bytes.Buffer
+	fallbackRedeployReminder(&buf)
+	got := buf.String()
+	want := "* Redeploy to every remote host you use with cc-clip:\n" +
+		"    cc-clip connect <host> --force\n" +
+		"    cc-clip connect <host> --all --force   # if you use Codex CLI there (Codex-only: --codex --force)\n"
+	if got != want {
+		t.Errorf("fallback reminder mismatch\ngot:\n%q\nwant:\n%q", got, want)
+	}
+}
 
 // TestReleaseArchiveName pins the exact filename the updater expects at
 // `<release>/cc-clip_<version>_<os>_<arch>.tar.gz`. If this shape ever
@@ -109,6 +128,60 @@ func TestNormalizeReleaseTag(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Errorf("normalizeReleaseTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewReleaseRequestAuth verifies that newReleaseRequest attaches an
+// Authorization header only when a GitHub token env var is present. An
+// authenticated request lifts the GitHub API rate limit from 60/hr to
+// 5000/hr, which dodges the 403s users hit when `cc-clip update` is run
+// repeatedly behind a shared NAT.
+func TestNewReleaseRequestAuth(t *testing.T) {
+	cases := []struct {
+		name        string
+		githubToken string
+		ghToken     string
+		setGithub   bool
+		setGh       bool
+		wantAuth    string // "" means the header must be absent
+	}{
+		{name: "no token unsets header", wantAuth: ""},
+		{name: "github token set", githubToken: "ght_abc", setGithub: true, wantAuth: "Bearer ght_abc"},
+		{name: "gh token set", ghToken: "gh_xyz", setGh: true, wantAuth: "Bearer gh_xyz"},
+		{name: "github token wins over gh", githubToken: "ght_abc", ghToken: "gh_xyz", setGithub: true, setGh: true, wantAuth: "Bearer ght_abc"},
+		{name: "empty github falls through to gh", githubToken: "", ghToken: "gh_xyz", setGithub: true, setGh: true, wantAuth: "Bearer gh_xyz"},
+		{name: "both empty unsets header", githubToken: "", ghToken: "", setGithub: true, setGh: true, wantAuth: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// t.Setenv restores the prior value automatically.
+			if tc.setGithub {
+				t.Setenv("GITHUB_TOKEN", tc.githubToken)
+			} else {
+				os.Unsetenv("GITHUB_TOKEN")
+			}
+			if tc.setGh {
+				t.Setenv("GH_TOKEN", tc.ghToken)
+			} else {
+				os.Unsetenv("GH_TOKEN")
+			}
+
+			req, err := newReleaseRequest(context.Background(), "https://example.test/x")
+			if err != nil {
+				t.Fatalf("newReleaseRequest error: %v", err)
+			}
+			if got := req.Header.Get("Authorization"); got != tc.wantAuth {
+				t.Errorf("Authorization = %q, want %q", got, tc.wantAuth)
+			}
+			// Unconditional headers must always be present so the seam never
+			// regresses the existing request shape.
+			if got := req.Header.Get("Accept"); got != "application/vnd.github+json" {
+				t.Errorf("Accept = %q, want application/vnd.github+json", got)
+			}
+			if got := req.Header.Get("User-Agent"); got != "cc-clip-updater" {
+				t.Errorf("User-Agent = %q, want cc-clip-updater", got)
 			}
 		})
 	}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -155,6 +155,29 @@ Verify with `which xclip` — it should point to `~/.local/bin/xclip`.
 - **Screenshot to clipboard:** `Cmd + Shift + Ctrl + 4` (select area) or `Cmd + Shift + Ctrl + 3` (full screen)
 - **Copy from an app:** Right-click an image → Copy Image
 
+## Clipboard-History Manager "Paste" Button Bypasses cc-clip
+
+**Symptom:** You copied an image, but pasting it into remote Claude Code / Codex
+via a clipboard-history manager's **"Paste to <terminal>"** button inserts the
+image's file *path* as text instead of the image. cc-clip never seems to fire.
+
+**Cause:** This is a usage gotcha, not a cc-clip failure. Clipboard-history
+managers (Raycast, Maccy, Paste) "Paste to <app>" buttons inject the file path as
+text — they do **not** trigger the agent's own clipboard read. cc-clip only
+serves the clipboard when the agent itself reads it, via the xclip shim (Claude
+Code) or arboard (Codex). A manager that types a path on your behalf goes around
+that read entirely.
+
+**Fix:** Paste with the **agent's own `Ctrl+V`**, after copying the image as
+**raw image data** (not a file reference):
+
+- Take a fresh screenshot to the clipboard (`Cmd + Shift + Ctrl + 4` /
+  `Cmd + Shift + Ctrl + 3`), or right-click an image → **Copy Image**.
+- In the remote Claude Code / Codex session, press `Ctrl+V` directly.
+
+Do **not** use the clipboard manager's paste button for images — it never hands
+the raw image to the agent, so cc-clip is never asked for it.
+
 ## Setup Fails: "killed" During Re-Deployment
 
 **Symptom:** `cc-clip setup` was working before, but now shows `zsh: killed` when re-running.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -55,6 +55,27 @@ upgrade an existing host:
 - **New targets:** `--opencode`, `--agy` (Antigravity), and an explicit
   `--claude`. `--all` selects every target.
 
+### Coming from a v0.9.0 beta?
+
+If you opted into a `v0.9.0-beta.x` prerelease, moving to stable `v0.9.0` is a
+non-event: stable v0.9.0 ships the **same feature set** as the beta prereleases.
+There is no beta-to-stable breaking change.
+
+- **`cc-clip update` moves you to v0.9.0.** The updater compares your installed
+  tag against the latest stable release. A `v0.9.0-beta.x` tag is *not* equal to
+  `v0.9.0`, so `cc-clip update` treats stable v0.9.0 as newer and upgrades.
+- **If you pinned the beta, drop the pin.** If you installed with
+  `CC_CLIP_VERSION=v0.9.0-beta.x`, run the next install/update without that env
+  var so you track the latest stable `v*` tag again.
+- **If `cc-clip update` hits a GitHub API rate limit**, use the pinned install
+  one-liner instead (it goes through the install script, which does not need the
+  `/releases/latest` API call):
+
+    ```sh
+    curl -fsSL https://raw.githubusercontent.com/ShunmeiCho/cc-clip/main/scripts/install.sh \
+      | CC_CLIP_VERSION=v0.9.0 sh
+    ```
+
 Otherwise the upgrade is the normal forward path below: update the local binary,
 then redeploy each remote with `--force`. Downgrading back across the v0.9.0
 boundary is **not lossless** — see
@@ -108,7 +129,7 @@ Pick the archive matching your OS and arch from
 <https://github.com/ShunmeiCho/cc-clip/releases/latest>, then:
 
 ```sh
-V=0.6.1   # latest version without the v prefix
+V=0.9.0   # latest version without the v prefix
 OS=darwin         # or linux
 ARCH=arm64        # or amd64
 

--- a/internal/hosts/registry.go
+++ b/internal/hosts/registry.go
@@ -219,11 +219,17 @@ func (r *Registry) FormatRedeployReminder(w io.Writer) bool {
 	}
 	fmt.Fprintln(w, "* Redeploy to every remote host you use with cc-clip:")
 	for _, e := range entries {
-		flags := "--force"
+		// Since v0.9.0, `--codex` is Codex-ONLY and no longer reinstalls the
+		// Claude shim. The registry only records a single Codex bool, so it
+		// cannot tell a Codex-only host from a Claude+Codex host. We default
+		// to `--all --force` (deploys both Claude and Codex) so the Claude
+		// shim is never silently dropped, and note that Codex-only users can
+		// use `--codex --force` instead.
 		if e.Codex {
-			flags = "--codex --force"
+			fmt.Fprintf(w, "    cc-clip connect %s --all --force   # Codex-only users: --codex --force\n", e.Host)
+			continue
 		}
-		fmt.Fprintf(w, "    cc-clip connect %s %s\n", e.Host, flags)
+		fmt.Fprintf(w, "    cc-clip connect %s --force\n", e.Host)
 	}
 	return true
 }

--- a/internal/hosts/registry_test.go
+++ b/internal/hosts/registry_test.go
@@ -221,8 +221,12 @@ func TestFormatRedeployReminderMixed(t *testing.T) {
 		t.Fatal("non-empty registry returned false")
 	}
 	got := buf.String()
+	// A Codex host gets `--all --force` (preserves the Claude shim, since the
+	// registry cannot tell Codex-only from Claude+Codex), with a note that
+	// Codex-only users can use `--codex --force` instead. Non-Codex hosts keep
+	// the plain `--force`.
 	want := "* Redeploy to every remote host you use with cc-clip:\n" +
-		"    cc-clip connect alpha --codex --force\n" +
+		"    cc-clip connect alpha --all --force   # Codex-only users: --codex --force\n" +
 		"    cc-clip connect mid --force\n" +
 		"    cc-clip connect zeta --force\n"
 	if got != want {

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -505,7 +505,9 @@ if printf '%%s\n' "$stripped" | awk '
   in_section == 0 && /^[[:space:]]*(notify|"notify"|'"'"'notify'"'"')[[:space:]]*=/ { found = 1 }
   END { exit !found }
 '; then
-  echo "existing top-level notify setting found in $config -- refusing to inject duplicate. Remove or comment out the top-level notify line first ([agents.X].notify is fine)" >&2
+  # Fold the refusal reason to stdout (2>&1) so it survives RemoteExecutor.Exec,
+  # which captures only stdout. Without this the caller sees a bare "exit status 7".
+  { echo "existing top-level notify setting found in $config -- refusing to inject duplicate. Remove or comment out the top-level notify line first ([agents.X].notify is fine)" >&2; } 2>&1
   exit 7
 fi
 
@@ -529,7 +531,10 @@ mv "$tmp" "$config"
 trap - EXIT
 `, sedEscape(markerStart), sedEscape(markerEnd), managedBlock)
 
-	if _, err := session.Exec(script); err != nil {
+	if out, err := session.Exec(script); err != nil {
+		if reason := strings.TrimSpace(out); reason != "" {
+			return fmt.Errorf("failed to inject notify config into ~/.codex/config.toml: %s: %w", reason, err)
+		}
 		return fmt.Errorf("failed to inject notify config into ~/.codex/config.toml: %w", err)
 	}
 

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -446,8 +446,16 @@ func TestEnsureRemoteCodexNotifyConfigRefusesUserNotify(t *testing.T) {
 	s := &localSession{home: t.TempDir()}
 	writeTestCodexConfig(t, s.home, `notify = ["custom", "notify"]`)
 
-	if err := EnsureRemoteCodexNotifyConfig(s, 18339); err == nil {
+	err := EnsureRemoteCodexNotifyConfig(s, 18339)
+	if err == nil {
 		t.Fatal("EnsureRemoteCodexNotifyConfig should refuse an existing user notify setting")
+	}
+	// The refusal reason is written to the injection script's stderr then
+	// exit 7. RemoteExecutor.Exec captures only stdout, so the reason must be
+	// folded to stdout (2>&1) on the refusal path and surfaced in the wrapped
+	// error. Otherwise the user sees only an opaque "exit status 7".
+	if !strings.Contains(err.Error(), "existing top-level notify setting found") {
+		t.Fatalf("error must carry the refusal reason, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Brings the remaining v0.9.1 fixes into main ahead of the v0.9.1 release. fix(update): authenticate GET /releases/latest with GITHUB_TOKEN/GH_TOKEN to avoid 403 rate-limit failures on 'cc-clip update --check'; redeploy reminder now defaults to --all. fix(shim): surface the Codex notify config refusal reason instead of a bare exit status 7. docs: v0.9.0 beta-to-stable upgrade note, clipboard-manager troubleshooting, refresh stale example. Merges cleanly onto current main (no conflicts with #100/#101/#102); CI validates the merged result.