### PR TITLE
fix: centralize remote PATH hardening in WrapRemoteShell (post-#101 /simplify)

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -775,18 +775,11 @@ func runConnect(opts connectOpts) {
 	fmt.Println("[N0] Checking for v0.7.0 wrapper corruption...")
 	state, diag, err := shim.DetectV070State(session)
 	if err != nil {
-		// Detection could not run — most often coreutils missing from the
-		// non-interactive SSH PATH (DetectV070State now hardens PATH, so this is
-		// rare). Skipping the gate is safe ONLY when the remote has no existing
-		// claude install: a fresh remote cannot be in a v0.7.0 corrupted state.
-		// If claude IS present (or we cannot probe it), fail closed — we must not
-		// layer a wrapper onto a remote we cannot prove is uncorrupted.
+		// Detection could not run (rare; WrapRemoteShell hardens PATH). Skip only
+		// when decideN0SkipOnDetectError proves the remote is fresh; otherwise
+		// fail closed rather than guess. See that helper for the policy rationale.
 		exists, probeErr := shim.RemoteClaudeProbe(session)
-		if decideN0SkipOnDetectError(exists, probeErr) {
-			fmt.Fprintf(os.Stderr, "      WARN: N0 detection could not run (%v); remote has no existing claude install — continuing\n", err)
-			state = shim.V070NotCorrupted
-			diag = "detection_skipped_fresh"
-		} else {
+		if !decideN0SkipOnDetectError(exists, probeErr) {
 			fmt.Fprintf(os.Stderr, `
 error: N0 v0.7.0 detection could not run on remote (%v), and cc-clip could not
        confirm the remote has no existing claude install, so it will not
@@ -798,6 +791,9 @@ error: N0 v0.7.0 detection could not run on remote (%v), and cc-clip could not
 `, err, host)
 			os.Exit(3)
 		}
+		fmt.Fprintf(os.Stderr, "      WARN: N0 detection could not run (%v); remote has no existing claude install — continuing\n", err)
+		state = shim.V070NotCorrupted
+		diag = "detection_skipped_fresh"
 	}
 	switch state {
 	case shim.V070NotCorrupted:

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -130,9 +130,20 @@ func sshHostArgs(prefix []string, host string, remoteArgs ...string) []string {
 // any other) login shell. The single-quote escaping in shSingleQuote is
 // interpreted identically by POSIX shells and fish, so the wrapper line itself
 // parses correctly no matter which shell sshd invokes.
+//
+// It also prepends remotePathPrelude so every remote command finds coreutils
+// under a minimal non-interactive PATH (another exit-127 source).
 func WrapRemoteShell(cmd string) string {
-	return "/bin/sh -c " + shSingleQuote(cmd)
+	return "/bin/sh -c " + shSingleQuote(remotePathPrelude+cmd)
 }
+
+// remotePathPrelude prepends the canonical system bin directories to PATH for
+// every remote command. Non-interactive SSH often runs with a minimal PATH that
+// omits these dirs, so coreutils (readlink, head, grep, wc, tr, ...) resolve to
+// "command not found" (exit 127) even when installed — which previously aborted
+// connect on minimal images (e.g. Coder workspaces). $PATH stays last so the
+// remote's own entries and their relative order are preserved.
+const remotePathPrelude = "export PATH=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH\"\n"
 
 // shSingleQuote renders s as a single single-quoted shell token, escaping any
 // embedded single quote via the portable '\'' close-escape-reopen idiom.
@@ -790,12 +801,6 @@ func (s V070State) String() string {
 // after C1+C2 hold do C3/C4/C5 distinguish recoverable from non-recoverable.
 func DetectV070State(s SessionExecutor) (V070State, string, error) {
 	out, err := s.Exec(`set -e
-# Non-interactive SSH often runs with a minimal PATH that omits the standard
-# coreutils locations, making readlink/head/grep/wc/tr resolve to "command not
-# found" (exit 127) even though the tools are installed. Prepend the canonical
-# bin dirs so detection works on minimal containers (e.g. Coder workspaces)
-# instead of fatally aborting connect.
-export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:$PATH"
 claude="$HOME/.local/bin/claude"
 bak="$HOME/.local/bin/claude.cc-clip-bak"
 # C1: claude is a symlink.

--- a/internal/shim/ssh_test.go
+++ b/internal/shim/ssh_test.go
@@ -173,19 +173,20 @@ func TestWrapRemoteShell(t *testing.T) {
 		{
 			name: "simple command",
 			cmd:  "uname -sm",
-			want: `/bin/sh -c 'uname -sm'`,
+			want: "/bin/sh -c '" + remotePathPrelude + "uname -sm'",
 		},
 		{
 			name: "embedded single quotes use close-escape-reopen idiom",
 			cmd:  "echo 'hi'",
-			want: `/bin/sh -c 'echo '\''hi'\'''`,
+			want: "/bin/sh -c '" + remotePathPrelude + `echo '\''hi'\'''`,
 		},
 		{
 			// sh syntax that a fish login shell mis-parses (exit 127) must end up
 			// fully inside the single-quoted token, never bare on the command line.
+			// The PATH prelude is part of the same single-quoted token.
 			name: "posix sh script is fully quoted",
 			cmd:  "set -e\n[ -L \"$HOME/x\" ] || exit 0",
-			want: "/bin/sh -c 'set -e\n[ -L \"$HOME/x\" ] || exit 0'",
+			want: "/bin/sh -c '" + remotePathPrelude + "set -e\n[ -L \"$HOME/x\" ] || exit 0'",
 		},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Follow-up to #101 from a /simplify altitude review. Moves the coreutils PATH prelude from the single DetectV070State script into WrapRemoteShell, the shared chokepoint every remote shell command passes through. Without this, connect on a minimal non-interactive PATH (e.g. Coder workspaces) survived N0 but still aborted with exit 127 on the next coreutils-dependent script (classifyClaudeBin, RecoverV070Corruption, xvfb, ...). Now all remote commands resolve readlink/head/grep/wc/tr. Safe: the only PATH-ordering-dependent check (CheckPathPriority) runs locally, not over SSH, and the prelude keeps the remote's own PATH last. Also flattens the N0 detection-error branch to a guard clause and trims a duplicated rationale comment. TestWrapRemoteShell updated; full internal/shim suite + build/vet green locally.