### PR TITLE
ci: scan with current Go, and enforce the agent-config gitignore policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Builds and tests against the toolchain go.mod declares. This job answers
+  # "does the project build and pass on the version we promise to support".
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # These paths are per-machine agent tooling, excluded by .gitignore.
+      # Enforced here because .gitignore only stops accidental adds — a
+      # forced add or an API-created commit walks straight past it, which is
+      # how #99 landed and had to be reverted in #102.
+      - name: Policy - agent tool config stays untracked
+        run: |
+          matches=$(git ls-files -- .claude .codex .agents AGENTS.md '*/AGENTS.md')
+          if [ -n "$matches" ]; then
+            echo "::error::Per-machine agent tool config must not be committed (see .gitignore):"
+            echo "$matches"
+            exit 1
+          fi
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -33,6 +48,26 @@ jobs:
 
       - name: Staticcheck
         run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
+  # Scans against the CURRENT Go release, not the pinned floor.
+  #
+  # These are deliberately separate concerns. go.mod pins a full patch version,
+  # so running govulncheck under it evaluates a rolling advisory database
+  # against a frozen toolchain: every new stdlib advisory turns CI red with no
+  # source change and no action available except bumping the pin. That happened
+  # twice in three days (#113, then #119 two days later).
+  #
+  # Reading it here means "current Go has a vulnerability this code actually
+  # reaches", which is actionable. Bumping the go.mod floor stays a deliberate
+  # compatibility decision instead of being forced by the advisory schedule.
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
 
       - name: Govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
Implements option **C** from #119, plus the repo-policy guard that #118 made necessary.

## 1. Scan with current Go, build with the pinned floor

`go.mod` pins a full patch version, and the workflow installed the toolchain from it via `go-version-file: go.mod`. So Govulncheck was evaluating a **rolling advisory database against a frozen toolchain**. Every new stdlib advisory turned CI red with no source change and no remedy except bumping the pin.

That is not hypothetical — it fired twice in three days:

| PR | Advisory | Gap |
|---|---|---|
| #113 | GO-2026-5856 | red on `main` for ~4 weeks before anyone looked |
| #119 | GO-2026-6089 / 6090 / 6218 | **2 days** after #113 landed |

Govulncheck now runs in its own job under `go-version: stable`. Build, vet, test and staticcheck keep using the `go.mod` floor.

The split matters because the two jobs answer different questions, and conflating them was the actual defect:

- **`test`** — does this build and pass on the version we promise to support?
- **`vulncheck`** — does current Go have a vulnerability this code actually reaches?

Under the old arrangement a red Govulncheck meant "the pinned floor has a known vulnerability" — true, but it fires on a schedule set by the Go security team rather than by anything in this repo, so a genuinely urgent advisory looked identical to routine noise. Now a red `vulncheck` is actionable, and bumping the `go.mod` floor goes back to being a deliberate compatibility decision.

## 2. Enforce the agent-config exclusion

`.gitignore` already says:

```gitignore
# Local tool artifacts (per-machine, not part of the repo)
.claude/
```

But `.gitignore` only stops *accidental* adds. A forced add or an API-created commit walks straight past it — which is exactly how the generated ECC bundle landed in #99 and had to be reverted in #102. It has been re-proposed twice since, in #112 and #118, and #118 was opened **one minute after** #119's merge commit hit `main`, so the regeneration is triggered by pushes to the default branch. Closing each one by hand does not converge.

A `git ls-files` check now fails the build when `.claude/`, `.codex/`, `.agents/` or `AGENTS.md` are tracked, turning that `.gitignore` comment into something enforced.

This does not stop the PRs from being opened — only an integration setting can do that — but it makes the outcome automatic and unambiguous instead of depending on someone noticing.

## Verification

- `git ls-files -- .claude .codex .agents AGENTS.md '*/AGENTS.md'` returns nothing on current `main`, so the guard does not fire on legitimate state.
- Both pathspec forms were checked against known-tracked paths (`git ls-files -- internal` and `git ls-files -- '*/main.go'`) to confirm the directory and glob forms behave as intended.
- Workflow YAML parses to the two expected jobs with the expected step order.
