### PR TITLE
fix(daemon): distinguish /notify auth failure classes (#20 I3)

### DIFF
--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -32,6 +32,7 @@ const (
 	userAgent         = "cc-clip"
 	criticalChCap     = 4
 	claudeHookCType   = "application/x-claude-hook"
+	bearerPrefix      = "Bearer "
 )
 
 // sizeLimitMB reads a whole-megabyte clipboard cap override from env.
@@ -582,11 +583,28 @@ func (s *Server) handleClipboardText(w http.ResponseWriter, r *http.Request) {
 // or generic senders. Auth is via notification nonce (separate from
 // clipboard bearer token).
 func (s *Server) handleNotify(w http.ResponseWriter, r *http.Request) {
-	nonce := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-	boundHost, ok := "", false
-	if nonce != "" {
-		boundHost, ok = s.lookupValidNonce(nonce)
+	// Each auth failure gets its own message so notify-health.log tells an
+	// operator which step broke: a hook deployed before any nonce existed
+	// sends no header at all, a hand-rolled sender usually gets the scheme
+	// wrong, and a rotated nonce is well-formed but unknown. Collapsing all
+	// three into one string made those cases indistinguishable in the field.
+	// Mirrors authMiddleware's handling of the clipboard token. No nonce
+	// value is ever echoed back.
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		http.Error(w, "missing authorization header", http.StatusUnauthorized)
+		return
 	}
+	if !strings.HasPrefix(auth, bearerPrefix) {
+		http.Error(w, `malformed authorization header: expected "Bearer <nonce>"`, http.StatusUnauthorized)
+		return
+	}
+	nonce := strings.TrimPrefix(auth, bearerPrefix)
+	if nonce == "" {
+		http.Error(w, "empty notification nonce", http.StatusUnauthorized)
+		return
+	}
+	boundHost, ok := s.lookupValidNonce(nonce)
 	if !ok {
 		http.Error(w, "invalid notification nonce", http.StatusUnauthorized)
 		return

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -658,6 +658,101 @@ func TestNotifyEndpointRejectsMissingAuth(t *testing.T) {
 	}
 }
 
+// TestNotifyEndpointDistinguishesAuthFailures pins the /notify 401 bodies so
+// an operator reading notify-health.log can tell WHICH auth step failed. All
+// four cases previously collapsed into "invalid notification nonce", which
+// made a hook that never got a nonce installed indistinguishable from one
+// whose nonce was rotated out from under it.
+func TestNotifyEndpointDistinguishesAuthFailures(t *testing.T) {
+	// Cases in the same class SHOULD share a message; the operator only needs
+	// to tell the classes apart. Uniqueness is therefore asserted per class.
+	cases := []struct {
+		name     string
+		class    string
+		setAuth  bool
+		auth     string
+		wantBody string
+	}{
+		{
+			name:     "no authorization header",
+			class:    "missing",
+			setAuth:  false,
+			wantBody: "missing authorization header",
+		},
+		{
+			name:     "non-bearer scheme",
+			class:    "malformed",
+			setAuth:  true,
+			auth:     "Basic bm9uY2U=",
+			wantBody: "malformed authorization header",
+		},
+		{
+			name:     "bare nonce without bearer prefix",
+			class:    "malformed",
+			setAuth:  true,
+			auth:     "nonce-registered",
+			wantBody: "malformed authorization header",
+		},
+		{
+			name:     "bearer prefix with empty nonce",
+			class:    "empty",
+			setAuth:  true,
+			auth:     "Bearer ",
+			wantBody: "empty notification nonce",
+		},
+		{
+			name:     "well-formed but unknown nonce",
+			class:    "invalid",
+			setAuth:  true,
+			auth:     "Bearer nonce-unknown",
+			wantBody: "invalid notification nonce",
+		},
+	}
+
+	bodyByClass := make(map[string]string, len(cases))
+	classByBody := make(map[string]string, len(cases))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clip := &mockClipboard{}
+			tm := token.NewManager(time.Hour)
+			_, _ = tm.Generate()
+			store := session.NewStore(12 * time.Hour)
+			srv := NewServer("127.0.0.1:0", clip, tm, store)
+			srv.RegisterNotificationNonce("nonce-registered")
+
+			body := strings.NewReader(`{"title":"test","body":"hello"}`)
+			req := httptest.NewRequest("POST", "/notify", body)
+			if tc.setAuth {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != http.StatusUnauthorized {
+				t.Fatalf("expected 401, got %d; body: %s", w.Code, w.Body.String())
+			}
+			got := strings.TrimSpace(w.Body.String())
+			if !strings.Contains(got, tc.wantBody) {
+				t.Fatalf("expected body to contain %q, got %q", tc.wantBody, got)
+			}
+			// The nonce itself must never be echoed back to the caller.
+			if strings.Contains(got, "nonce-registered") || strings.Contains(got, "nonce-unknown") {
+				t.Fatalf("401 body leaks a nonce value: %q", got)
+			}
+			if prev, seen := bodyByClass[tc.class]; seen && prev != got {
+				t.Fatalf("class %q is inconsistent: %q vs %q", tc.class, prev, got)
+			}
+			if prev, seen := classByBody[got]; seen && prev != tc.class {
+				t.Fatalf("classes %q and %q share the body %q; auth failure classes must stay distinguishable", prev, tc.class, got)
+			}
+			bodyByClass[tc.class] = got
+			classByBody[got] = tc.class
+		})
+	}
+}
+
 func TestNotifyEndpointAcceptsGenericJSON(t *testing.T) {
 	clip := &mockClipboard{}
 	tm := token.NewManager(time.Hour)


### PR DESCRIPTION
Closes item **I3** of #20.

## The bug

`handleNotify` collapsed every auth failure into one 401:

```go
nonce := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
boundHost, ok := "", false
if nonce != "" { boundHost, ok = s.lookupValidNonce(nonce) }
if !ok {
    http.Error(w, "invalid notification nonce", http.StatusUnauthorized)
    return
}
```

So `notify-health.log` could not tell an operator whether the hook had no nonce installed at all, sent a malformed header, or was using a nonce that had been rotated out from under it — three different problems with three different fixes.

## The fix

Split it into the shape `authMiddleware` already uses for the clipboard token, 165 lines earlier in the same file:

| Condition | 401 body |
|---|---|
| header absent | `missing authorization header` |
| non-`Bearer ` scheme | `malformed authorization header: expected "Bearer <nonce>"` |
| `Bearer ` + empty rest | `empty notification nonce` |
| well-formed, unknown | `invalid notification nonce` |

All stay 401 and none echo a nonce value.

## Also closes an unnoticed parsing laxity

`strings.TrimPrefix` returns its input unchanged when the prefix is absent, so an `Authorization` header carrying a **bare nonce with no `Bearer ` prefix was accepted**. The added test caught this: that case returned 204, not 401.

The prefix is now required. Confirmed safe — every in-repo sender uses `Bearer `:

- `internal/shim/hook_template.go`
- `internal/plugin/notify.go`
- `internal/tunnel/fetch.go`
- `internal/x11bridge/bridge.go`
- `cmd/cc-clip`

and `docs/notifications.md`'s documented `curl` example does too.

## Blast radius

Message text only. `cc-clip-hook` pipes the response body to `/dev/null` and branches solely on `%{http_code}`, and all existing `/notify` auth assertions check `w.Code`.

## Test

`TestNotifyEndpointDistinguishesAuthFailures` asserts each class returns 401 with its own message, that cases in the same class share a message, that different classes never collide, and that no nonce value leaks into a 401 body.

`go test ./... -race -count=1`, `go vet`, staticcheck all clean.

## Note on CI

Branched from `main`, so the Govulncheck step is red for the reason fixed in #113, not because of this change. Rebase after #113 lands.
