### PR TITLE
ci: gate the release on the same checks CI runs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,98 @@
+name: Checks
+
+# The single definition of "does this commit pass". Called by ci.yml on pull
+# requests and pushes to main, and by release.yml before it publishes a tag.
+#
+# It lives in its own reusable workflow rather than being duplicated so the two
+# callers cannot drift. A tag push does not trigger ci.yml (that fires on
+# pull_request and push to main only), so before this existed the release
+# commit was published without ever running the race tests, staticcheck,
+# govulncheck, or the agent-config policy check.
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  # Builds and tests against the toolchain go.mod declares. This job answers
+  # "does the project build and pass on the version we promise to support".
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # These paths are per-machine agent tooling, excluded by .gitignore.
+      # Enforced here because .gitignore only stops accidental adds — a
+      # forced add or an API-created commit walks straight past it, which is
+      # how #99 landed and had to be reverted in #102.
+      - name: Policy - agent tool config stays untracked
+        run: |
+          matches=$(git ls-files -- .claude .codex .agents AGENTS.md '*/AGENTS.md')
+          if [ -n "$matches" ]; then
+            echo "::error::Per-machine agent tool config must not be committed (see .gitignore):"
+            echo "$matches"
+            exit 1
+          fi
+
+      # goreleaser's archive naming and the two installers must agree, or
+      # published assets 404 on download. Checked on every commit rather than
+      # only at tag time, so a PR that breaks the contract fails while it is
+      # still cheap to fix.
+      - name: Policy - release asset naming contract
+        run: |
+          # goreleaser must produce cc-clip_{version}_{os}_{arch}.tar.gz
+          # -E (ERE) rather than -P (PCRE) so the same pattern is portable
+          # between the Ubuntu runner's GNU grep and BSD grep on developer
+          # macOS machines running `make release-preflight`.
+          grep -qE 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
+          # install.sh must expect the same format with version stripped of v prefix
+          # (-F is literal match: the pattern contains ${...} / . which are
+          #  regex metacharacters — -F keeps this robust across grep flavors.)
+          grep -Fq 'cc-clip_${VERSION#v}_${PLATFORM}.tar.gz' scripts/install.sh
+          # Windows installer must expect the matching zip artifact.
+          grep -Fq '$archiveName = "cc-clip_$($version.TrimStart("v"))_${platform}.zip"' scripts/install.ps1
+          # goreleaser archives must default to tar.gz (darwin/linux); windows
+          # uses the `formats: [zip]` override in the same block. Schema is the
+          # plural GoReleaser v2 form introduced in PR #33.
+          grep -Fq 'formats: [tar.gz]' .goreleaser.yaml
+          grep -Fq 'formats: [zip]' .goreleaser.yaml
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test (race)
+        run: go test ./... -race -count=1
+
+      - name: Staticcheck
+        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+
+  # Scans against the CURRENT Go release, not the pinned floor.
+  #
+  # These are deliberately separate concerns. go.mod pins a full patch version,
+  # so running govulncheck under it evaluates a rolling advisory database
+  # against a frozen toolchain: every new stdlib advisory turns CI red with no
+  # source change and no action available except bumping the pin. That happened
+  # twice in three days (#113, then #119 two days later).
+  #
+  # Reading it here means "current Go has a vulnerability this code actually
+  # reaches", which is actionable. Bumping the go.mod floor stays a deliberate
+  # compatibility decision instead of being forced by the advisory schedule.
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: stable
+
+      - name: Govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,61 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Builds and tests against the toolchain go.mod declares. This job answers
-  # "does the project build and pass on the version we promise to support".
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      # These paths are per-machine agent tooling, excluded by .gitignore.
-      # Enforced here because .gitignore only stops accidental adds — a
-      # forced add or an API-created commit walks straight past it, which is
-      # how #99 landed and had to be reverted in #102.
-      - name: Policy - agent tool config stays untracked
-        run: |
-          matches=$(git ls-files -- .claude .codex .agents AGENTS.md '*/AGENTS.md')
-          if [ -n "$matches" ]; then
-            echo "::error::Per-machine agent tool config must not be committed (see .gitignore):"
-            echo "$matches"
-            exit 1
-          fi
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: go.mod
-
-      - name: Build
-        run: go build ./...
-
-      - name: Vet
-        run: go vet ./...
-
-      - name: Test (race)
-        run: go test ./... -race -count=1
-
-      - name: Staticcheck
-        run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
-
-  # Scans against the CURRENT Go release, not the pinned floor.
-  #
-  # These are deliberately separate concerns. go.mod pins a full patch version,
-  # so running govulncheck under it evaluates a rolling advisory database
-  # against a frozen toolchain: every new stdlib advisory turns CI red with no
-  # source change and no action available except bumping the pin. That happened
-  # twice in three days (#113, then #119 two days later).
-  #
-  # Reading it here means "current Go has a vulnerability this code actually
-  # reaches", which is actionable. Bumping the go.mod floor stays a deliberate
-  # compatibility decision instead of being forced by the advisory schedule.
-  vulncheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: stable
-
-      - name: Govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+  # The gates themselves live in checks.yml so release.yml runs exactly the
+  # same set before publishing a tag, with no chance of the two drifting.
+  checks:
+    uses: ./.github/workflows/checks.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,23 @@ on:
     tags:
       - "v*"
 
+# Read by default; only the publishing job is granted write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  # A tag push does not trigger ci.yml, which fires on pull_request and push to
+  # main only. Without this the release commit was published having run nothing
+  # but `make test` — no race detector, no staticcheck, no govulncheck, and
+  # none of the repo policy checks.
+  checks:
+    uses: ./.github/workflows/checks.yml
+
   release:
+    needs: checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -19,28 +30,6 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-
-      - name: Run tests
-        run: make test
-
-      - name: Verify release contract
-        run: |
-          # goreleaser must produce cc-clip_{version}_{os}_{arch}.tar.gz
-          # -E (ERE) rather than -P (PCRE) so the same pattern is portable
-          # between the Ubuntu runner's GNU grep and BSD grep on developer
-          # macOS machines running `make release-preflight`.
-          grep -qE 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml
-          # install.sh must expect the same format with version stripped of v prefix
-          # (-F is literal match: the pattern contains ${...} / . which are
-          #  regex metacharacters — -F keeps this robust across grep flavors.)
-          grep -Fq 'cc-clip_${VERSION#v}_${PLATFORM}.tar.gz' scripts/install.sh
-          # Windows installer must expect the matching zip artifact.
-          grep -Fq '$archiveName = "cc-clip_$($version.TrimStart("v"))_${platform}.zip"' scripts/install.ps1
-          # goreleaser archives must default to tar.gz (darwin/linux); windows
-          # uses the `formats: [zip]` override in the same block. Schema is the
-          # plural GoReleaser v2 form introduced in PR #33.
-          grep -Fq 'formats: [tar.gz]' .goreleaser.yaml
-          grep -Fq 'formats: [zip]' .goreleaser.yaml
 
       - uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ release-preflight: test vet
 		exit 1; \
 	}
 	@goreleaser check
-	@echo "==> release contract greps (mirrors .github/workflows/release.yml)"
+	@echo "==> release contract greps (mirrors .github/workflows/checks.yml)"
 	@grep -qE 'name_template:.*ProjectName.*Version.*Os.*Arch' .goreleaser.yaml \
 		|| { echo "FAIL: name_template drift in .goreleaser.yaml"; exit 1; }
 	@grep -Fq 'cc-clip_$${VERSION#v}_$${PLATFORM}.tar.gz' scripts/install.sh \


### PR DESCRIPTION
Found during the v0.9.2 release preflight.

## The gap

A tag push triggers `release.yml` only — `ci.yml` fires on `pull_request` and `push` to `main`. So the commit that actually ships was published having run nothing but `make test` (plain `go test`, no race detector):

| Gate | On a PR | On a tag push, before this change |
|---|---|---|
| Build | yes | yes (via goreleaser) |
| `go vet` | yes | **no** |
| `go test -race` | yes | **no** (plain `go test` only) |
| Staticcheck | yes | **no** |
| Govulncheck | yes | **no** |
| Agent-config policy | yes | **no** |

v0.9.2 shipped that way. The tag happened to point at a commit that had passed CI as a PR, but nothing enforced that — a tag on any commit would have published unchecked.

## The fix

Extract the gates into a reusable workflow both callers use, rather than copying them into `release.yml`. Copying would leave the release gate one edit away from silently diverging from CI — the same drift class the release-contract greps exist to catch in the first place.

- **`.github/workflows/checks.yml`** (new) — `on: workflow_call`, holding the `test` job (policy checks, build, vet, race tests, staticcheck) and the `vulncheck` job.
- **`ci.yml`** — now just calls it.
- **`release.yml`** — calls it, and the publish job gains `needs: checks`.

## Two changes made while moving

**The release-contract greps moved into `checks.yml`.** They verify that `.goreleaser.yaml`'s archive naming agrees with `scripts/install.sh` and `scripts/install.ps1` — an invariant CLAUDE.md flags as MUST-stay-in-sync. Living only in `release.yml` meant a PR could break it and only find out at tag time, which is the same late-gate problem this PR is about. `Makefile`'s `release-preflight` comment is repointed accordingly.

**`release.yml`'s `make test` step is dropped** as redundant — `needs: checks` already guarantees a strictly stronger run.

## Permissions

Tightened as a side effect: the workflow default drops to `contents: read` and only the publishing job holds `contents: write`, so the checks job no longer runs with write access to the repository.

## Verification

- All three workflows parse; job graph is `ci -> checks`, `release -> checks + release(needs: checks)`.
- The five contract greps pass against the current tree.
- Branch protection on `main` has no `required_status_checks` configured, so renaming the check contexts (they become `checks / test` and `checks / vulncheck`) breaks no existing rule. Worth noting if you later add required checks — use the new names.

## Follow-up worth considering

There are still no required status checks on `main`, which is why PRs were mergeable earlier in this batch while CI was red. Now that CI is green and meaningful, making `checks / test` and `checks / vulncheck` required would make the gate binding rather than advisory.