### PR TITLE
chore(release): group changelog into Features/Fixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,15 @@ release:
 
 changelog:
   sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
   filters:
     exclude:
       - "^docs:"


### PR DESCRIPTION
Auto-generated release notes (e.g. v0.9.1) were a flat commit list with raw hashes. This adds changelog.groups to .goreleaser.yaml so future releases render grouped Features / Fixes / Others sections automatically. Validated locally with goreleaser check. Only affects future tag releases; no code or runtime change.