### PR TITLE
fix(tunnel): verify daemon liveness instead of TCP reachability (#22 P0)

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -1724,10 +1724,11 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string, target
 	remoteBin := "~/.local/bin/cc-clip"
 
 	fmt.Printf("[7/7] Verifying tunnel from remote...\n")
-	probeCmd := fmt.Sprintf(
-		"bash -c 'echo >/dev/tcp/127.0.0.1/%d' 2>/dev/null && echo 'tunnel:ok' || echo 'tunnel:fail'",
-		port)
-	probeOut, probeErr := session.Exec(probeCmd)
+	// Ask the daemon to identify itself through the forward rather than only
+	// completing a TCP handshake. A stale sshd from a previous session keeps
+	// the port in LISTEN, which satisfied the old /dev/tcp probe and made
+	// connect print "tunnel verified" for a tunnel that carried nothing.
+	probeOut, probeErr := session.Exec(tunnel.RemoteHealthProbeCommand(port))
 
 	if probeErr != nil {
 		// The probe itself could not run — the SSH master is dead, not the
@@ -1736,17 +1737,10 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string, target
 		// exist; name the real failure instead.
 		fmt.Printf("      tunnel probe could not be executed over SSH: %v\n", probeErr)
 		fmt.Println("      The SSH session appears to be down; re-run 'cc-clip connect' once SSH is reachable.")
-	} else if probeOut == "tunnel:ok" {
-		fmt.Println("      tunnel verified (via existing SSH session)")
 	} else {
-		fmt.Println("      tunnel not detected (this is normal if no interactive SSH session is open)")
-		fmt.Println("      The tunnel is provided by your SSH connection, not by 'cc-clip connect'.")
-		fmt.Println("      Ensure your SSH session includes RemoteForward:")
-		fmt.Printf("        ssh -R %d:127.0.0.1:%d %s\n", port, port, host)
-		fmt.Println()
-		fmt.Println("      Or add to ~/.ssh/config:")
-		fmt.Printf("        Host %s\n", host)
-		fmt.Printf("            RemoteForward %d 127.0.0.1:%d\n", port, port)
+		for _, line := range tunnelVerificationReport(tunnel.ClassifyRemoteProbeOutput(probeOut), port, host) {
+			fmt.Println(line)
+		}
 	}
 
 	// Verify remote binary is functional

--- a/cmd/cc-clip/tunnel_report.go
+++ b/cmd/cc-clip/tunnel_report.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/shunmei/cc-clip/internal/tunnel"
+)
+
+// tunnelVerificationReport renders the operator-facing lines for a remote
+// tunnel probe outcome. It is kept separate from connectVerifyTunnel so the
+// guidance can be tested without an SSH session.
+//
+// Each state gets its own remedy. Collapsing "nothing is listening" and "the
+// port is held by something that is not a cc-clip daemon" into one message is
+// what previously sent operators to fix RemoteForward while the real cause was
+// a stale sshd or a stopped local daemon.
+func tunnelVerificationReport(state tunnel.RemoteTunnelState, port int, host string) []string {
+	switch state {
+	case tunnel.RemoteTunnelOK:
+		return []string{"      tunnel verified (cc-clip daemon answered through the existing SSH session)"}
+
+	case tunnel.RemoteTunnelStale:
+		return []string{
+			fmt.Sprintf("      WARNING: port %d is held on the remote, but no cc-clip daemon answered.", port),
+			"      The port being open does NOT mean the tunnel works. Two known causes:",
+			"        1. A stale sshd from a previous SSH session still owns the forward.",
+			fmt.Sprintf("           On the remote, find and end it: lsof -ti tcp:%d", port),
+			"        2. The forward is live but the local daemon is not running.",
+			"           On this machine, start it: cc-clip serve",
+			fmt.Sprintf("      Then re-run: cc-clip doctor --host %s", host),
+		}
+
+	case tunnel.RemoteTunnelUnverified:
+		return []string{
+			fmt.Sprintf("      port %d is reachable from the remote, but liveness could not be confirmed.", port),
+			"      The remote has no curl, so the daemon could not be asked to identify itself.",
+			"      Install curl on the remote to get a real verification.",
+		}
+
+	case tunnel.RemoteTunnelUnknown:
+		return []string{
+			"      tunnel check did not complete (the remote probe returned unrecognized output).",
+			fmt.Sprintf("      Run 'cc-clip doctor --host %s' for a full diagnosis.", host),
+		}
+
+	default: // tunnel.RemoteTunnelDown
+		return []string{
+			"      tunnel not detected (this is normal if no interactive SSH session is open)",
+			"      The tunnel is provided by your SSH connection, not by 'cc-clip connect'.",
+			"      Ensure your SSH session includes RemoteForward:",
+			fmt.Sprintf("        ssh -R %d:127.0.0.1:%d %s", port, port, host),
+			"",
+			"      Or add to ~/.ssh/config:",
+			fmt.Sprintf("        Host %s", host),
+			fmt.Sprintf("            RemoteForward %d 127.0.0.1:%d", port, port),
+		}
+	}
+}

--- a/cmd/cc-clip/tunnel_report_test.go
+++ b/cmd/cc-clip/tunnel_report_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shunmei/cc-clip/internal/tunnel"
+)
+
+func joinReport(lines []string) string {
+	return strings.Join(lines, "\n")
+}
+
+// TestTunnelVerificationReportNeverClaimsSuccessWithoutDaemon is the guard for
+// the reason this report exists: connect used a TCP-only probe, so a stale
+// sshd still holding the forwarded port made it print "tunnel verified" for a
+// tunnel that could not carry a byte. Only a daemon that answered may produce
+// a success line.
+func TestTunnelVerificationReportNeverClaimsSuccessWithoutDaemon(t *testing.T) {
+	notHealthy := []tunnel.RemoteTunnelState{
+		tunnel.RemoteTunnelDown,
+		tunnel.RemoteTunnelStale,
+		tunnel.RemoteTunnelUnverified,
+		tunnel.RemoteTunnelUnknown,
+	}
+	for _, state := range notHealthy {
+		got := joinReport(tunnelVerificationReport(state, 18339, "venus"))
+		if strings.Contains(got, "tunnel verified") {
+			t.Fatalf("state %q must not report a verified tunnel, got:\n%s", state, got)
+		}
+		if strings.TrimSpace(got) == "" {
+			t.Fatalf("state %q produced no operator guidance", state)
+		}
+	}
+
+	ok := joinReport(tunnelVerificationReport(tunnel.RemoteTunnelOK, 18339, "venus"))
+	if !strings.Contains(ok, "tunnel verified") {
+		t.Fatalf("healthy state must report a verified tunnel, got:\n%s", ok)
+	}
+}
+
+// TestTunnelVerificationReportStaleNamesBothCauses pins the guidance for the
+// state operators actually have to act on. Sending them to check RemoteForward
+// when the real cause is a dead local daemon (or vice versa) is the failure
+// mode this replaces.
+func TestTunnelVerificationReportStaleNamesBothCauses(t *testing.T) {
+	got := strings.ToLower(joinReport(tunnelVerificationReport(tunnel.RemoteTunnelStale, 18339, "venus")))
+
+	for _, want := range []string{"stale", "cc-clip serve", "lsof"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stale guidance must mention %q, got:\n%s", want, got)
+		}
+	}
+	// The RemoteForward advice belongs to the "nothing listening" case; on a
+	// stale port it sends the operator down the wrong path.
+	if strings.Contains(got, "remoteforward") {
+		t.Fatalf("stale guidance must not blame RemoteForward, got:\n%s", got)
+	}
+}
+
+// TestTunnelVerificationReportDownKeepsRemoteForwardGuidance preserves the
+// pre-existing, correct advice for the common "no interactive SSH session is
+// open" case.
+func TestTunnelVerificationReportDownKeepsRemoteForwardGuidance(t *testing.T) {
+	got := joinReport(tunnelVerificationReport(tunnel.RemoteTunnelDown, 18339, "venus"))
+
+	if !strings.Contains(got, "RemoteForward 18339 127.0.0.1:18339") {
+		t.Fatalf("down guidance must keep the ssh_config snippet, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ssh -R 18339:127.0.0.1:18339 venus") {
+		t.Fatalf("down guidance must keep the ssh -R example for the host, got:\n%s", got)
+	}
+}
+
+func TestTunnelVerificationReportUnknownAdmitsItDidNotRun(t *testing.T) {
+	got := strings.ToLower(joinReport(tunnelVerificationReport(tunnel.RemoteTunnelUnknown, 18339, "venus")))
+
+	if !strings.Contains(got, "did not complete") {
+		t.Fatalf("unknown guidance must say the check did not complete, got:\n%s", got)
+	}
+}

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/shunmei/cc-clip/internal/shim"
 	"github.com/shunmei/cc-clip/internal/token"
+	"github.com/shunmei/cc-clip/internal/tunnel"
 )
 
 func RunRemote(host string, port int) []CheckResult {
@@ -59,9 +60,10 @@ func RunRemote(host string, port int) []CheckResult {
 		results = append(results, CheckResult{"path-order", false, fmt.Sprintf("%s resolves to %s (shim not first)", checkTarget, strings.TrimSpace(out))})
 	}
 
-	// Check tunnel from remote side
-	out, err = remoteExecNoForward(host, fmt.Sprintf(
-		"bash -c 'echo >/dev/tcp/127.0.0.1/%d' 2>&1 && echo 'tunnel ok' || echo 'tunnel fail'", port))
+	// Check tunnel from remote side. A TCP-only probe is not enough: a stale
+	// sshd forward keeps the port in LISTEN after its session is gone, so the
+	// handshake succeeds while nothing reaches the daemon.
+	out, err = remoteExecNoForward(host, tunnel.RemoteHealthProbeCommand(port))
 	results = append(results, classifyTunnelCheck(out, err, port))
 
 	// Check token on remote
@@ -89,14 +91,17 @@ func RunRemote(host string, port int) []CheckResult {
 // CheckResult. An SSH transport failure (err != nil) is reported as a distinct
 // "check did not run" result so it is not confused with the legitimate
 // "check ran and the port is not reachable" outcome.
+//
+// Only tunnel.RemoteTunnelOK — a cc-clip daemon answering GET /health through
+// the forward — counts as OK. Reachable-but-silent and unrecognized output
+// both fail closed, so a stale sshd holding the port can no longer be reported
+// as a working tunnel.
 func classifyTunnelCheck(out string, err error, port int) CheckResult {
 	if err != nil {
 		return CheckResult{"tunnel", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
 	}
-	if strings.Contains(out, "tunnel ok") {
-		return CheckResult{"tunnel", true, fmt.Sprintf("port %d forwarded", port)}
-	}
-	return CheckResult{"tunnel", false, fmt.Sprintf("port %d not reachable from remote", port)}
+	state := tunnel.ClassifyRemoteProbeOutput(out)
+	return CheckResult{"tunnel", state.Healthy(), state.Summary(port)}
 }
 
 // classifyRemoteTokenCheck turns the result of the remote token-presence probe

--- a/internal/doctor/remote_test.go
+++ b/internal/doctor/remote_test.go
@@ -39,18 +39,42 @@ func TestClassifyTunnelCheck(t *testing.T) {
 			wantContain: "could not run over SSH",
 		},
 		{
-			name:        "tunnel reachable",
-			out:         "tunnel ok",
+			name:        "daemon answering through tunnel",
+			out:         "cc-clip-probe:ok",
 			err:         nil,
 			wantOK:      true,
-			wantContain: "forwarded",
+			wantContain: "daemon answering",
 		},
 		{
 			name:        "tunnel not reachable",
-			out:         "tunnel fail",
+			out:         "cc-clip-probe:down",
 			err:         nil,
 			wantOK:      false,
 			wantContain: "not reachable from remote",
+		},
+		{
+			// The regression this check exists for: a stale sshd from a
+			// previous session still owns the LISTEN socket, so a TCP-only
+			// probe called this healthy and doctor stopped looking.
+			name:        "stale listener with no daemon behind it",
+			out:         "cc-clip-probe:stale",
+			err:         nil,
+			wantOK:      false,
+			wantContain: "no cc-clip daemon answered",
+		},
+		{
+			name:        "remote has no curl to verify with",
+			out:         "cc-clip-probe:unverified",
+			err:         nil,
+			wantOK:      false,
+			wantContain: "unverified",
+		},
+		{
+			name:        "probe output not recognized",
+			out:         "bash: /dev/tcp: No such file or directory",
+			err:         nil,
+			wantOK:      false,
+			wantContain: "did not complete",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/tunnel/remote_probe.go
+++ b/internal/tunnel/remote_probe.go
@@ -1,0 +1,116 @@
+package tunnel
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Markers the remote probe script prints. They are matched as substrings, so
+// they must not be prefixes of one another and must be unlikely to appear in
+// unrelated shell noise.
+const (
+	probeMarkerOK         = "cc-clip-probe:ok"
+	probeMarkerDown       = "cc-clip-probe:down"
+	probeMarkerStale      = "cc-clip-probe:stale"
+	probeMarkerUnverified = "cc-clip-probe:unverified"
+)
+
+// RemoteTunnelState is the outcome of probing the forwarded port from the
+// remote side.
+//
+// The distinction that matters is Down vs Stale. A TCP-only check cannot tell
+// them apart: an sshd child left over from a previous session keeps the LISTEN
+// socket on the forwarded port, so the handshake succeeds while nothing can
+// actually reach the daemon. Reporting that as a healthy tunnel is worse than
+// reporting nothing, because the operator stops looking.
+type RemoteTunnelState string
+
+const (
+	// RemoteTunnelOK means a cc-clip daemon answered GET /health through the
+	// tunnel. This is the only state that proves the data path works.
+	RemoteTunnelOK RemoteTunnelState = "ok"
+
+	// RemoteTunnelDown means nothing is listening on the forwarded port.
+	// Normal when no SSH session with RemoteForward is currently open.
+	RemoteTunnelDown RemoteTunnelState = "down"
+
+	// RemoteTunnelStale means the port accepted a TCP connection but no
+	// cc-clip daemon answered. Either a stale sshd from a previous session
+	// still owns the port, or the forward is live and the local daemon is
+	// not running.
+	RemoteTunnelStale RemoteTunnelState = "stale"
+
+	// RemoteTunnelUnverified means the port is reachable but the remote has
+	// no HTTP client to confirm the daemon with. Deliberately not folded
+	// into OK: reachability is not liveness.
+	RemoteTunnelUnverified RemoteTunnelState = "unverified"
+
+	// RemoteTunnelUnknown means the probe output could not be interpreted,
+	// so the check did not actually run to completion.
+	RemoteTunnelUnknown RemoteTunnelState = "unknown"
+)
+
+// Healthy reports whether the state proves the data path works. Only
+// RemoteTunnelOK qualifies; every other state, including Unverified and
+// Unknown, fails closed.
+func (s RemoteTunnelState) Healthy() bool {
+	return s == RemoteTunnelOK
+}
+
+// Summary returns a one-line operator-facing description of the state.
+func (s RemoteTunnelState) Summary(port int) string {
+	switch s {
+	case RemoteTunnelOK:
+		return fmt.Sprintf("port %d forwarded and cc-clip daemon answering", port)
+	case RemoteTunnelDown:
+		return fmt.Sprintf("port %d not reachable from remote", port)
+	case RemoteTunnelStale:
+		return fmt.Sprintf(
+			"port %d accepts connections but no cc-clip daemon answered "+
+				"(stale sshd forward from a previous session, or the local daemon is not running)",
+			port)
+	case RemoteTunnelUnverified:
+		return fmt.Sprintf("port %d reachable but daemon liveness unverified (no curl on remote)", port)
+	default:
+		return fmt.Sprintf("port %d check did not complete (unrecognized probe output)", port)
+	}
+}
+
+// RemoteHealthProbeCommand builds a POSIX sh command to run ON THE REMOTE that
+// classifies the forwarded port. It first checks TCP reachability, then asks
+// the daemon to identify itself via GET /health, and prints exactly one marker.
+//
+// /health is the only unauthenticated cc-clip endpoint, so the probe needs no
+// token and stays usable even when the remote token is stale.
+func RemoteHealthProbeCommand(port int) string {
+	return fmt.Sprintf(`if ! bash -c 'echo >/dev/tcp/127.0.0.1/%[1]d' 2>/dev/null; then
+  echo '%[2]s'
+elif ! command -v curl >/dev/null 2>&1; then
+  echo '%[3]s'
+else
+  _body=$(curl -sf --max-time 5 "http://127.0.0.1:%[1]d/health" 2>/dev/null) || _body=""
+  case "$_body" in
+    *'"service":"cc-clip"'*) echo '%[4]s' ;;
+    *) echo '%[5]s' ;;
+  esac
+fi`, port, probeMarkerDown, probeMarkerUnverified, probeMarkerOK, probeMarkerStale)
+}
+
+// ClassifyRemoteProbeOutput maps the probe script's output to a state. Output
+// is matched by substring so trailing shell noise (motd fragments, warnings)
+// does not defeat the classification. Anything unrecognized is Unknown rather
+// than being optimistically read as success.
+func ClassifyRemoteProbeOutput(out string) RemoteTunnelState {
+	switch {
+	case strings.Contains(out, probeMarkerOK):
+		return RemoteTunnelOK
+	case strings.Contains(out, probeMarkerStale):
+		return RemoteTunnelStale
+	case strings.Contains(out, probeMarkerUnverified):
+		return RemoteTunnelUnverified
+	case strings.Contains(out, probeMarkerDown):
+		return RemoteTunnelDown
+	default:
+		return RemoteTunnelUnknown
+	}
+}

--- a/internal/tunnel/remote_probe_test.go
+++ b/internal/tunnel/remote_probe_test.go
@@ -1,0 +1,216 @@
+package tunnel
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/shunmei/cc-clip/internal/shim"
+)
+
+func TestRemoteHealthProbeCommandTargetsLoopbackHealth(t *testing.T) {
+	cmd := RemoteHealthProbeCommand(18339)
+
+	// The probe must stay pinned to the remote's loopback interface: the
+	// forwarded port is bound there and nowhere else.
+	if !strings.Contains(cmd, "127.0.0.1/18339") {
+		t.Fatalf("probe command must TCP-check 127.0.0.1/18339, got:\n%s", cmd)
+	}
+	if !strings.Contains(cmd, "http://127.0.0.1:18339/health") {
+		t.Fatalf("probe command must GET the loopback /health endpoint, got:\n%s", cmd)
+	}
+	// Every branch has to emit a marker, otherwise the classifier cannot
+	// tell "the probe ran and found nothing" from "the probe never ran".
+	for _, marker := range []string{probeMarkerOK, probeMarkerDown, probeMarkerStale, probeMarkerUnverified} {
+		if !strings.Contains(cmd, marker) {
+			t.Fatalf("probe command must be able to emit %q, got:\n%s", marker, cmd)
+		}
+	}
+}
+
+func TestClassifyRemoteProbeOutput(t *testing.T) {
+	cases := []struct {
+		name string
+		out  string
+		want RemoteTunnelState
+	}{
+		{"healthy daemon", probeMarkerOK, RemoteTunnelOK},
+		{"nothing listening", probeMarkerDown, RemoteTunnelDown},
+		{"listener without cc-clip daemon", probeMarkerStale, RemoteTunnelStale},
+		{"no http client on remote", probeMarkerUnverified, RemoteTunnelUnverified},
+		{"marker with surrounding noise", "warning: blah\n" + probeMarkerOK + "\n", RemoteTunnelOK},
+		{"empty output", "", RemoteTunnelUnknown},
+		{"unrelated output", "bash: line 1: syntax error", RemoteTunnelUnknown},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyRemoteProbeOutput(tc.out); got != tc.want {
+				t.Fatalf("ClassifyRemoteProbeOutput(%q) = %q, want %q", tc.out, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRemoteTunnelStaleIsNotHealthy is the regression guard for the bug this
+// probe exists to fix: a stale sshd from a previous session still owns the
+// LISTEN socket, so a TCP-only check reports success for a tunnel that cannot
+// carry a single byte to the daemon. Stale must never be treated as healthy.
+func TestRemoteTunnelStaleIsNotHealthy(t *testing.T) {
+	for _, state := range []RemoteTunnelState{RemoteTunnelStale, RemoteTunnelDown, RemoteTunnelUnknown, RemoteTunnelUnverified} {
+		if state.Healthy() {
+			t.Fatalf("state %q must not report Healthy()", state)
+		}
+	}
+	if !RemoteTunnelOK.Healthy() {
+		t.Fatal("RemoteTunnelOK must report Healthy()")
+	}
+}
+
+func TestRemoteTunnelStateSummaryIsDistinctPerState(t *testing.T) {
+	states := []RemoteTunnelState{
+		RemoteTunnelOK,
+		RemoteTunnelDown,
+		RemoteTunnelStale,
+		RemoteTunnelUnverified,
+		RemoteTunnelUnknown,
+	}
+
+	seen := make(map[string]RemoteTunnelState, len(states))
+	for _, state := range states {
+		summary := state.Summary(18339)
+		if summary == "" {
+			t.Fatalf("state %q has an empty summary", state)
+		}
+		if prev, dup := seen[summary]; dup {
+			t.Fatalf("states %q and %q share the summary %q", prev, state, summary)
+		}
+		seen[summary] = state
+	}
+
+	// The stale summary is the one an operator acts on, so it must name both
+	// causes rather than sending them to look at only one.
+	stale := RemoteTunnelStale.Summary(18339)
+	for _, want := range []string{"stale", "daemon"} {
+		if !strings.Contains(strings.ToLower(stale), want) {
+			t.Fatalf("stale summary must mention %q, got %q", want, stale)
+		}
+	}
+}
+
+// requireProbeShellTools skips when the local machine cannot stand in for a
+// remote: the probe needs bash for /dev/tcp and curl for the health request.
+func requireProbeShellTools(t *testing.T) {
+	t.Helper()
+	for _, bin := range []string{"bash", "curl", "sh"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not available; skipping shell round-trip", bin)
+		}
+	}
+}
+
+// runProbeThroughLoginShell executes the probe exactly the way a remote does:
+// shim.WrapRemoteShell produces one command string, and the login shell parses
+// it. This is what catches single-quote escaping mistakes — the probe script
+// is full of quotes, and a broken one degrades silently into "unknown".
+func runProbeThroughLoginShell(t *testing.T, port int) string {
+	t.Helper()
+	wrapped := shim.WrapRemoteShell(RemoteHealthProbeCommand(port))
+	out, err := exec.Command("sh", "-c", wrapped).CombinedOutput()
+	if err != nil {
+		t.Fatalf("probe command failed to execute: %v\noutput: %s\nwrapped: %s", err, out, wrapped)
+	}
+	return string(out)
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind loopback: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+	return port
+}
+
+func TestRemoteProbeShellRoundTripHealthyDaemon(t *testing.T) {
+	requireProbeShellTools(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"service":"cc-clip","status":"ok"}`)
+	}))
+	defer ts.Close()
+
+	port := ts.Listener.Addr().(*net.TCPAddr).Port
+	got := ClassifyRemoteProbeOutput(runProbeThroughLoginShell(t, port))
+	if got != RemoteTunnelOK {
+		t.Fatalf("healthy daemon classified as %q, want %q", got, RemoteTunnelOK)
+	}
+}
+
+// TestRemoteProbeShellRoundTripStaleListener reproduces the actual bug: a
+// listener that completes the TCP handshake and then goes silent, exactly as a
+// stale sshd forward does. The old /dev/tcp-only probe called this healthy.
+func TestRemoteProbeShellRoundTripStaleListener(t *testing.T) {
+	requireProbeShellTools(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot bind loopback: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close() // accept, then drop — no HTTP is ever spoken
+		}
+	}()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+	got := ClassifyRemoteProbeOutput(runProbeThroughLoginShell(t, port))
+	if got != RemoteTunnelStale {
+		t.Fatalf("stale listener classified as %q, want %q", got, RemoteTunnelStale)
+	}
+}
+
+func TestRemoteProbeShellRoundTripNothingListening(t *testing.T) {
+	requireProbeShellTools(t)
+
+	port := freePort(t)
+	got := ClassifyRemoteProbeOutput(runProbeThroughLoginShell(t, port))
+	if got != RemoteTunnelDown {
+		t.Fatalf("closed port classified as %q, want %q", got, RemoteTunnelDown)
+	}
+}
+
+// TestRemoteProbeShellRoundTripRejectsNonCcClipService guards the identity
+// check: something else listening on the port (a different service, another
+// user's server) must not be accepted as a cc-clip daemon.
+func TestRemoteProbeShellRoundTripRejectsNonCcClipService(t *testing.T) {
+	requireProbeShellTools(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"service":"something-else","status":"ok"}`)
+	}))
+	defer ts.Close()
+
+	port := ts.Listener.Addr().(*net.TCPAddr).Port
+	got := ClassifyRemoteProbeOutput(runProbeThroughLoginShell(t, port))
+	if got != RemoteTunnelStale {
+		t.Fatalf("foreign service classified as %q, want %q", got, RemoteTunnelStale)
+	}
+}


### PR DESCRIPTION
Closes the P0 item of #22.

## The bug

`connect` and `doctor` both decided the tunnel was healthy from a bare TCP handshake:

```sh
bash -c 'echo >/dev/tcp/127.0.0.1/<port>'
```

An sshd child left over from a previous session keeps the forwarded port in `LISTEN` after its client is gone. The handshake succeeds, nothing reaches the daemon, and `connect` printed:

```
[7/7] Verifying tunnel from remote...
      tunnel verified (via existing SSH session)
```

`doctor` reported `port 18339 forwarded` for the same dead tunnel. This was the one place in the codebase that silently reported a wrong success — worse than reporting nothing, because the operator stops looking. Until now #22's P0 was only a manual workaround in `docs/troubleshooting.md`.

## The fix

Replace reachability with identity. The remote probe asks the daemon to identify itself through the forward via `GET /health` — the only unauthenticated endpoint, so no token is needed and a stale remote token cannot mask the result.

Two states become five:

| State | Meaning | `Healthy()` |
|---|---|---|
| `ok` | daemon answered — the data path provably works | yes |
| `down` | nothing listening; normal with no SSH session open | no |
| `stale` | port accepts but no cc-clip answered | no |
| `unverified` | reachable, but no `curl` on the remote to confirm with | no |
| `unknown` | probe output unrecognized — the check did not complete | no |

`unverified` and `unknown` deliberately fail closed. Reachability is not liveness, and a check that did not complete is not a pass.

## Guidance per state

The stale case previously inherited the "add `RemoteForward` to `~/.ssh/config`" advice, which sends the operator to fix the one thing already working. It now names both real causes:

```
      WARNING: port 18339 is held on the remote, but no cc-clip daemon answered.
      The port being open does NOT mean the tunnel works. Two known causes:
        1. A stale sshd from a previous SSH session still owns the forward.
           On the remote, find and end it: lsof -ti tcp:18339
        2. The forward is live but the local daemon is not running.
           On this machine, start it: cc-clip serve
      Then re-run: cc-clip doctor --host <host>
```

This also gives `tunnel.ProbeHealth`'s sibling logic its first production use — `ErrDaemonNotAnswering` documented exactly this distinction but had no callers outside tests.

## Tests

- **`internal/tunnel`** — table-driven classification, marker coverage, per-state summary distinctness, plus four **shell round-trips** that run the probe through `shim.WrapRemoteShell` and a real `/bin/sh` against `httptest` servers: a healthy daemon, a listener that accepts and drops (the actual bug), a foreign service on the port, and a closed port. These exist because the probe script is dense with single quotes and a broken escape would degrade silently to `unknown`.
- **`internal/doctor`** — stale, unverified and unrecognized outputs each assert not-OK.
- **`cmd/cc-clip`** — `tunnelVerificationReport` is extracted so guidance is testable without SSH; asserts no non-healthy state can emit "tunnel verified".

Verified with `go test ./... -race -count=1`, `go vet`, staticcheck, all clean.

## Note on CI

Branched from `main`, so the Govulncheck step is red for the reason fixed in #113, not because of this change. Rebase after #113 lands.
