### PR TITLE
fix(windows): abort paste when focus moves between copy and keystroke (#43)

### DIFF
--- a/cmd/cc-clip/focus_guard.go
+++ b/cmd/cc-clip/focus_guard.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// focusResult is one observation of which window currently has focus.
+//
+// Known is deliberately separate from Handle rather than being inferred from
+// it. GetForegroundWindow returns NULL while a window is losing activation, so
+// "I could not tell" is a genuine third state alongside "same window" and
+// "different window". Folding it into either of the other two turns the guard
+// into a boolean that fails open exactly when focus is in motion — which is
+// the only moment the guard matters.
+type focusResult struct {
+	Handle uintptr
+	Known  bool
+}
+
+// focusProbe reports which window currently has focus. The production
+// implementation lives with its only caller in send_windows.go; tests inject
+// their own so this decision logic stays runnable on every platform.
+type focusProbe func() focusResult
+
+var (
+	// errFocusUnknown means the focused window could not be determined,
+	// either when capturing or when re-checking.
+	errFocusUnknown = errors.New("focus could not be determined (no foreground window)")
+
+	// errFocusChanged means focus moved between the clipboard write and the
+	// keystroke.
+	errFocusChanged = errors.New("focus changed during paste")
+)
+
+// focusGuard remembers the window a paste was aimed at so the keystroke can be
+// withheld if focus moved in the meantime.
+//
+// The exposure window is wider than the configured delay: windowsSendCtrlShiftV
+// spawns a fresh `powershell -STA -NoProfile` process, so the clipboard holds
+// the remote path for the delay plus that cold start. Anything the user focuses
+// during that period — a password manager, a chat input, a browser URL bar —
+// would otherwise receive the keystroke.
+type focusGuard struct {
+	probe  focusProbe
+	origin uintptr
+}
+
+// newFocusGuard captures the window that currently has focus. It fails when the
+// foreground window cannot be identified, so callers never proceed on an
+// unverifiable target.
+func newFocusGuard(probe focusProbe) (*focusGuard, error) {
+	got := probe()
+	if !got.Known || got.Handle == 0 {
+		return nil, fmt.Errorf("%w; paste aborted before the clipboard was touched", errFocusUnknown)
+	}
+	return &focusGuard{probe: probe, origin: got.Handle}, nil
+}
+
+// verify reports whether focus still rests on the captured window. A non-nil
+// error means the keystroke must not be sent.
+func (g *focusGuard) verify() error {
+	got := g.probe()
+	if !got.Known || got.Handle == 0 {
+		return fmt.Errorf("%w; paste aborted, nothing was typed — retry with the target window focused", errFocusUnknown)
+	}
+	if got.Handle != g.origin {
+		return fmt.Errorf(
+			"%w; paste aborted, nothing was typed into the other window — retry without switching windows",
+			errFocusChanged,
+		)
+	}
+	return nil
+}

--- a/cmd/cc-clip/focus_guard_test.go
+++ b/cmd/cc-clip/focus_guard_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// staticProbe returns a focusProbe that yields the given results in order,
+// repeating the last one once exhausted.
+func staticProbe(results ...focusResult) focusProbe {
+	i := 0
+	return func() focusResult {
+		r := results[i]
+		if i < len(results)-1 {
+			i++
+		}
+		return r
+	}
+}
+
+func TestFocusGuardAllowsPasteWhenFocusIsUnchanged(t *testing.T) {
+	probe := staticProbe(focusResult{Handle: 0x1234, Known: true})
+
+	guard, err := newFocusGuard(probe)
+	if err != nil {
+		t.Fatalf("capturing a known foreground window must succeed: %v", err)
+	}
+	if err := guard.verify(); err != nil {
+		t.Fatalf("unchanged focus must verify: %v", err)
+	}
+}
+
+// TestFocusGuardAbortsWhenFocusMoved is the core of issue #43: the clipboard
+// holds the remote path across the delay plus a PowerShell cold start, and if
+// the user switches to a password manager or a browser URL bar in that window,
+// the keystroke lands in the wrong trust boundary.
+func TestFocusGuardAbortsWhenFocusMoved(t *testing.T) {
+	probe := staticProbe(
+		focusResult{Handle: 0x1234, Known: true}, // capture
+		focusResult{Handle: 0x5678, Known: true}, // verify: different window
+	)
+
+	guard, err := newFocusGuard(probe)
+	if err != nil {
+		t.Fatalf("capture must succeed: %v", err)
+	}
+
+	err = guard.verify()
+	if err == nil {
+		t.Fatal("a focus change must abort the paste")
+	}
+	if !errors.Is(err, errFocusChanged) {
+		t.Fatalf("expected errFocusChanged, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "aborted") {
+		t.Fatalf("abort error must say the paste was aborted, got %q", err)
+	}
+}
+
+// TestFocusGuardFailsClosedWhenFocusIsUnknown pins the tri-state contract.
+// GetForegroundWindow returns NULL while a window is losing activation, so
+// "unknown" is a real third state. Collapsing it into "same" would fail open
+// and paste into whatever happens to be focused — the exact defect class this
+// guard exists to prevent.
+func TestFocusGuardFailsClosedWhenFocusIsUnknown(t *testing.T) {
+	t.Run("unknown at capture", func(t *testing.T) {
+		probe := staticProbe(focusResult{Known: false})
+
+		_, err := newFocusGuard(probe)
+		if err == nil {
+			t.Fatal("an undeterminable foreground window must not produce a usable guard")
+		}
+		if !errors.Is(err, errFocusUnknown) {
+			t.Fatalf("expected errFocusUnknown, got %v", err)
+		}
+	})
+
+	t.Run("unknown at verify", func(t *testing.T) {
+		probe := staticProbe(
+			focusResult{Handle: 0x1234, Known: true},
+			focusResult{Known: false},
+		)
+
+		guard, err := newFocusGuard(probe)
+		if err != nil {
+			t.Fatalf("capture must succeed: %v", err)
+		}
+
+		err = guard.verify()
+		if err == nil {
+			t.Fatal("an undeterminable foreground window at verify time must abort")
+		}
+		if !errors.Is(err, errFocusUnknown) {
+			t.Fatalf("expected errFocusUnknown, got %v", err)
+		}
+	})
+}
+
+// TestFocusGuardTreatsZeroHandleAsUnknown guards against a probe that reports
+// Known while handing back a NULL handle. NULL identifies no window, so it can
+// never be compared meaningfully.
+func TestFocusGuardTreatsZeroHandleAsUnknown(t *testing.T) {
+	probe := staticProbe(focusResult{Handle: 0, Known: true})
+
+	if _, err := newFocusGuard(probe); !errors.Is(err, errFocusUnknown) {
+		t.Fatalf("a NULL handle must be treated as unknown, got %v", err)
+	}
+}
+
+func TestFocusGuardErrorsExplainTheRemedy(t *testing.T) {
+	changed := staticProbe(
+		focusResult{Handle: 0x1234, Known: true},
+		focusResult{Handle: 0x5678, Known: true},
+	)
+	guard, err := newFocusGuard(changed)
+	if err != nil {
+		t.Fatalf("capture must succeed: %v", err)
+	}
+	msg := guard.verify().Error()
+
+	// The operator needs to know nothing was typed into the other window and
+	// what to do next.
+	for _, want := range []string{"focus", "aborted", "retry"} {
+		if !strings.Contains(strings.ToLower(msg), want) {
+			t.Fatalf("focus-change error must mention %q, got %q", want, msg)
+		}
+	}
+}

--- a/cmd/cc-clip/send_windows.go
+++ b/cmd/cc-clip/send_windows.go
@@ -7,7 +7,18 @@ import (
 	"os"
 	"os/exec"
 	"time"
+
+	"github.com/shunmei/cc-clip/internal/win32"
 )
+
+// systemFocusProbe is the production focusProbe. It lives here rather than
+// alongside the guard logic because Windows is the only platform that can
+// answer the question, and the guard's decision logic stays build-tag-free so
+// it remains testable everywhere.
+func systemFocusProbe() focusResult {
+	h, ok := win32.ForegroundWindow()
+	return focusResult{Handle: h, Known: ok}
+}
 
 // hiddenExec creates an exec.Cmd that won't flash a console window.
 func hiddenExec(name string, args ...string) *exec.Cmd {
@@ -28,12 +39,35 @@ func defaultRemoteHost() (string, bool, error) {
 }
 
 func pasteRemotePath(remotePath, imagePath string, delay time.Duration, restoreClipboard bool) error {
+	// Pin the window this paste is aimed at BEFORE touching the clipboard.
+	// The keystroke below goes to whatever is focused when it fires, and the
+	// gap is wider than `delay` alone: windowsSendCtrlShiftV spawns a fresh
+	// PowerShell process, so its cold start counts too. Without this guard a
+	// window switch in that gap delivers the remote path into whatever the
+	// user moved to — a password manager, a chat box, a browser URL bar.
+	guard, err := newFocusGuard(systemFocusProbe)
+	if err != nil {
+		return err
+	}
+
 	if err := windowsSetClipboardText(remotePath); err != nil {
 		return err
 	}
 
 	if delay > 0 {
 		time.Sleep(delay)
+	}
+
+	if err := guard.verify(); err != nil {
+		// Withhold the keystroke. cc-clip never snapshots the user's prior
+		// clipboard, so the most we can undo is our own text write — put the
+		// image back when the caller asked for restoration.
+		if restoreClipboard {
+			if restoreErr := windowsSetClipboardImage(imagePath); restoreErr != nil {
+				return fmt.Errorf("%w (clipboard restore also failed: %v)", err, restoreErr)
+			}
+		}
+		return err
 	}
 
 	if err := windowsSendCtrlShiftV(); err != nil {

--- a/docs/windows-quickstart.md
+++ b/docs/windows-quickstart.md
@@ -109,6 +109,20 @@ The hotkey/send path is static: it sends to the configured host. If you use
 several remote hosts at the same time, run an explicit one-shot command with
 the host you want, or use separate hotkey configuration per workflow.
 
+> **Focus guard.** The paste is delivered as a synthesized `Ctrl+Shift+V`, which
+> goes to whichever window is focused when it fires — and the gap is not only
+> the configured `--delay-ms`, it also covers the PowerShell process start.
+> `cc-clip` therefore records the focused window before writing the clipboard
+> and re-checks it immediately before the keystroke. If focus moved, the paste
+> is **aborted and nothing is typed**, so the remote path cannot land in a
+> password field, a chat input, or a browser URL bar.
+>
+> An aborted paste reports `focus changed during paste` and is logged to
+> `~/.cache/cc-clip/hotkey.log`. Re-focus the target window and press the
+> hotkey again. The guard also aborts when Windows reports no foreground
+> window at all, which happens briefly while a window is losing activation —
+> retrying with the window focused is the fix.
+
 ## Experimental: Direct Remote Clipboard
 
 This section is for source builds and future explicit prereleases only. It is

--- a/internal/win32/foreground_other.go
+++ b/internal/win32/foreground_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package win32
+
+// ForegroundWindow has no meaning off Windows, so it always reports that the
+// focused window is unknown. Callers fail closed on that, which is correct:
+// the paste path it guards is Windows-only.
+func ForegroundWindow() (handle uintptr, ok bool) {
+	return 0, false
+}

--- a/internal/win32/foreground_windows.go
+++ b/internal/win32/foreground_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package win32
+
+import "syscall"
+
+var (
+	user32DLL             = syscall.NewLazyDLL("user32.dll")
+	procGetForegroundWind = user32DLL.NewProc("GetForegroundWindow")
+)
+
+// ForegroundWindow returns a handle to the window the user is currently
+// working in, and whether it could be determined.
+//
+// GetForegroundWindow returns NULL when no window has focus — notably while a
+// window is losing activation. That is reported as ok=false rather than as
+// handle 0 so callers cannot accidentally compare two "no window" observations
+// and conclude focus was unchanged.
+func ForegroundWindow() (handle uintptr, ok bool) {
+	h, _, _ := procGetForegroundWind.Call()
+	if h == 0 {
+		return 0, false
+	}
+	return h, true
+}


### PR DESCRIPTION
Closes #43.

## The bug

`pasteRemotePath` wrote the remote path to the clipboard, slept `--delay-ms` (default 150), then synthesized `Ctrl+Shift+V` against whatever window happened to be focused at that moment. A window switch in that gap delivered the remote path into the wrong trust boundary — a password manager, a chat input, a browser URL bar.

The gap is wider than #43's title suggests: `windowsSendCtrlShiftV` spawns a fresh `powershell -STA -NoProfile` for `SendKeys::SendWait`, so the clipboard carries the path for the configured delay **plus that process cold start**.

## The fix

Capture the foreground window before the clipboard is touched, re-check it immediately before the keystroke, and withhold the keystroke if it moved. Since cc-clip never snapshots the user's prior clipboard, an abort undoes only our own write by restoring the image, and only when the caller asked for restoration.

## Why focus is tri-state, not a boolean

`GetForegroundWindow` returns `NULL` while a window is losing activation, so "could not tell" is a real state distinct from "same window". A same/different comparison folds `NULL` into "same" and **fails open at exactly the moment focus is in motion** — the defect class this guard exists to prevent.

So: unknown aborts, both at capture and at verify, and a `NULL` handle is treated as unknown even if the probe claims otherwise.

## Layout — testable without a Windows machine

Every existing Windows test in this repo is `//go:build windows` and cannot execute on the maintainer's machine. This change keeps the decision logic runnable everywhere:

| File | Build tag | Role |
|---|---|---|
| `internal/win32/foreground_windows.go` | `windows` | binds `GetForegroundWindow` via `syscall.NewLazyDLL`, mirroring the existing `HideConsoleWindow` pairing |
| `internal/win32/foreground_other.go` | `!windows` | reports unknown |
| `cmd/cc-clip/focus_guard.go` | **none** | decision logic behind an injectable `focusProbe` seam |
| `cmd/cc-clip/focus_guard_test.go` | **none** | runs on darwin/linux with a fake probe |
| `cmd/cc-clip/send_windows.go` | `windows` | the production probe, kept next to its only caller so the linux staticcheck run sees no unused symbol |

The binding lives in `internal/win32`, not `package main`, where `user32DLL` is already declared in `tray_windows.go`.

Verified on darwin/arm64: `go test ./... -race`, plus `GOOS=windows` build, vet, and `go test -c` for `cmd/cc-clip`. Staticcheck clean on the default (linux) target.

## Docs regression fixed alongside

`df42fae`'s 251-line rewrite of `docs/windows-quickstart.md` dropped the interim focus warning added by `d9e8007` (#45). `grep -c` for it is 0 at HEAD and 1 at `eaea0a5`, and the READMEs never carried it — so HEAD shipped **neither a guard nor a warning**. The section is restored and rewritten to describe the guard that now exists: an abort types nothing, reports `focus changed during paste`, and is logged to `~/.cache/cc-clip/hotkey.log`.

## Deliberately not included

#43 lists an optional `force` flag for users who know what they are doing. Left out to keep this diff to the guard itself — worth a follow-up if anyone hits a legitimate case where `GetForegroundWindow` stays `NULL`. The other two optional items need no code: abort events already reach `hotkey.log` via `log.Printf` at the hotkey loop, and "restore the original clipboard" is restated honestly as "undo our own write", since cc-clip never snapshots what was there before.

## Note on CI

Branched from `main`, so the Govulncheck step is red for the reason fixed in #113, not because of this change. Rebase after #113 lands.
