### PR TITLE
fix(ci): bump Go floor to 1.25.13 to clear GO-2026-6089/6090/6218

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/shunmei/cc-clip
 
-go 1.25.12
+go 1.25.13
 
 require github.com/jezek/xgb v1.3.0 // indirect


### PR DESCRIPTION
## Immediate unblock

Three stdlib advisories were published after #113 landed, all fixed in `go1.25.13`:

| Advisory | Package | Reached from |
|---|---|---|
| GO-2026-6089 | `net/http` | `daemon.Server.ListenAndServe` |
| GO-2026-6090 | `crypto/tls` | `ListenAndServe`, `shim.LocalBinaryHash`, `hosts.FormatRedeployReminder`, `plugin.PostNotification` |
| GO-2026-6218 | `net/url` | `plugin.PostNotification` |

Verified with `GOTOOLCHAIN=go1.25.13`: build, vet, `go test ./... -race -count=1`, and govulncheck all pass — `No vulnerabilities found`.

## The recurrence is the point

CI went red again **two days** after #113, with no source change. That is exactly what #113's closing note flagged:

> Pinning a full patch version in `go.mod` while scanning with `govulncheck@latest` means CI will go red again on the next stdlib advisory, with no code change involved.

`go.mod` currently pins a full patch version, and `.github/workflows/ci.yml` installs the toolchain from it with `go-version-file: go.mod`. So a rolling advisory database is being evaluated against a frozen toolchain. Every new stdlib advisory is an unavoidable red build, and the only remedy is another one-line bump like this one. That is not a sustainable steady state — it also means a genuinely important advisory looks identical to routine noise.

## Options for the steady state

**A — keep as-is.** Accept that `go.mod` pins the exact toolchain and treat these bumps as routine maintenance. Most reproducible; guarantees recurring red builds between advisory and bump.

**B — make `go.mod` a floor instead of a pin.** Write the directive as a minor version (`go 1.25`) so `setup-go` resolves the newest patch. This matches how the directive is conventionally used — "requires Go 1.25+", not "requires exactly 1.25.13". Worth confirming `setup-go`'s resolution behaviour for a patchless directive before relying on it.

**C — separate build floor from scan target.** Keep `go.mod` pinned for builds, and give the Govulncheck step its own `setup-go` with `go-version: 'stable'`. Unambiguous, and it draws the right line: the pin says what the project is guaranteed to build with, the scan says whether current Go has a problem this code reaches.

The tradeoff between B and C is what a red Govulncheck should *mean*. Under B and C it means "current Go has a vulnerability this code reaches" — actionable. Under A it means "the pinned floor has a known vulnerability" — also true, but it fires on a schedule set by the Go security team rather than by anything in this repo.

This PR does not implement any of them; it only unblocks. Happy to follow up with whichever you pick.
