### PR TITLE
fix(ci): bump Go floor to 1.25.12 to clear GO-2026-5856

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shunmei/cc-clip
 
-go 1.25.11
+go 1.25.12
 
 require github.com/jezek/xgb v1.3.0 // indirect


### PR DESCRIPTION
## Summary

CI has been red on `main` and on every pull request since 2026-07-14 without any source change. This is a one-line fix for the cause.

`.github/workflows/ci.yml` installs the toolchain with `go-version-file: go.mod`, and `go.mod` pinned the full patch version `go 1.25.11`. The Govulncheck step resolves `golang.org/x/vuln/cmd/govulncheck@latest`, so it tracks a rolling advisory database against a frozen toolchain. When GO-2026-5856 (Encrypted Client Hello privacy leak in `crypto/tls`, fixed in go1.25.12) was published, every run started failing on four stdlib call paths that the project legitimately uses:

- `internal/daemon/server.go` — `Server.ListenAndServe` -> `http.Server.Serve` -> `tls.Conn.HandshakeContext`
- `internal/shim/deploy.go` — `LocalBinaryHash` -> `io.Copy` -> `tls.Conn.Read`
- `internal/hosts/registry.go` — `Registry.FormatRedeployReminder` -> `fmt.Fprintf` -> `tls.Conn.Write`
- `internal/plugin/notify.go` — `PostNotification` -> `http.Client.Do` -> `tls.Dialer.DialContext`

Bumping the floor to `go 1.25.12` clears the advisory. No source change is required.

## Why this is not an accidental toolchain bump

`go 1.25.12` is the minimum version that is not affected, so this is the smallest bump that makes CI honest rather than a jump to a newer minor. Contributors on any go1.25.12+ or go1.26.x toolchain are unaffected.

## Verification

Run locally with `GOTOOLCHAIN=go1.25.12`, mirroring all five CI steps:

| Step | Result |
|---|---|
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./... -race -count=1` | pass, all packages |
| `staticcheck ./...` | pass, exit 0 |
| `govulncheck ./...` | `No vulnerabilities found` |

## Note for other open PRs

Both currently open pull requests inherit this red step from `main`'s `go.mod`, so neither can go green until this lands. #111 will need a rebase afterwards.

## Follow-up worth considering (not in this PR)

Pinning a full patch version in `go.mod` while scanning with `govulncheck@latest` means CI will go red again on the next stdlib advisory, with no code change involved. Options are to keep the current arrangement and treat the bump as routine maintenance, or to separate the two concerns: keep `go.mod` as the compatibility floor and give the Govulncheck step its own `go-version: stable`, so stdlib advisories are evaluated against the toolchain users actually build with.
