### PR TITLE
feat: support package-managed remote binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ run that command manually, then repeat setup.
 The Claude and opencode paths use the remote `xclip` or `wl-paste` shim. Codex
 reads X11 directly, so its target adds Xvfb and `cc-clip x11-bridge` instead.
 
+If a package manager already owns `cc-clip` on the remote, preserve that
+ownership with `cc-clip setup myserver --use-remote-bin`. Setup resolves
+`cc-clip` from the remote PATH, records its version and hash, and performs the
+normal integration setup without uploading a replacement binary. The flag
+cannot be combined with `--local-bin`.
+
 > opencode and Antigravity integration generation is covered by tests, but host
 > event delivery has not yet been smoke-tested on a representative machine.
 > Please [report what you find](https://github.com/ShunmeiCho/cc-clip/issues).
@@ -176,6 +182,7 @@ before using cc-clip on a shared or untrusted host.
 | Command | Use it for |
 |---|---|
 | `cc-clip setup HOST [target]` | First-time dependencies, SSH config, daemon, and deploy |
+| `cc-clip setup HOST --use-remote-bin` | Configure a host whose remote binary is package-managed |
 | `cc-clip connect HOST --force [target]` | Repair or fully redeploy a host |
 | `cc-clip connect HOST --token-only` | Sync a rotated or expired token |
 | `cc-clip doctor --host HOST` | End-to-end diagnosis |

--- a/README.md
+++ b/README.md
@@ -101,9 +101,15 @@ reads X11 directly, so its target adds Xvfb and `cc-clip x11-bridge` instead.
 
 If a package manager already owns `cc-clip` on the remote, preserve that
 ownership with `cc-clip setup myserver --use-remote-bin`. Setup resolves
-`cc-clip` from the remote PATH, records its version and hash, and performs the
-normal integration setup without uploading a replacement binary. The flag
-cannot be combined with `--local-bin`.
+`cc-clip` under your remote **login shell's** PATH (so `~/.nix-profile/bin`,
+pipx and asdf installs are found), records its version and hash, and performs
+the normal integration setup without uploading a replacement binary.
+
+The mode is remembered in the host's deploy state: later `cc-clip connect`
+runs — including the `connect <host> --force` line that `cc-clip update`
+suggests — keep using the package-managed binary without needing the flag
+again. Deploy with `--local-bin` to switch the host back to uploaded
+binaries. The flag cannot be combined with `--local-bin` in the same run.
 
 > opencode and Antigravity integration generation is covered by tests, but host
 > event delivery has not yet been smoke-tested on a representative machine.

--- a/cmd/cc-clip/cli_flag_test.go
+++ b/cmd/cc-clip/cli_flag_test.go
@@ -37,6 +37,16 @@ func TestCLIMutex(t *testing.T) {
 			args:    []string{"connect", "fakehost.invalid", "--token-only", "--hooks"},
 			wantErr: "--no-hooks/--hooks cannot be combined with --token-only",
 		},
+		{
+			name:    "connect_remote_bin_with_local_bin",
+			args:    []string{"connect", "fakehost.invalid", "--use-remote-bin", "--local-bin", "/tmp/cc-clip"},
+			wantErr: "--use-remote-bin cannot be combined with --local-bin",
+		},
+		{
+			name:    "setup_remote_bin_with_local_bin",
+			args:    []string{"setup", "fakehost.invalid", "--use-remote-bin", "--local-bin", "/tmp/cc-clip"},
+			wantErr: "--use-remote-bin cannot be combined with --local-bin",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -933,7 +933,7 @@ remote has a valid claude binary installed.
 		// Codex flag is sticky in the registry, so passing codexTargeted here
 		// (false for a plain --token-only run that resolves to {Claude}) won't
 		// downgrade a previously recorded Codex=true entry.
-		recordHostConnect(host, registryVersionOrEmpty(), codexTargeted(opts.targets))
+		recordHostConnect(host, deployedRegistryVersion(existingRemoteBin), codexTargeted(opts.targets))
 		return
 	}
 
@@ -948,6 +948,11 @@ remote has a valid claude binary installed.
 			log.Fatalf("      failed to read remote state: %v\n      Re-run with --force only if you intend to ignore deploy.json.", err)
 		}
 	}
+	// Captured before --force nulls remoteState below: package-managed mode
+	// adoption and the bridge-restart hash comparison both need the state as
+	// it was actually read — under --force especially, since `cc-clip update`
+	// prints `connect <host> --force` as its redeploy reminder.
+	priorState := remoteState
 	// Forward downgrade guard: if the remote was deployed by a newer cc-clip
 	// (deploy-state schema > this binary's), refuse to overwrite it unless the
 	// operator explicitly passes --force. Runs before any deploy-state or
@@ -968,6 +973,18 @@ remote has a valid claude binary installed.
 		remoteState = nil
 	} else {
 		fmt.Println("      no previous deploy state")
+	}
+
+	// A host recorded as package-managed keeps that mode when the flag is
+	// omitted; --local-bin is the explicit way back to uploaded deploys.
+	if shouldAdoptRemoteBinMode(opts.useRemoteBin, getFlag("local-bin", ""), priorState) {
+		fmt.Println("      deploy state records this host as package-managed; keeping the remote binary")
+		fmt.Println("      (pass --local-bin to switch back to uploaded deploys)")
+		existingRemoteBin, err = shim.InspectRemoteBinary(session)
+		if err != nil {
+			log.Fatalf("      failed to resolve remote binary: %v", err)
+		}
+		remoteBin = existingRemoteBin.Command()
 	}
 
 	// Step 4: Prepare and upload binary (skip if hash matches)
@@ -1129,6 +1146,10 @@ remote has a valid claude binary installed.
 			log.Fatalf("      failed to prepare remote deploy state: %v", err)
 		}
 	}
+	// Record the binary-ownership mode so the next flag-less connect (notably
+	// the update reminder's `connect <host> --force`) keeps it. An explicit
+	// --local-bin deploy lands in the upload arm and clears it.
+	newState.UseRemoteBin = existingRemoteBin != nil
 	if err := shim.WriteRemoteState(session, newState); err != nil {
 		log.Printf("      warning: could not write remote deploy state: %v", err)
 	}
@@ -1144,9 +1165,12 @@ remote has a valid claude binary installed.
 		}
 	}
 
-	// Steps 8-11: Codex support (only if Codex is among the resolved targets)
+	// Steps 8-11: Codex support (only if Codex is among the resolved targets).
+	// On the remote-bin path needsUpload is permanently false, so the bridge
+	// restart decision also compares the remote executable's hash against the
+	// prior state — a package-manager upgrade must restart the bridge.
 	if codexTargeted(opts.targets) {
-		codexOk := runConnectCodex(session, opts, needsUpload, newState, remoteBin)
+		codexOk := runConnectCodex(session, opts, needsUpload || remoteBinChanged(existingRemoteBin, priorState), newState, remoteBin)
 		if err := shim.WriteRemoteState(session, newState); err != nil {
 			log.Printf("      warning: could not update deploy state: %v", err)
 		}
@@ -1170,7 +1194,19 @@ remote has a valid claude binary installed.
 	// (any error above exits via log.Fatal / os.Exit). Codex flag is sticky
 	// inside the registry, so a plain connect won't downgrade a previously
 	// recorded Codex=true.
-	recordHostConnect(host, registryVersionOrEmpty(), codexTargeted(opts.targets))
+	recordHostConnect(host, deployedRegistryVersion(existingRemoteBin), codexTargeted(opts.targets))
+}
+
+// deployedRegistryVersion returns the version to record for a host: the REMOTE
+// executable's version when the host is package-managed, the local binary's
+// otherwise. Recording the local version for a remote-bin host made
+// `hosts list` show whatever this machine happened to build (and suppressed
+// the redeploy reminder), while deploy.json said something else.
+func deployedRegistryVersion(existingRemoteBin *shim.RemoteBinaryInfo) string {
+	if existingRemoteBin != nil {
+		return normalizeVersion(existingRemoteBin.Version)
+	}
+	return registryVersionOrEmpty()
 }
 
 func newDeployState(localBin, binaryVersion, shimTarget string, pathFixed bool, remoteState *shim.DeployState, targets DeployTargets) (*shim.DeployState, error) {
@@ -2242,7 +2278,7 @@ const codexStateDir = "~/.cache/cc-clip/codex"
 
 // runConnectCodex executes steps 8-11 of the Codex deploy flow.
 // Returns true on success, false on failure (Claude path is preserved).
-func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded bool, state *shim.DeployState, remoteBin string) bool {
+func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryChanged bool, state *shim.DeployState, remoteBin string) bool {
 	port := opts.port
 
 	if opts.tokenOnly {
@@ -2296,8 +2332,9 @@ func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded 
 	// Step 10: Start or reuse x11-bridge
 	fmt.Println("[10/11] Starting x11-bridge...")
 
-	// Unconditionally restart bridge if binary was uploaded or --force was used.
-	needsBridgeRestart := binaryUploaded || opts.force
+	// Unconditionally restart the bridge when the binary changed (uploaded, or
+	// a package-managed remote binary's hash moved) or --force was used.
+	needsBridgeRestart := binaryChanged || opts.force
 	if needsBridgeRestart {
 		stopBridgeRemote(session)
 	}

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -132,6 +132,7 @@ One-command setup:
   setup <host>       Full setup: deps, SSH config, daemon, deploy
     --port           Tunnel port (default: 18339)
     --claude/--codex/--opencode/--agy/--all   Deployment target (see "Deployment targets" below)
+    --use-remote-bin Use cc-clip from the remote PATH; skip binary upload
     --auto-recover   Recover from v0.7.0 wrapper corruption (mutex with --token-only)
 
 Known hosts (per-user registry):
@@ -149,6 +150,7 @@ Deploy (local -> remote):
   connect <host>     Deploy cc-clip to remote and establish session
     --port           Tunnel port (default: 18339)
     --local-bin      Path to pre-downloaded remote binary
+    --use-remote-bin Use cc-clip from the remote PATH; skip binary upload
     --force          Ignore remote state, full redeploy
     --token-only     Only sync token, skip binary/shim deploy
     --no-hooks       Persistently disable Claude Code hook injection (Claude target only)
@@ -625,15 +627,16 @@ func cmdUninstallCodexLocal() {
 }
 
 type connectOpts struct {
-	host        string
-	port        int
-	force       bool
-	tokenOnly   bool
-	targets     DeployTargets // resolved deployment target set (parse + TTY menu); codex/claude/shim phases gate on its membership
-	noNotify    bool
-	noHooks     bool
-	hooks       bool
-	autoRecover bool
+	host         string
+	port         int
+	force        bool
+	tokenOnly    bool
+	useRemoteBin bool
+	targets      DeployTargets // resolved deployment target set (parse + TTY menu); codex/claude/shim phases gate on its membership
+	noNotify     bool
+	noHooks      bool
+	hooks        bool
+	autoRecover  bool
 }
 
 // rejectAutoRecoverWithTokenOnly enforces the spec-mandated mutual
@@ -672,16 +675,27 @@ func rejectHookControlWithTokenOnly(noHooks, hooks, tokenOnly bool) {
 	}
 }
 
+func rejectRemoteBinWithLocalBin(useRemoteBin bool, localBin string) {
+	if !useRemoteBin || localBin == "" {
+		return
+	}
+	fmt.Fprintln(os.Stderr, `error: --use-remote-bin cannot be combined with --local-bin
+       --use-remote-bin uses the cc-clip executable already on the remote PATH,
+       while --local-bin selects a local executable to upload.`)
+	os.Exit(2)
+}
+
 func cmdConnect() {
 	if len(os.Args) < 3 {
-		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify] [--no-hooks|--hooks]")
+		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--use-remote-bin] [--no-notify] [--no-hooks|--hooks]")
 	}
 	host, err := hostFromArgs(os.Args[2:])
 	if err != nil {
-		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--no-notify] [--no-hooks|--hooks]")
+		log.Fatal("usage: cc-clip connect <host> [--port PORT] [--force] [--token-only] [--use-remote-bin] [--no-notify] [--no-hooks|--hooks]")
 	}
 	autoRecover := hasFlag("auto-recover")
 	tokenOnly := hasFlag("token-only")
+	useRemoteBin := hasFlag("use-remote-bin")
 	noHooks := hasFlag("no-hooks")
 	hooks := hasFlag("hooks")
 	if noHooks && hooks {
@@ -689,6 +703,7 @@ func cmdConnect() {
 	}
 	rejectAutoRecoverWithTokenOnly("connect", autoRecover, tokenOnly)
 	rejectHookControlWithTokenOnly(noHooks, hooks, tokenOnly)
+	rejectRemoteBinWithLocalBin(useRemoteBin, getFlag("local-bin", ""))
 
 	// Resolve deployment targets BEFORE any SSH/daemon activity so the
 	// interactive menu (design §5) precedes the passphrase prompt. A multi-
@@ -711,15 +726,16 @@ func cmdConnect() {
 	maybeLegacyCodexNotice(os.Stderr, os.Args[2:], targets)
 
 	runConnect(connectOpts{
-		host:        host,
-		port:        getPort(),
-		force:       hasFlag("force"),
-		tokenOnly:   tokenOnly,
-		targets:     targets,
-		noNotify:    hasFlag("no-notify"),
-		noHooks:     noHooks,
-		hooks:       hooks,
-		autoRecover: autoRecover,
+		host:         host,
+		port:         getPort(),
+		force:        hasFlag("force"),
+		tokenOnly:    tokenOnly,
+		useRemoteBin: useRemoteBin,
+		targets:      targets,
+		noNotify:     hasFlag("no-notify"),
+		noHooks:      noHooks,
+		hooks:        hooks,
+		autoRecover:  autoRecover,
 	})
 }
 
@@ -850,10 +866,38 @@ remote has a valid claude binary installed.
 		os.Exit(3)
 	}
 
+	remoteBin := "~/.local/bin/cc-clip"
+	var existingRemoteBin *shim.RemoteBinaryInfo
+	if opts.useRemoteBin {
+		existingRemoteBin, err = shim.InspectRemoteBinary(session)
+		if err != nil {
+			log.Fatalf("      failed to resolve remote binary: %v", err)
+		}
+		remoteBin = existingRemoteBin.Command()
+		localVersion := normalizeVersion(version)
+		remoteVersion := normalizeVersion(existingRemoteBin.Version)
+		if localVersion != "" && remoteVersion != "" && localVersion != remoteVersion {
+			log.Printf(
+				"      warning: local version is %s, remote version is %s; continuing with the remote binary",
+				localVersion,
+				remoteVersion,
+			)
+		}
+	}
+
 	// --token-only: skip binary/shim, just sync token and verify tunnel
 	if tokenOnly {
-		fmt.Println("[3/7] Skipping binary check (--token-only)")
-		fmt.Println("[4/7] Skipping binary upload (--token-only)")
+		if existingRemoteBin != nil {
+			fmt.Printf(
+				"[3/7] Using remote binary %s (%s)\n",
+				existingRemoteBin.Path,
+				existingRemoteBin.Version,
+			)
+			fmt.Println("[4/7] Skipping binary upload (--use-remote-bin)")
+		} else {
+			fmt.Println("[3/7] Skipping binary check (--token-only)")
+			fmt.Println("[4/7] Skipping binary upload (--token-only)")
+		}
 		fmt.Println("[5/7] Skipping shim install (--token-only)")
 
 		fmt.Printf("[6/7] Syncing token and session...\n")
@@ -882,7 +926,7 @@ remote has a valid claude binary installed.
 			}
 		}
 
-		connectVerifyTunnel(session, port, host, opts.targets)
+		connectVerifyTunnel(session, port, host, opts.targets, remoteBin)
 
 		// Record this host even on the --token-only path so `hosts list` and
 		// per-host update reminders reflect the most recent successful sync.
@@ -926,42 +970,51 @@ remote has a valid claude binary installed.
 		fmt.Println("      no previous deploy state")
 	}
 
-	remoteOS, remoteArch, err := shim.DetectRemoteArchViaSession(session)
-	if err != nil {
-		log.Fatalf("      failed to detect remote arch: %v", err)
-	}
-	fmt.Printf("      %s/%s\n", remoteOS, remoteArch)
-
-	remoteBin := "~/.local/bin/cc-clip"
-
 	// Step 4: Prepare and upload binary (skip if hash matches)
-	localBin, err := prepareBinaryLocal(host, remoteOS, remoteArch)
-	if err != nil {
-		log.Fatalf("[4/7] Prepare binary failed: %v", err)
-	}
-
-	needsUpload := force || shim.NeedsUpload(localBin, remoteState)
-	if !needsUpload {
-		// Verify the remote binary actually exists — deploy state can be stale.
-		if _, err := session.Exec(fmt.Sprintf("test -x %s", remoteBin)); err != nil {
-			fmt.Println("[4/7] Remote binary missing despite cached state, re-uploading")
-			needsUpload = true
-		}
-	}
-	if needsUpload {
-		fmt.Printf("[4/7] Uploading cc-clip binary...\n")
-		// Stop bridge if running — it holds the binary open, preventing overwrite.
-		stopBridgeRemote(session)
-		// Ensure remote directory exists
-		if _, err := session.Exec("mkdir -p ~/.local/bin"); err != nil {
-			log.Fatalf("      failed to create remote binary directory: %v", err)
-		}
-		if err := shim.UploadBinaryViaSession(session, localBin, remoteBin); err != nil {
-			log.Fatalf("      failed: %v", err)
-		}
-		fmt.Printf("      uploaded to %s\n", remoteBin)
+	var localBin string
+	var needsUpload bool
+	if existingRemoteBin != nil {
+		fmt.Printf(
+			"      remote binary: %s (%s)\n",
+			existingRemoteBin.Path,
+			existingRemoteBin.Version,
+		)
+		fmt.Println("[4/7] Using existing remote binary, skipping upload")
 	} else {
-		fmt.Println("[4/7] Binary up to date, skipping upload")
+		remoteOS, remoteArch, err := shim.DetectRemoteArchViaSession(session)
+		if err != nil {
+			log.Fatalf("      failed to detect remote arch: %v", err)
+		}
+		fmt.Printf("      %s/%s\n", remoteOS, remoteArch)
+
+		localBin, err = prepareBinaryLocal(host, remoteOS, remoteArch)
+		if err != nil {
+			log.Fatalf("[4/7] Prepare binary failed: %v", err)
+		}
+
+		needsUpload = force || shim.NeedsUpload(localBin, remoteState)
+		if !needsUpload {
+			// Verify the remote binary actually exists — deploy state can be stale.
+			if _, err := session.Exec(fmt.Sprintf("test -x %s", remoteBin)); err != nil {
+				fmt.Println("[4/7] Remote binary missing despite cached state, re-uploading")
+				needsUpload = true
+			}
+		}
+		if needsUpload {
+			fmt.Printf("[4/7] Uploading cc-clip binary...\n")
+			// Stop bridge if running — it holds the binary open, preventing overwrite.
+			stopBridgeRemote(session)
+			// Ensure remote directory exists
+			if _, err := session.Exec("mkdir -p ~/.local/bin"); err != nil {
+				log.Fatalf("      failed to create remote binary directory: %v", err)
+			}
+			if err := shim.UploadBinaryViaSession(session, localBin, remoteBin); err != nil {
+				log.Fatalf("      failed: %v", err)
+			}
+			fmt.Printf("      uploaded to %s\n", remoteBin)
+		} else {
+			fmt.Println("[4/7] Binary up to date, skipping upload")
+		}
 	}
 
 	// Step 5: Install shim — only for targets that use the clipboard shim
@@ -1053,16 +1106,35 @@ remote has a valid claude binary installed.
 	} else if remoteState != nil && remoteState.ShimTarget != "" {
 		shimTarget = remoteState.ShimTarget
 	}
-	newState, err := newDeployState(localBin, version, shimTarget, pathFixed, remoteState, opts.targets)
-	if err != nil {
-		log.Fatalf("      failed to prepare remote deploy state: %v", err)
+	var newState *shim.DeployState
+	if existingRemoteBin != nil {
+		newState = newDeployStateFromBinary(
+			existingRemoteBin.Hash,
+			existingRemoteBin.Version,
+			shimTarget,
+			pathFixed,
+			remoteState,
+			opts.targets,
+		)
+	} else {
+		newState, err = newDeployState(
+			localBin,
+			version,
+			shimTarget,
+			pathFixed,
+			remoteState,
+			opts.targets,
+		)
+		if err != nil {
+			log.Fatalf("      failed to prepare remote deploy state: %v", err)
+		}
 	}
 	if err := shim.WriteRemoteState(session, newState); err != nil {
 		log.Printf("      warning: could not write remote deploy state: %v", err)
 	}
 
 	// Step 7: Verify tunnel
-	connectVerifyTunnel(session, port, host, opts.targets)
+	connectVerifyTunnel(session, port, host, opts.targets, remoteBin)
 
 	// Notification bridge setup (unless --no-notify)
 	if !opts.noNotify {
@@ -1074,7 +1146,7 @@ remote has a valid claude binary installed.
 
 	// Steps 8-11: Codex support (only if Codex is among the resolved targets)
 	if codexTargeted(opts.targets) {
-		codexOk := runConnectCodex(session, opts, needsUpload, newState)
+		codexOk := runConnectCodex(session, opts, needsUpload, newState, remoteBin)
 		if err := shim.WriteRemoteState(session, newState); err != nil {
 			log.Printf("      warning: could not update deploy state: %v", err)
 		}
@@ -1107,8 +1179,19 @@ func newDeployState(localBin, binaryVersion, shimTarget string, pathFixed bool, 
 		return nil, err
 	}
 
+	return newDeployStateFromBinary(
+		localHash,
+		binaryVersion,
+		shimTarget,
+		pathFixed,
+		remoteState,
+		targets,
+	), nil
+}
+
+func newDeployStateFromBinary(binaryHash, binaryVersion, shimTarget string, pathFixed bool, remoteState *shim.DeployState, targets DeployTargets) *shim.DeployState {
 	state := &shim.DeployState{
-		BinaryHash:    localHash,
+		BinaryHash:    binaryHash,
 		BinaryVersion: binaryVersion,
 		// Only claim a shim when this run targeted it (Claude/opencode). A
 		// shim-less target (pure --codex/--agy) preserves any prior shim below
@@ -1133,7 +1216,7 @@ func newDeployState(localBin, binaryVersion, shimTarget string, pathFixed bool, 
 			}
 		}
 	}
-	return state, nil
+	return state
 }
 
 // adapterOutcome captures one detect-install adapter's per-connect result.
@@ -1619,7 +1702,9 @@ func cmdSetup() {
 	// setup to fail-fast just like connect does.
 	autoRecover := hasFlag("auto-recover")
 	tokenOnly := hasFlag("token-only")
+	useRemoteBin := hasFlag("use-remote-bin")
 	rejectAutoRecoverWithTokenOnly("setup", autoRecover, tokenOnly)
+	rejectRemoteBinWithLocalBin(useRemoteBin, getFlag("local-bin", ""))
 
 	// Resolve deployment targets BEFORE any local dependency / daemon / SSH
 	// activity so the interactive menu (design §5) precedes any prompt, and a
@@ -1692,10 +1777,11 @@ func cmdSetup() {
 	// Step 4: Deploy to remote
 	fmt.Printf("\n[4/4] Deploying to %s...\n", host)
 	runConnect(connectOpts{
-		host:        host,
-		port:        port,
-		targets:     targets,
-		autoRecover: autoRecover,
+		host:         host,
+		port:         port,
+		targets:      targets,
+		useRemoteBin: useRemoteBin,
+		autoRecover:  autoRecover,
 	})
 }
 
@@ -1720,9 +1806,7 @@ func connectSuccessSummary(t DeployTargets) string {
 }
 
 // connectVerifyTunnel verifies the SSH tunnel from the remote side.
-func connectVerifyTunnel(session *shim.SSHSession, port int, host string, targets DeployTargets) {
-	remoteBin := "~/.local/bin/cc-clip"
-
+func connectVerifyTunnel(session *shim.SSHSession, port int, host string, targets DeployTargets, remoteBin string) {
 	fmt.Printf("[7/7] Verifying tunnel from remote...\n")
 	probeCmd := fmt.Sprintf(
 		"bash -c 'echo >/dev/tcp/127.0.0.1/%d' 2>/dev/null && echo 'tunnel:ok' || echo 'tunnel:fail'",
@@ -2164,7 +2248,7 @@ const codexStateDir = "~/.cache/cc-clip/codex"
 
 // runConnectCodex executes steps 8-11 of the Codex deploy flow.
 // Returns true on success, false on failure (Claude path is preserved).
-func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded bool, state *shim.DeployState) bool {
+func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded bool, state *shim.DeployState, remoteBin string) bool {
 	port := opts.port
 
 	if opts.tokenOnly {
@@ -2230,7 +2314,7 @@ func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded 
 		// Stop any existing bridge first.
 		stopBridgeRemote(session)
 
-		if err := startBridgeRemote(session, xvfbState.Display, port); err != nil {
+		if err := startBridgeRemote(session, xvfbState.Display, port, remoteBin); err != nil {
 			fmt.Printf("      x11-bridge start failed: %v\n", err)
 			dumpRemoteLog(session, codexStateDir+"/bridge.log")
 			return false
@@ -2260,13 +2344,13 @@ func runConnectCodex(session *shim.SSHSession, opts connectOpts, binaryUploaded 
 }
 
 // startBridgeRemote starts the x11-bridge daemon on the remote.
-func startBridgeRemote(session *shim.SSHSession, display string, port int) error {
+func startBridgeRemote(session *shim.SSHSession, display string, port int, remoteBin string) error {
 	startScript := fmt.Sprintf(
-		`nohup env DISPLAY=":%s" ~/.local/bin/cc-clip x11-bridge --display ":%s" --port %d > %s/bridge.log 2>&1 < /dev/null &
+		`nohup env DISPLAY=":%s" %s x11-bridge --display ":%s" --port %d > %s/bridge.log 2>&1 < /dev/null &
 echo $! > %s/bridge.pid
 sleep 0.3
 kill -0 $(cat %s/bridge.pid 2>/dev/null) 2>/dev/null && echo 'bridge:ok' || echo 'bridge:fail'`,
-		display, display, port,
+		display, remoteBin, display, port,
 		codexStateDir, codexStateDir, codexStateDir,
 	)
 	out, err := session.Exec(startScript)

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -372,6 +372,25 @@ func TestNewDeployStatePreservesCodexWhenNotRequested(t *testing.T) {
 	}
 }
 
+func TestNewDeployStateFromBinaryMetadata(t *testing.T) {
+	hash := "sha256:" + strings.Repeat("b", 64)
+	state := newDeployStateFromBinary(
+		hash,
+		"v0.9.1",
+		"xclip",
+		true,
+		nil,
+		DeployTargets{Claude: true},
+	)
+
+	if state.BinaryHash != hash {
+		t.Errorf("BinaryHash = %q, want %q", state.BinaryHash, hash)
+	}
+	if got, want := state.BinaryVersion, "v0.9.1"; got != want {
+		t.Errorf("BinaryVersion = %q, want %q", got, want)
+	}
+}
+
 func TestNewDeployStateDoesNotPreserveCodexWhenRequested(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "cc-clip")

--- a/cmd/cc-clip/remote_bin_mode.go
+++ b/cmd/cc-clip/remote_bin_mode.go
@@ -1,0 +1,28 @@
+package main
+
+import "github.com/shunmei/cc-clip/internal/shim"
+
+// shouldAdoptRemoteBinMode decides whether a run that did NOT pass
+// --use-remote-bin should still treat the host as package-managed because a
+// previous deploy recorded it as such (DeployState.UseRemoteBin, #110).
+//
+// Without this stickiness, the mode lasts exactly one run: `cc-clip update`
+// prints `cc-clip connect <host> --force` as its redeploy reminder, and
+// pasting that line would re-upload to ~/.local/bin/cc-clip, shadowing the
+// package manager's binary the flag exists to preserve. An explicit
+// --local-bin is the deliberate way back to uploaded deploys, so it wins over
+// the recorded mode.
+func shouldAdoptRemoteBinMode(useRemoteBinFlag bool, localBinFlag string, state *shim.DeployState) bool {
+	return !useRemoteBinFlag && localBinFlag == "" && state != nil && state.UseRemoteBin
+}
+
+// remoteBinChanged reports whether the package-managed remote executable
+// differs from what deploy state last recorded. On the --use-remote-bin path
+// nothing is uploaded, so `needsUpload` stays false forever — this is the
+// remote-bin counterpart that keeps the x11-bridge restart decision honest
+// when the package manager upgraded the binary underneath us. A missing prior
+// state counts as changed: with nothing to compare against, restarting the
+// bridge is the safe direction.
+func remoteBinChanged(existing *shim.RemoteBinaryInfo, prior *shim.DeployState) bool {
+	return existing != nil && (prior == nil || prior.BinaryHash != existing.Hash)
+}

--- a/cmd/cc-clip/remote_bin_mode_test.go
+++ b/cmd/cc-clip/remote_bin_mode_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/shunmei/cc-clip/internal/shim"
+)
+
+func TestShouldAdoptRemoteBinMode(t *testing.T) {
+	t.Parallel()
+	recorded := &shim.DeployState{UseRemoteBin: true}
+	uploaded := &shim.DeployState{}
+
+	tests := []struct {
+		name     string
+		flag     bool
+		localBin string
+		state    *shim.DeployState
+		want     bool
+	}{
+		// The case the stickiness exists for: `cc-clip update` tells the user
+		// to run `connect <host> --force` with no mode flag at all.
+		{"recorded host, no flags -> adopt", false, "", recorded, true},
+		{"flag given -> caller already handles it", true, "", recorded, false},
+		{"--local-bin is the explicit way back to uploads", false, "/tmp/cc-clip", recorded, false},
+		{"uploaded-mode state -> no adoption", false, "", uploaded, false},
+		{"no prior state -> no adoption", false, "", nil, false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldAdoptRemoteBinMode(tt.flag, tt.localBin, tt.state); got != tt.want {
+				t.Fatalf("shouldAdoptRemoteBinMode(%v,%q,%+v) = %v, want %v", tt.flag, tt.localBin, tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRemoteBinChanged pins the bridge-restart decision for package-managed
+// hosts: needsUpload is permanently false on that path, so a package-manager
+// upgrade of the remote binary must be detected by hash instead — otherwise
+// deploy.json records the new hash while the x11-bridge keeps running the old
+// executable.
+func TestRemoteBinChanged(t *testing.T) {
+	t.Parallel()
+	info := &shim.RemoteBinaryInfo{Hash: "sha256:new"}
+
+	tests := []struct {
+		name  string
+		exist *shim.RemoteBinaryInfo
+		prior *shim.DeployState
+		want  bool
+	}{
+		{"nil existing (upload path) -> not the remote-bin case", nil, &shim.DeployState{BinaryHash: "sha256:new"}, false},
+		{"same hash -> unchanged", info, &shim.DeployState{BinaryHash: "sha256:new"}, false},
+		{"package manager upgraded the binary", info, &shim.DeployState{BinaryHash: "sha256:old"}, true},
+		{"no prior state -> fail toward restart", info, nil, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := remoteBinChanged(tt.exist, tt.prior); got != tt.want {
+				t.Fatalf("remoteBinChanged(%+v,%+v) = %v, want %v", tt.exist, tt.prior, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,8 @@ Complete cc-clip command reference. For the 10 most common commands, see the [Co
 | `cc-clip connect <host> --agy` | Antigravity: agy-notify (alias `--antigravity`) |
 | `cc-clip connect <host> --all` | Every target (Claude + Codex + opencode + agy) |
 | `cc-clip connect <host> --token-only` | Sync token only (fast) |
+| `cc-clip setup <host> --use-remote-bin` | Full setup using `cc-clip` from the remote PATH; skip binary upload |
+| `cc-clip connect <host> --use-remote-bin` | Incremental deploy using `cc-clip` from the remote PATH; skip binary upload |
 | `cc-clip connect <host> --auto-recover` | Recover from v0.7.0 wrapper corruption + reinstall (mutex with --token-only) |
 | `cc-clip setup <host> --auto-recover` | Same recovery flow via setup path |
 | `cc-clip connect <host> --force` | Full redeploy ignoring cache |

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -26,15 +26,12 @@ func RunRemote(host string, port int) []CheckResult {
 	results = append(results, CheckResult{"ssh", true, fmt.Sprintf("connected to %s", host)})
 
 	// Check remote binary
-	out, err = remoteExecNoForward(
-		host,
-		"if command -v cc-clip >/dev/null 2>&1; then cc-clip version; else ~/.local/bin/cc-clip version; fi",
-	)
+	out, err = remoteExecNoForward(host, remoteBinProbeCommand)
 	if err != nil {
 		results = append(results, CheckResult{
 			"remote-bin",
 			false,
-			"cc-clip not found in remote PATH or at ~/.local/bin/cc-clip",
+			"cc-clip not found at ~/.local/bin/cc-clip or on the login-shell PATH",
 		})
 	} else {
 		results = append(results, CheckResult{"remote-bin", true, strings.TrimSpace(out)})
@@ -124,6 +121,31 @@ func classifyRemoteTokenCheck(out string, err error) CheckResult {
 	}
 	return CheckResult{"remote-token", false, "token file missing"}
 }
+
+// remoteBinProbeCommand locates and versions the remote cc-clip executable.
+//
+// Order is deliberate (#111 review): the deployed ~/.local/bin/cc-clip is the
+// PRIMARY probe because it is the binary cc-clip itself manages — a PATH-first
+// lookup reported "remote-bin OK" for a stale system copy on hosts whose
+// actually deployed binary was missing or truncated. The fallback covers
+// package-managed hosts (--use-remote-bin, #110) and runs under the user's
+// LOGIN shell: every doctor command is wrapped by WrapRemoteShell, whose
+// prelude prepends system bin dirs ahead of $PATH, so a plain `command -v`
+// here could never see ~/.nix-profile/bin or pipx installs. The candidate is
+// taken from the last output line (rc noise prints first) and must itself be
+// executable before adoption. The output names the path that answered so the
+// operator can tell which binary was probed.
+const remoteBinProbeCommand = `bin=""
+if [ -x "$HOME/.local/bin/cc-clip" ]; then
+    bin="$HOME/.local/bin/cc-clip"
+elif [ -n "$SHELL" ] && [ -x "$SHELL" ]; then
+    candidate=$("$SHELL" -lc 'command -v cc-clip' 2>/dev/null | tail -n 1)
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+        bin="$candidate"
+    fi
+fi
+[ -n "$bin" ] || exit 127
+printf '%s\n' "$("$bin" version) ($bin)"`
 
 // remoteExecNoForward runs an SSH command without applying RemoteForward from ssh config.
 // Doctor checks should inspect the existing tunnel, not compete with it by opening a new one.

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -25,9 +25,16 @@ func RunRemote(host string, port int) []CheckResult {
 	results = append(results, CheckResult{"ssh", true, fmt.Sprintf("connected to %s", host)})
 
 	// Check remote binary
-	out, err = remoteExecNoForward(host, "~/.local/bin/cc-clip version")
+	out, err = remoteExecNoForward(
+		host,
+		"if command -v cc-clip >/dev/null 2>&1; then cc-clip version; else ~/.local/bin/cc-clip version; fi",
+	)
 	if err != nil {
-		results = append(results, CheckResult{"remote-bin", false, "cc-clip not found at ~/.local/bin/cc-clip"})
+		results = append(results, CheckResult{
+			"remote-bin",
+			false,
+			"cc-clip not found in remote PATH or at ~/.local/bin/cc-clip",
+		})
 	} else {
 		results = append(results, CheckResult{"remote-bin", true, strings.TrimSpace(out)})
 	}

--- a/internal/doctor/remote_test.go
+++ b/internal/doctor/remote_test.go
@@ -135,3 +135,35 @@ func TestClassifyRemoteTokenCheck(t *testing.T) {
 		})
 	}
 }
+
+// TestRemoteBinProbeCommand pins the remote-bin check's resolution order
+// (#111 review, finding 1): the deployed ~/.local/bin/cc-clip is the PRIMARY
+// probe — it is the binary cc-clip manages — and the login-shell PATH lookup
+// is only the fallback for package-managed hosts. Probing the PATH first
+// reported "remote-bin OK" for a stale system copy on hosts whose actually
+// deployed binary was missing or truncated. The command must also print the
+// resolved path so the operator can see WHICH binary answered.
+func TestRemoteBinProbeCommand(t *testing.T) {
+	cmd := remoteBinProbeCommand
+
+	localIdx := strings.Index(cmd, `$HOME/.local/bin/cc-clip`)
+	loginIdx := strings.Index(cmd, `"$SHELL" -lc`)
+	if localIdx == -1 {
+		t.Fatalf("probe must check the deployed ~/.local/bin/cc-clip:\n%s", cmd)
+	}
+	if loginIdx == -1 {
+		t.Fatalf("probe must fall back to a login-shell PATH lookup (package-managed hosts):\n%s", cmd)
+	}
+	if loginIdx < localIdx {
+		t.Fatalf("deployed binary must be probed BEFORE the PATH fallback:\n%s", cmd)
+	}
+	// A plain `command -v` under the session PATH is exactly the resolution
+	// the login shell exists to avoid (remotePathPrelude shadows user dirs);
+	// the fallback must run inside the login shell only.
+	if strings.Contains(strings.ReplaceAll(cmd, `-lc 'command -v cc-clip'`, ""), "command -v cc-clip") {
+		t.Fatalf("PATH lookup outside the login shell would resolve under the hardened prelude PATH:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `"$bin"`) || !strings.Contains(cmd, `($bin)`) {
+		t.Fatalf("probe output must include the resolved path so the operator sees which binary answered:\n%s", cmd)
+	}
+}

--- a/internal/shim/deploy.go
+++ b/internal/shim/deploy.go
@@ -71,11 +71,14 @@ type ClaudeWrapperState struct {
 }
 
 // currentDeploySchemaVersion is the deploy-state schema version this binary
-// writes. v1 is the v0.9.0 per-adapter Notify schema. A state stamped with a
+// writes. v1 is the v0.9.0 per-adapter Notify schema; v2 adds UseRemoteBin
+// (package-managed remote binaries, #110) — the bump exists so a v1 binary
+// refuses to rewrite a package-managed host's state rather than silently
+// dropping the marker and re-enabling upload mode. A state stamped with a
 // HIGHER version was written by a newer cc-clip; the connect path refuses to
 // overwrite it (see DeployState.IsNewerSchema). A state with SchemaVersion==0
 // (legacy / pre-guard) is NOT newer — it migrates normally via migrateNotifyState.
-const currentDeploySchemaVersion = 1
+const currentDeploySchemaVersion = 2
 
 // DeployState represents the state of a cc-clip deployment on a remote host.
 // It is stored as ~/.cache/cc-clip/deploy.json on the remote.
@@ -89,6 +92,17 @@ type DeployState struct {
 	Notify        *NotifyDeployState  `json:"notify,omitempty"`
 	Codex         *CodexDeployState   `json:"codex,omitempty"`
 	ClaudeWrapper *ClaudeWrapperState `json:"claude_wrapper,omitempty"`
+
+	// UseRemoteBin records that this host's cc-clip executable is owned by a
+	// package manager on the remote (--use-remote-bin, #110). connect reads it
+	// to keep package-managed mode across runs that omit the flag — without
+	// it, pasting the update reminder's `cc-clip connect <host> --force`
+	// re-uploads to ~/.local/bin and shadows the package binary the flag
+	// exists to preserve. BinaryHash/BinaryVersion describe the REMOTE
+	// executable when this is set. Cleared by an explicit --local-bin deploy.
+	// Guarded by the v2 schema bump: a v1 binary rewriting this file would
+	// silently drop the field and re-enable upload mode.
+	UseRemoteBin bool `json:"use_remote_bin,omitempty"`
 }
 
 // CurrentDeploySchemaVersion returns the deploy-state schema version this

--- a/internal/shim/deploy_test.go
+++ b/internal/shim/deploy_test.go
@@ -2,6 +2,7 @@ package shim
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1152,11 +1153,14 @@ func TestIsNewerSchema_LegacyStillMigrates(t *testing.T) {
 // SchemaVersion greater than this binary's is reported as newer.
 func TestIsNewerSchema_NewerStateDetected(t *testing.T) {
 	s := &localSession{home: t.TempDir()}
-	writeRemoteDeployState(t, s.home, `{
+	// The fixture version is derived from the current constant so this test
+	// keeps meaning "strictly newer than THIS binary" across schema bumps
+	// (a hardcoded number silently stopped being "future" at the v2 bump).
+	writeRemoteDeployState(t, s.home, fmt.Sprintf(`{
   "binary_hash": "sha256:future",
-  "schema_version": 2,
+  "schema_version": %d,
   "shim_installed": true
-}`)
+}`, currentDeploySchemaVersion+1))
 
 	state, err := ReadRemoteState(s)
 	if err != nil {
@@ -1227,5 +1231,42 @@ func TestClipboardTransportPreserved(t *testing.T) {
 	}
 	if !state.Codex.Enabled || state.Codex.Mode != "xvfb" || !state.Codex.DisplayFixed {
 		t.Errorf("Codex transport state mutated: %+v", state.Codex)
+	}
+}
+
+// TestDeployStateUseRemoteBinRoundTrip pins the package-managed marker (#110):
+// it must survive a JSON round trip, and the schema version must be at least 2
+// so a pre-#110 binary refuses to rewrite (and thereby silently drop) it.
+func TestDeployStateUseRemoteBinRoundTrip(t *testing.T) {
+	state := &DeployState{UseRemoteBin: true, BinaryHash: "sha256:abc", BinaryVersion: "0.9.1"}
+	stampSchemaVersion(state)
+
+	if currentDeploySchemaVersion < 2 {
+		t.Fatalf("currentDeploySchemaVersion = %d; the use_remote_bin field requires the v2 bump", currentDeploySchemaVersion)
+	}
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"use_remote_bin":true`) {
+		t.Fatalf("marshalled state missing use_remote_bin: %s", data)
+	}
+
+	var decoded DeployState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if !decoded.UseRemoteBin {
+		t.Fatal("UseRemoteBin lost in round trip")
+	}
+
+	// The zero value must stay absent so uploaded-mode states are unchanged.
+	plain, err := json.Marshal(&DeployState{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(plain), "use_remote_bin") {
+		t.Fatalf("zero-value state must omit use_remote_bin: %s", plain)
 	}
 }

--- a/internal/shim/remote_binary.go
+++ b/internal/shim/remote_binary.go
@@ -2,22 +2,53 @@ package shim
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 )
 
-const inspectRemoteBinaryCommand = `binary=$(command -v cc-clip) || exit 127
-test -x "$binary" || exit 126
-binary_version=$("$binary" version) || exit $?
+// inspectRemoteBinaryCommand resolves and fingerprints cc-clip on the remote.
+//
+// Resolution runs under the user's LOGIN shell first, and only falls back to a
+// plain `command -v`. The order is load-bearing: every remote command goes
+// through WrapRemoteShell, whose remotePathPrelude prepends the system bin
+// directories ahead of the inherited $PATH (so coreutils resolve on minimal
+// images — see #106). Under that PATH a plain `command -v cc-clip` can never
+// see ~/.nix-profile/bin, ~/.local/bin, pipx or asdf — precisely the package
+// managers #110 was filed about — and a stale /usr/local/bin copy wins
+// silently. `"$SHELL" -lc` re-resolves PATH from the user's own profile, where
+// those managers install themselves.
+//
+// The login-shell candidate is taken from the LAST output line (rc files may
+// print before `command -v` does) and must itself be executable before it is
+// adopted; otherwise rc noise on the last line would be mistaken for a path.
+// Shells without a `command` builtin (csh) yield nothing and degrade to the
+// plain fallback.
+//
+// Distinct exit codes per failure mode: 127 nothing found, 126 found but not
+// executable, 125 no sha256 tool on the remote.
+const inspectRemoteBinaryCommand = `resolved=""
+if [ -n "$SHELL" ] && [ -x "$SHELL" ]; then
+    candidate=$("$SHELL" -lc 'command -v cc-clip' 2>/dev/null | tail -n 1)
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+        resolved="$candidate"
+    fi
+fi
+if [ -z "$resolved" ]; then
+    resolved=$(command -v cc-clip 2>/dev/null) || true
+fi
+[ -n "$resolved" ] || exit 127
+[ -x "$resolved" ] || exit 126
+binary_version=$("$resolved" version) || exit $?
 if command -v sha256sum >/dev/null 2>&1; then
-    binary_hash=$(sha256sum "$binary") || exit $?
+    binary_hash=$(sha256sum "$resolved") || exit $?
 elif command -v shasum >/dev/null 2>&1; then
-    binary_hash=$(shasum -a 256 "$binary") || exit $?
+    binary_hash=$(shasum -a 256 "$resolved") || exit $?
 else
-    exit 127
+    exit 125
 fi
 binary_hash=${binary_hash%% *}
-printf '%s\n%s\nsha256:%s\n' "$binary" "$binary_version" "$binary_hash"`
+printf '%s\n%s\nsha256:%s\n' "$resolved" "$binary_version" "$binary_hash"`
 
 // RemoteBinaryInfo describes an existing cc-clip executable on a remote host.
 type RemoteBinaryInfo struct {
@@ -31,14 +62,16 @@ func (i *RemoteBinaryInfo) Command() string {
 	return shSingleQuote(i.Path)
 }
 
+// exitCoder is the subset of *exec.ExitError InspectRemoteBinary needs to map
+// remote exit codes to actionable messages. An interface rather than a type
+// assertion so SSH transport wrappers and tests can both convey codes.
+type exitCoder interface{ ExitCode() int }
+
 // InspectRemoteBinary resolves and fingerprints cc-clip on the remote PATH.
 func InspectRemoteBinary(session RemoteExecutor) (*RemoteBinaryInfo, error) {
 	out, err := session.Exec(inspectRemoteBinaryCommand)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"failed to inspect remote cc-clip; ensure it is installed and executable: %w",
-			err,
-		)
+		return nil, classifyInspectError(err)
 	}
 
 	lines := strings.Split(strings.TrimSpace(out), "\n")
@@ -68,6 +101,24 @@ func InspectRemoteBinary(session RemoteExecutor) (*RemoteBinaryInfo, error) {
 		Hash:    hash,
 		Version: binaryVersion,
 	}, nil
+}
+
+// classifyInspectError maps the inspection script's distinct exit codes to
+// messages that name the actual failure, so "no cc-clip installed" is not
+// reported the same way as "the remote has no sha256 tool".
+func classifyInspectError(err error) error {
+	var ec exitCoder
+	if errors.As(err, &ec) {
+		switch ec.ExitCode() {
+		case 127:
+			return fmt.Errorf("no cc-clip executable found on the remote (checked the login-shell PATH, then the non-interactive PATH); install it with the remote's package manager or drop --use-remote-bin: %w", err)
+		case 126:
+			return fmt.Errorf("remote cc-clip was found but is not executable: %w", err)
+		case 125:
+			return fmt.Errorf("cannot fingerprint the remote cc-clip: the remote has neither sha256sum nor shasum: %w", err)
+		}
+	}
+	return fmt.Errorf("failed to inspect remote cc-clip; ensure it is installed and executable: %w", err)
 }
 
 func validateRemoteBinaryHash(hash string) error {

--- a/internal/shim/remote_binary.go
+++ b/internal/shim/remote_binary.go
@@ -1,0 +1,83 @@
+package shim
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+const inspectRemoteBinaryCommand = `binary=$(command -v cc-clip) || exit 127
+test -x "$binary" || exit 126
+binary_version=$("$binary" version) || exit $?
+if command -v sha256sum >/dev/null 2>&1; then
+    binary_hash=$(sha256sum "$binary") || exit $?
+elif command -v shasum >/dev/null 2>&1; then
+    binary_hash=$(shasum -a 256 "$binary") || exit $?
+else
+    exit 127
+fi
+binary_hash=${binary_hash%% *}
+printf '%s\n%s\nsha256:%s\n' "$binary" "$binary_version" "$binary_hash"`
+
+// RemoteBinaryInfo describes an existing cc-clip executable on a remote host.
+type RemoteBinaryInfo struct {
+	Path    string
+	Hash    string
+	Version string
+}
+
+// Command returns the remote binary path as a safely quoted shell token.
+func (i *RemoteBinaryInfo) Command() string {
+	return shSingleQuote(i.Path)
+}
+
+// InspectRemoteBinary resolves and fingerprints cc-clip on the remote PATH.
+func InspectRemoteBinary(session RemoteExecutor) (*RemoteBinaryInfo, error) {
+	out, err := session.Exec(inspectRemoteBinaryCommand)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to inspect remote cc-clip; ensure it is installed and executable: %w",
+			err,
+		)
+	}
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 3 {
+		return nil, fmt.Errorf("unexpected inspection output: got %d lines", len(lines))
+	}
+
+	path := strings.TrimSpace(lines[0])
+	versionLine := strings.TrimSpace(lines[1])
+	hash := strings.TrimSpace(lines[2])
+	if path == "" {
+		return nil, fmt.Errorf("unexpected inspection output: binary path is empty")
+	}
+	if !strings.HasPrefix(versionLine, "cc-clip ") {
+		return nil, fmt.Errorf("unexpected version output: %q", versionLine)
+	}
+	binaryVersion := strings.TrimSpace(strings.TrimPrefix(versionLine, "cc-clip "))
+	if binaryVersion == "" {
+		return nil, fmt.Errorf("unexpected version output: %q", versionLine)
+	}
+	if err := validateRemoteBinaryHash(hash); err != nil {
+		return nil, err
+	}
+
+	return &RemoteBinaryInfo{
+		Path:    path,
+		Hash:    hash,
+		Version: binaryVersion,
+	}, nil
+}
+
+func validateRemoteBinaryHash(hash string) error {
+	const prefix = "sha256:"
+	if !strings.HasPrefix(hash, prefix) {
+		return fmt.Errorf("invalid remote binary hash: %q", hash)
+	}
+	decoded, err := hex.DecodeString(strings.TrimPrefix(hash, prefix))
+	if err != nil || len(decoded) != 32 {
+		return fmt.Errorf("invalid remote binary hash: %q", hash)
+	}
+	return nil
+}

--- a/internal/shim/remote_binary_test.go
+++ b/internal/shim/remote_binary_test.go
@@ -93,3 +93,79 @@ func TestInspectRemoteBinaryErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestInspectRemoteBinaryResolvesViaLoginShell pins the fix for the PATH
+// shadowing defect: WrapRemoteShell prepends remotePathPrelude to every remote
+// command, putting system bin directories ahead of the inherited $PATH, so a
+// plain `command -v cc-clip` can never see ~/.nix-profile/bin, ~/.local/bin,
+// pipx or asdf — the package managers issue #110 was filed about. Resolution
+// must therefore happen under the user's own login shell, with the plain
+// lookup only as a fallback.
+func TestInspectRemoteBinaryResolvesViaLoginShell(t *testing.T) {
+	hash := "sha256:" + strings.Repeat("a", 64)
+	executor := &remoteBinaryExecutor{
+		output: "/home/u/.nix-profile/bin/cc-clip\ncc-clip v0.9.1\n" + hash,
+	}
+
+	if _, err := InspectRemoteBinary(executor); err != nil {
+		t.Fatalf("InspectRemoteBinary returned error: %v", err)
+	}
+
+	cmd := executor.command
+	// The login-shell resolution must come BEFORE the plain fallback, and the
+	// candidate it yields must be validated executable so rc-file noise on the
+	// last output line cannot be adopted as a path.
+	loginIdx := strings.Index(cmd, `"$SHELL" -lc`)
+	plainIdx := strings.LastIndex(cmd, "command -v cc-clip")
+	if loginIdx == -1 {
+		t.Fatalf("inspection command must resolve via the login shell:\n%s", cmd)
+	}
+	if plainIdx == -1 || plainIdx < loginIdx {
+		t.Fatalf("plain command -v must remain as the fallback AFTER the login-shell attempt:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, `-x "$candidate"`) {
+		t.Fatalf("login-shell candidate must be validated executable before adoption:\n%s", cmd)
+	}
+}
+
+// TestInspectRemoteBinaryErrorsAreActionablePerExitCode verifies the three
+// distinct remote failure modes are not collapsed into one message.
+func TestInspectRemoteBinaryErrorsAreActionablePerExitCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantAll []string
+	}{
+		{"not found (127)", fakeExitError{code: 127}, []string{"no cc-clip executable found", "--use-remote-bin"}},
+		{"not executable (126)", fakeExitError{code: 126}, []string{"not executable"}},
+		{"no hash tool (125)", fakeExitError{code: 125}, []string{"sha256sum", "shasum"}},
+	}
+	seen := map[string]string{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &remoteBinaryExecutor{err: tt.err}
+			_, err := InspectRemoteBinary(executor)
+			if err == nil {
+				t.Fatal("want error")
+			}
+			for _, want := range tt.wantAll {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("error %q must mention %q", err, want)
+				}
+			}
+			if prev, dup := seen[err.Error()]; dup {
+				t.Fatalf("cases %q and %q share the message %q; failure modes must stay distinguishable", prev, tt.name, err)
+			}
+			seen[err.Error()] = tt.name
+		})
+	}
+}
+
+// fakeExitError mimics an *exec.ExitError-style exit code carrier without
+// spawning a process. InspectRemoteBinary must read the code via the
+// exitCoder interface, not by type-asserting exec.ExitError, so SSH transport
+// wrappers and tests can both convey remote exit codes.
+type fakeExitError struct{ code int }
+
+func (e fakeExitError) Error() string { return "exit status" }
+func (e fakeExitError) ExitCode() int { return e.code }

--- a/internal/shim/remote_binary_test.go
+++ b/internal/shim/remote_binary_test.go
@@ -1,0 +1,95 @@
+package shim
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type remoteBinaryExecutor struct {
+	output  string
+	err     error
+	command string
+}
+
+func (e *remoteBinaryExecutor) Exec(command string) (string, error) {
+	e.command = command
+	return e.output, e.err
+}
+
+func TestInspectRemoteBinary(t *testing.T) {
+	hash := "sha256:" + strings.Repeat("a", 64)
+	executor := &remoteBinaryExecutor{
+		output: "/nix/store/pkg's/bin/cc-clip\ncc-clip v0.9.1\n" + hash,
+	}
+
+	info, err := InspectRemoteBinary(executor)
+	if err != nil {
+		t.Fatalf("InspectRemoteBinary returned error: %v", err)
+	}
+	if got, want := info.Path, "/nix/store/pkg's/bin/cc-clip"; got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+	if got, want := info.Version, "v0.9.1"; got != want {
+		t.Errorf("Version = %q, want %q", got, want)
+	}
+	if info.Hash != hash {
+		t.Errorf("Hash = %q, want %q", info.Hash, hash)
+	}
+	if got, want := info.Command(), `'/nix/store/pkg'\''s/bin/cc-clip'`; got != want {
+		t.Errorf("Command() = %q, want %q", got, want)
+	}
+	for _, fragment := range []string{
+		"command -v cc-clip",
+		"sha256sum",
+		"shasum -a 256",
+	} {
+		if !strings.Contains(executor.command, fragment) {
+			t.Errorf("inspection command missing %q: %s", fragment, executor.command)
+		}
+	}
+}
+
+func TestInspectRemoteBinaryErrors(t *testing.T) {
+	hash := "sha256:" + strings.Repeat("a", 64)
+	tests := []struct {
+		name    string
+		output  string
+		err     error
+		wantErr string
+	}{
+		{
+			name:    "remote command failed",
+			err:     errors.New("exit status 127"),
+			wantErr: "remote cc-clip",
+		},
+		{
+			name:    "malformed output",
+			output:  "/usr/bin/cc-clip\ncc-clip v0.9.1",
+			wantErr: "unexpected inspection output",
+		},
+		{
+			name:    "invalid version",
+			output:  "/usr/bin/cc-clip\nv0.9.1\n" + hash,
+			wantErr: "unexpected version output",
+		},
+		{
+			name:    "invalid hash",
+			output:  "/usr/bin/cc-clip\ncc-clip v0.9.1\nsha256:not-hex",
+			wantErr: "invalid remote binary hash",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := &remoteBinaryExecutor{output: tt.output, err: tt.err}
+			info, err := InspectRemoteBinary(executor)
+			if err == nil {
+				t.Fatalf("InspectRemoteBinary() = %+v, want error", info)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add `--use-remote-bin` to `setup` and `connect`;
- resolve, execute, and fingerprint `cc-clip` from the remote PATH instead of detecting an architecture or uploading a binary;
- pass the resolved executable through shim installation, status verification, and X11 bridge startup;
- persist the remote executable's actual hash and version in deploy state; and
- teach remote diagnostics and the user docs about PATH-managed binaries.

## Design

The default deployment path is unchanged. The new mode is opt-in and deliberately PATH-based, so package managers remain responsible for choosing and updating the executable.

`--use-remote-bin` fails fast when combined with `--local-bin`. If clean release versions differ, setup warns and continues with the explicitly selected remote executable.

## Tests

- `make test` (with `xclip` removed from PATH because this workstation has it installed and the existing missing-fallback test requires it to be absent)
- `make vet`
- cross-build `go build ./...` for darwin/amd64, windows/amd64, and linux/arm64
- `git diff --check`

Closes #110