### PR TITLE
docs: align tunnel troubleshooting with the health probe

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,7 +32,13 @@ ssh myserver 'CC_CLIP_DEBUG=1 xclip -selection clipboard -t TARGETS -o'
 
 ## SSH ControlMaster Breaks RemoteForward
 
-**Symptom:** `cc-clip connect` reports "tunnel verified", but the tunnel doesn't work in your interactive SSH session. `curl -s http://127.0.0.1:18339/health` hangs on the remote.
+**Symptom:** `cc-clip connect` warns that the port is held on the remote but no cc-clip daemon answered, and `curl -s http://127.0.0.1:18339/health` hangs on the remote:
+
+```
+      WARNING: port 18339 is held on the remote, but no cc-clip daemon answered.
+```
+
+(Before v0.9.2 this same situation was misreported as `tunnel verified`, because the check only completed a TCP handshake.)
 
 **Cause:** If you use SSH `ControlMaster auto` (connection multiplexing), the first SSH connection becomes the "master". All subsequent connections **reuse the master** — even if you later add `RemoteForward` to your config. The old master connection does not have the port forwarding, so the tunnel silently fails.
 

--- a/docs/windows-quickstart.md
+++ b/docs/windows-quickstart.md
@@ -246,11 +246,19 @@ If experimental direct paste does not work:
     type $HOME\.ssh\config
     ```
 
-3. Open a new SSH session and check the remote can see the tunnel:
+3. Open a new SSH session and check the remote can reach the daemon through
+   the tunnel:
 
     ```sh
-    bash -c 'echo >/dev/tcp/127.0.0.1/18339' && echo ok
+    curl -sf http://127.0.0.1:18339/health
     ```
+
+    A healthy tunnel answers `{"service":"cc-clip","status":"ok"}`. Do not use
+    a bare TCP check such as `bash -c 'echo >/dev/tcp/127.0.0.1/18339'` — a
+    stale `sshd` from an earlier session keeps the port open after its client
+    is gone, so the handshake succeeds while nothing reaches the daemon. That
+    is why `cc-clip connect` and `cc-clip doctor` ask the daemon to identify
+    itself instead.
 
 4. Confirm the shim is first in `PATH`:
 


### PR DESCRIPTION
Release blocker for v0.9.2, found during release preflight.

#114 stopped accepting a bare TCP handshake as proof the tunnel works, because a stale `sshd` keeps the forwarded port in `LISTEN` after its client is gone. Two docs still taught exactly that check, so tagging v0.9.2 would ship documentation that contradicts the tool.

### `docs/windows-quickstart.md`

Told users to verify the tunnel with:

```sh
bash -c 'echo >/dev/tcp/127.0.0.1/18339' && echo ok
```

Replaced with a `/health` request. The bare TCP form is kept as an explicit counter-example with the reason it misleads, since it is the intuitive thing to reach for.

### `docs/troubleshooting.md`

The "SSH ControlMaster Breaks RemoteForward" section is keyed on the symptom `cc-clip connect reports "tunnel verified"`. After #114 that string is no longer emitted in this situation, so someone hitting the problem could no longer find the section by its symptom. Updated to the warning they now see, with a parenthetical about the pre-v0.9.2 wording so the section stays findable for anyone upgrading from an older version.

Verified: `grep -rn 'dev/tcp' docs/ README*.md` now returns only the counter-example.

Docs only, no behavior change.