### PR TITLE
feat: add Cursor CLI deployment target (#109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,11 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 
 ### Shim Interception Patterns
 
-The shim intercepts these invocation shapes (covers Claude Code and opencode; other consumers that use the same flags get interception for free):
+The shim intercepts these invocation shapes (covers Claude Code, opencode, and Cursor CLI; other consumers that use the same flags get interception for free):
 - xclip: `*"-selection clipboard"*"-t TARGETS"*"-o"*` and `*"-selection clipboard"*"-t image/"*"-o"*`
-- wl-paste: `*"--list-types"*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude uses `--type`, opencode uses `-t`)
+- wl-paste: `*"--list-types"*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude and Cursor use `--type`, opencode uses `-t`)
+
+Cursor reads via `xclip -selection clipboard -t <mime> -o` / `wl-paste --type <mime>` over image/png,jpeg,gif,webp — all four hit the existing image branches, so the transport needs no new shim code. Its gate is environmental: Cursor only attempts a clipboard read when `DISPLAY` or `WAYLAND_DISPLAY` is set in its shell, and cc-clip deliberately does not inject one (issue #109, option C). It also kills clipboard children after ~4s, hence the `CC_CLIP_FETCH_TIMEOUT_MS=3000` guidance printed by the Cursor target.
 
 Everything else passes through to the real binary via `exec`. The `-l` short form of `--list-types` is deliberately not matched because no current consumer uses it and matching standalone `-l` without false positives is non-trivial. End-to-end coverage is asserted by `TestShimInterceptsMatchingInvocations` in `internal/shim/template_test.go`, which runs the generated bash against a mock HTTP daemon and verifies stdout contains the daemon's payload for matched patterns (proving interception took the HTTP path) and fallback captures the original args for unmatched patterns.
 

--- a/README.md
+++ b/README.md
@@ -91,13 +91,25 @@ Choose one selector per setup. With no selector, cc-clip configures Claude Code.
 | All integrations | `cc-clip setup myserver --all` | Yes | Yes | Xvfb for Codex |
 | opencode | `cc-clip setup myserver --opencode` | Yes | Yes | `xclip` or `wl-paste` |
 | Antigravity | `cc-clip setup myserver --agy` | No | Yes | Notification integration only |
+| Cursor CLI | `cc-clip setup myserver --cursor` | Yes | No | `DISPLAY` or `WAYLAND_DISPLAY` set in Cursor's shell |
 
 For Codex targets, cc-clip tries to install Xvfb with `apt` or `dnf`. If
 passwordless `sudo` is unavailable, it stops and prints the exact install command;
 run that command manually, then repeat setup.
 
-The Claude and opencode paths use the remote `xclip` or `wl-paste` shim. Codex
-reads X11 directly, so its target adds Xvfb and `cc-clip x11-bridge` instead.
+The Claude, opencode, and Cursor paths use the remote `xclip` or `wl-paste`
+shim. Codex reads X11 directly, so its target adds Xvfb and `cc-clip x11-bridge`
+instead.
+
+Cursor has one extra prerequisite the deploy cannot satisfy: its clipboard
+reader only runs when `DISPLAY` or `WAYLAND_DISPLAY` is set in the shell where
+Cursor runs (check with `echo $DISPLAY`). Connect with `ssh -X myserver` or
+export an existing display — cc-clip deliberately does not invent one, because
+a `DISPLAY` with no X server behind it would break clipboard fallback for every
+other tool in that shell. Cursor also stops waiting for clipboard helpers after
+about 4 seconds, so for large images over a slow link add
+`export CC_CLIP_FETCH_TIMEOUT_MS=3000` to your remote shell rc. Cursor
+notifications are not wired up yet.
 
 > opencode and Antigravity integration generation is covered by tests, but host
 > event delivery has not yet been smoke-tested on a representative machine.

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -131,7 +131,7 @@ Remote:
 One-command setup:
   setup <host>       Full setup: deps, SSH config, daemon, deploy
     --port           Tunnel port (default: 18339)
-    --claude/--codex/--opencode/--agy/--all   Deployment target (see "Deployment targets" below)
+    --claude/--codex/--opencode/--agy/--cursor/--all   Deployment target (see "Deployment targets" below)
     --auto-recover   Recover from v0.7.0 wrapper corruption (mutex with --token-only)
 
 Known hosts (per-user registry):
@@ -160,6 +160,8 @@ Deployment targets (connect/setup; choose at most one selector):
     --codex          Codex CLI ONLY: Xvfb + x11-bridge + codex-notify (no Claude shim)
     --opencode       opencode: clipboard shim + session.idle notify plugin
     --agy            Antigravity: agy-notify (alias --antigravity)
+    --cursor         Cursor CLI: clipboard shim only (requires DISPLAY or
+                     WAYLAND_DISPLAY in Cursor's shell; no notifications yet)
     --all            Everything above
   With no selector: interactive menu on a TTY, or the {Claude} default on a
   non-TTY. v0.9.0 BREAKING: --codex no longer installs the Claude shim; use
@@ -1714,8 +1716,39 @@ func connectSuccessSummary(t DeployTargets) string {
 		return "Setup complete. Codex CLI clipboard support is configured below."
 	case t.Antigravity:
 		return "Setup complete. Antigravity notifications configured; clipboard transport is pending."
+	case t.Cursor:
+		return "Setup complete. Ctrl+V in remote Cursor will paste images once DISPLAY is set (see the note above)."
 	default:
 		return "Setup complete."
+	}
+}
+
+// cursorDisplayNotice is printed when the Cursor target is selected. Cursor's
+// clipboard reader only builds its xclip/wl-paste candidate list when DISPLAY
+// or WAYLAND_DISPLAY is set in the shell it runs in; on a headless SSH session
+// neither is, so the shim is never invoked at all. cc-clip deliberately does
+// NOT inject a DISPLAY (issue #109, option C): a value with no X server behind
+// it would leak into the whole login shell and turn the shim's real-xclip
+// fallback into a guaranteed failure for every other consumer.
+//
+// The timeout note exists because Cursor kills each clipboard child after ~4s
+// while the shim's default fetch timeout is 5s — a large image over a slow
+// tunnel would be killed mid-transfer without the override.
+const cursorDisplayNotice = `      Cursor CLI notes:
+      1. Cursor only reads the clipboard when DISPLAY or WAYLAND_DISPLAY is set
+         in the shell where it runs. Check with:  echo $DISPLAY
+         If empty, connect with 'ssh -X <host>' or export an existing display.
+         cc-clip does not set one for you.
+      2. Cursor stops waiting for clipboard helpers after about 4 seconds; the
+         shim's default fetch timeout is 5. For large images over a slow link,
+         add to your remote shell rc:  export CC_CLIP_FETCH_TIMEOUT_MS=3000`
+
+// maybePrintCursorNotice writes cursorDisplayNotice to out when the Cursor
+// integration is among the resolved targets.
+func maybePrintCursorNotice(out io.Writer, t DeployTargets) {
+	if cursorTargeted(t) {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, cursorDisplayNotice)
 	}
 }
 
@@ -1753,6 +1786,10 @@ func connectVerifyTunnel(session *shim.SSHSession, port int, host string, target
 		os.Exit(1)
 	}
 	fmt.Printf("      %s\n", shimOut)
+
+	// The DISPLAY prerequisite must precede the summary: the summary's Cursor
+	// line refers to "the note above".
+	maybePrintCursorNotice(os.Stdout, targets)
 
 	fmt.Println()
 	fmt.Println(connectSuccessSummary(targets))

--- a/cmd/cc-clip/main_test.go
+++ b/cmd/cc-clip/main_test.go
@@ -405,10 +405,11 @@ func TestConnectSuccessSummary(t *testing.T) {
 		want    string
 	}{
 		{"claude mentions Claude Code", DeployTargets{Claude: true}, "remote Claude Code"},
-		{"all mentions Claude Code (codex line printed separately)", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, "remote Claude Code"},
+		{"all mentions Claude Code (codex line printed separately)", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, "remote Claude Code"},
 		{"opencode mentions opencode", DeployTargets{Opencode: true}, "remote opencode"},
 		{"pure codex does not claim the Claude shim", DeployTargets{Codex: true}, "Codex CLI clipboard support"},
 		{"agy mentions notifications + pending clipboard", DeployTargets{Antigravity: true}, "Antigravity notifications configured"},
+		{"cursor mentions Cursor and the DISPLAY prerequisite", DeployTargets{Cursor: true}, "DISPLAY"},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cmd/cc-clip/notify_targets_test.go
+++ b/cmd/cc-clip/notify_targets_test.go
@@ -19,15 +19,18 @@ import (
 func TestTargetMembership(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name                                string
-		targets                             DeployTargets
-		wantClaude, wantCx, wantSh, wantAgy bool
+		name                                         string
+		targets                                      DeployTargets
+		wantClaude, wantCx, wantSh, wantAgy, wantCur bool
 	}{
-		{"claude only", DeployTargets{Claude: true}, true, false, true, false},
-		{"codex only", DeployTargets{Codex: true}, false, true, false, false},
-		{"opencode only", DeployTargets{Opencode: true}, false, false, true, false},
-		{"agy only", DeployTargets{Antigravity: true}, false, false, false, true},
-		{"all", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, true, true, true, true},
+		{"claude only", DeployTargets{Claude: true}, true, false, true, false, false},
+		{"codex only", DeployTargets{Codex: true}, false, true, false, false, false},
+		{"opencode only", DeployTargets{Opencode: true}, false, false, true, false, false},
+		{"agy only", DeployTargets{Antigravity: true}, false, false, false, true, false},
+		// Cursor rides the same xclip/wl-paste shim as Claude/opencode; it has
+		// no notify adapter yet, so only the shim axis and its own predicate fire.
+		{"cursor only", DeployTargets{Cursor: true}, false, false, true, false, true},
+		{"all", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, true, true, true, true, true},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -44,6 +47,9 @@ func TestTargetMembership(t *testing.T) {
 			}
 			if got := agyTargeted(tt.targets); got != tt.wantAgy {
 				t.Errorf("agyTargeted=%v want %v", got, tt.wantAgy)
+			}
+			if got := cursorTargeted(tt.targets); got != tt.wantCur {
+				t.Errorf("cursorTargeted=%v want %v", got, tt.wantCur)
 			}
 		})
 	}

--- a/cmd/cc-clip/target_matrix_test.go
+++ b/cmd/cc-clip/target_matrix_test.go
@@ -22,7 +22,7 @@ func TestRejectNonClaudeHookControl(t *testing.T) {
 	}{
 		{"claude+no-hooks ok", DeployTargets{Claude: true}, true, false, false},
 		{"claude+hooks ok", DeployTargets{Claude: true}, false, true, false},
-		{"all+no-hooks ok (claude is a member)", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, true, false, false},
+		{"all+no-hooks ok (claude is a member)", DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, true, false, false},
 		{"codex+no-hooks ERROR", DeployTargets{Codex: true}, true, false, true},
 		{"opencode+hooks ERROR", DeployTargets{Opencode: true}, false, true, true},
 		{"agy+no-hooks ERROR", DeployTargets{Antigravity: true}, true, false, true},
@@ -70,7 +70,7 @@ func TestLegacyCodexNotice(t *testing.T) {
 
 	t.Run("--all does not print legacy notice", func(t *testing.T) {
 		var errOut bytes.Buffer
-		maybeLegacyCodexNotice(&errOut, []string{"--all"}, DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true})
+		maybeLegacyCodexNotice(&errOut, []string{"--all"}, DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true})
 		if errOut.Len() != 0 {
 			t.Fatalf("--all must not print the legacy notice:\n%s", errOut.String())
 		}

--- a/cmd/cc-clip/targets.go
+++ b/cmd/cc-clip/targets.go
@@ -20,18 +20,19 @@ type DeployTargets struct {
 	Codex       bool
 	Opencode    bool
 	Antigravity bool // canonical CLI flag is --agy (alias --antigravity)
+	Cursor      bool // Cursor CLI: shim-based clipboard; requires DISPLAY in Cursor's shell (issue #109)
 }
 
 // Any reports whether at least one target is selected.
 func (t DeployTargets) Any() bool {
-	return t.Claude || t.Codex || t.Opencode || t.Antigravity
+	return t.Claude || t.Codex || t.Opencode || t.Antigravity || t.Cursor
 }
 
 // errMultipleTargets is returned when more than one DISTINCT deployment target is
 // selected (e.g. --codex --all, or --claude --codex). Callers print it to stderr
 // and exit 2. It is a sentinel so tests can match with errors.Is.
 var errMultipleTargets = errors.New(
-	"only one deployment target may be given: choose one of --claude / --codex / --opencode / --agy / --all (use --all for everything)")
+	"only one deployment target may be given: choose one of --claude / --codex / --opencode / --agy / --cursor / --all (use --all for everything)")
 
 // parseDeployTargets resolves the deployment-target selector flags from args.
 // --agy is the canonical Antigravity flag with --antigravity as an accepted
@@ -51,10 +52,11 @@ func parseDeployTargets(args []string) (t DeployTargets, explicit bool, err erro
 	codex := flagInArgs(args, "codex")
 	opencode := flagInArgs(args, "opencode")
 	antigravity := flagInArgs(args, "agy") || flagInArgs(args, "antigravity")
+	cursor := flagInArgs(args, "cursor")
 	all := flagInArgs(args, "all")
 
 	selected := 0
-	for _, on := range []bool{claude, codex, opencode, antigravity, all} {
+	for _, on := range []bool{claude, codex, opencode, antigravity, cursor, all} {
 		if on {
 			selected++
 		}
@@ -66,13 +68,15 @@ func parseDeployTargets(args []string) (t DeployTargets, explicit bool, err erro
 	case selected > 1:
 		return DeployTargets{}, false, errMultipleTargets
 	case all:
-		return DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, true, nil
+		return DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, true, nil
 	case claude:
 		return DeployTargets{Claude: true}, true, nil
 	case codex:
 		return DeployTargets{Codex: true}, true, nil
 	case opencode:
 		return DeployTargets{Opencode: true}, true, nil
+	case cursor:
+		return DeployTargets{Cursor: true}, true, nil
 	default: // antigravity
 		return DeployTargets{Antigravity: true}, true, nil
 	}
@@ -106,14 +110,15 @@ const targetMenu = `Select deployment target:
   2) codex        X11 bridge + codex-notify
   3) opencode     clipboard shim + opencode-notify
   4) agy          Antigravity (agy-notify plugin; clipboard transport pending)
-  5) all          everything above (Antigravity clipboard excluded until resolved)
+  5) cursor       clipboard shim (requires DISPLAY in Cursor's shell; no notifications yet)
+  6) all          everything above (Antigravity clipboard excluded until resolved)
 `
 
 // maxMenuAttempts bounds invalid-input re-prompts so a misbehaving stream cannot
 // loop forever; after the cap the caller's default is applied.
 const maxMenuAttempts = 3
 
-// menuSelection maps a raw menu choice (1-5, surrounding whitespace tolerated) to
+// menuSelection maps a raw menu choice (1-6, surrounding whitespace tolerated) to
 // DeployTargets. ok=false for any unrecognized choice.
 func menuSelection(choice string) (DeployTargets, bool) {
 	switch strings.TrimSpace(choice) {
@@ -126,13 +131,15 @@ func menuSelection(choice string) (DeployTargets, bool) {
 	case "4":
 		return DeployTargets{Antigravity: true}, true
 	case "5":
-		return DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, true
+		return DeployTargets{Cursor: true}, true
+	case "6":
+		return DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, true
 	default:
 		return DeployTargets{}, false
 	}
 }
 
-// promptDeployTargets renders the target menu to out and reads a 1-5 selection
+// promptDeployTargets renders the target menu to out and reads a 1-6 selection
 // from in, re-prompting on invalid input up to maxMenuAttempts. It returns the
 // chosen targets with ok=true on a valid selection, or ok=false on EOF/read
 // error or exhausted attempts so the caller applies its own default.
@@ -147,7 +154,7 @@ func promptDeployTargets(in io.Reader, out io.Writer) (DeployTargets, bool) {
 		if t, ok := menuSelection(scanner.Text()); ok {
 			return t, true
 		}
-		fmt.Fprintln(out, "  invalid selection; enter a number 1-5")
+		fmt.Fprintln(out, "  invalid selection; enter a number 1-6")
 	}
 	return DeployTargets{}, false
 }
@@ -166,7 +173,7 @@ func resolveImplicitTargets(isTTY bool, in io.Reader, out, errOut io.Writer, fal
 		fmt.Fprintf(out, "no selection made; defaulting to %s\n", fallbackLabel)
 		return fallback
 	}
-	fmt.Fprintf(errOut, "cc-clip: no target flag given and stdin is not a TTY; defaulting to %s (pass --claude/--codex/--opencode/--agy/--all to choose explicitly)\n", fallbackLabel)
+	fmt.Fprintf(errOut, "cc-clip: no target flag given and stdin is not a TTY; defaulting to %s (pass --claude/--codex/--opencode/--agy/--cursor/--all to choose explicitly)\n", fallbackLabel)
 	return fallback
 }
 
@@ -275,11 +282,20 @@ func claudeTargeted(t DeployTargets) bool { return t.Claude }
 func codexTargeted(t DeployTargets) bool { return t.Codex }
 
 // shimTargeted reports whether this run should install the clipboard shim. The
-// xclip/wl-paste shim serves Claude Code AND opencode (both terminal tools that
-// shell out to the real binary); Codex reads X11 directly and agy is notify-only,
-// so neither needs the shim. A run that does not target the shim SKIPS install
-// but must never uninstall an existing shim (design §3 + Option A).
-func shimTargeted(t DeployTargets) bool { return t.Claude || t.Opencode }
+// xclip/wl-paste shim serves Claude Code, opencode AND Cursor (all terminal
+// tools that shell out to the real binary); Codex reads X11 directly and agy is
+// notify-only, so neither needs the shim. A run that does not target the shim
+// SKIPS install but must never uninstall an existing shim (design §3 + Option A).
+func shimTargeted(t DeployTargets) bool { return t.Claude || t.Opencode || t.Cursor }
+
+// cursorTargeted reports whether the Cursor CLI integration is selected. Cursor
+// is shim-only: its clipboard reader shells out to `xclip -selection clipboard
+// -t <mime> -o` / `wl-paste --type <mime>`, which the existing shim patterns
+// already intercept. The one prerequisite the deploy cannot satisfy is
+// environmental — Cursor only attempts a clipboard read when DISPLAY or
+// WAYLAND_DISPLAY is set in its shell (issue #109, option C: documented
+// prerequisite, no DISPLAY injection). No notify adapter exists yet.
+func cursorTargeted(t DeployTargets) bool { return t.Cursor }
 
 // agyTargeted reports whether the Antigravity (agy CLI) integration is selected.
 // agy is notify-only: it installs a bundled agy plugin whose Stop hook runs

--- a/cmd/cc-clip/targets_test.go
+++ b/cmd/cc-clip/targets_test.go
@@ -28,13 +28,16 @@ func TestParseDeployTargets(t *testing.T) {
 		{"--agy canonical", []string{"myhost", "--agy"}, DeployTargets{Antigravity: true}, true, false},
 		{"--antigravity alias", []string{"myhost", "--antigravity"}, DeployTargets{Antigravity: true}, true, false},
 		{"--agy --antigravity is one distinct target", []string{"--agy", "--antigravity"}, DeployTargets{Antigravity: true}, true, false},
-		{"--all selects everything", []string{"myhost", "--all"}, DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}, true, false},
+		{"--cursor", []string{"myhost", "--cursor"}, DeployTargets{Cursor: true}, true, false},
+		{"--all selects everything", []string{"myhost", "--all"}, DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}, true, false},
 		{"--claude=true equivalent to --claude", []string{"--claude=true"}, DeployTargets{Claude: true}, true, false},
 		{"--claude=false disables -> default", []string{"--claude=false"}, DeployTargets{}, false, false},
 		{"--codex --all conflict", []string{"--codex", "--all"}, DeployTargets{}, false, true},
 		{"--claude --codex conflict", []string{"--claude", "--codex"}, DeployTargets{}, false, true},
 		{"--claude --all conflict", []string{"--claude", "--all"}, DeployTargets{}, false, true},
 		{"--opencode --agy conflict", []string{"--opencode", "--agy"}, DeployTargets{}, false, true},
+		{"--cursor --claude conflict", []string{"--cursor", "--claude"}, DeployTargets{}, false, true},
+		{"--cursor --all conflict", []string{"--cursor", "--all"}, DeployTargets{}, false, true},
 		{"three targets conflict", []string{"--claude", "--codex", "--opencode"}, DeployTargets{}, false, true},
 	}
 
@@ -77,13 +80,13 @@ func TestDeployTargetsAny(t *testing.T) {
 		t.Fatal("zero DeployTargets must report Any()==false")
 	}
 	for _, s := range []DeployTargets{
-		{Claude: true}, {Codex: true}, {Opencode: true}, {Antigravity: true},
+		{Claude: true}, {Codex: true}, {Opencode: true}, {Antigravity: true}, {Cursor: true},
 	} {
 		if !s.Any() {
 			t.Fatalf("%+v must report Any()==true", s)
 		}
 	}
-	if !(DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}).Any() {
+	if !(DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}).Any() {
 		t.Fatal("full DeployTargets must report Any()==true")
 	}
 }
@@ -97,7 +100,8 @@ func TestMenuSelection(t *testing.T) {
 		"2":   {Codex: true},
 		"3":   {Opencode: true},
 		"4":   {Antigravity: true},
-		"5":   {Claude: true, Codex: true, Opencode: true, Antigravity: true},
+		"5":   {Cursor: true},
+		"6":   {Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true},
 		" 3 ": {Opencode: true},
 	}
 	for in, want := range valid {
@@ -105,7 +109,7 @@ func TestMenuSelection(t *testing.T) {
 			t.Errorf("menuSelection(%q) = %+v,%v; want %+v,true", in, got, ok, want)
 		}
 	}
-	for _, bad := range []string{"", "0", "6", "x", "12", "-1"} {
+	for _, bad := range []string{"", "0", "7", "x", "12", "-1"} {
 		if got, ok := menuSelection(bad); ok {
 			t.Errorf("menuSelection(%q) = %+v,true; want ok=false", bad, got)
 		}
@@ -184,8 +188,8 @@ func TestResolveImplicitTargets(t *testing.T) {
 	t.Run("TTY presents menu and returns selection", func(t *testing.T) {
 		t.Parallel()
 		var out, errOut bytes.Buffer
-		got := resolveImplicitTargets(true, strings.NewReader("5\n"), &out, &errOut, fallback, "claude")
-		if got != (DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true}) {
+		got := resolveImplicitTargets(true, strings.NewReader("6\n"), &out, &errOut, fallback, "claude")
+		if got != (DeployTargets{Claude: true, Codex: true, Opencode: true, Antigravity: true, Cursor: true}) {
 			t.Fatalf("got %+v, want all", got)
 		}
 		if !strings.Contains(out.String(), "Select deployment target:") {


### PR DESCRIPTION
Implements option C from the #109 discussion: Cursor as a shim-path deployment target with the `DISPLAY` prerequisite documented, not injected.

## What this adds

`--cursor` on `connect`/`setup` (interactive menu entry 5; `all` moves to 6 and now includes Cursor).

The clipboard transport needs **no new shim code**: Cursor's reader shells out as `xclip -selection clipboard -t <mime> -o` / `wl-paste --type <mime>` over `image/png,jpeg,gif,webp`, and all four shapes already hit the shim's image branches. cc-clip always serves PNG and Cursor asks for `image/png` first, so MIME negotiation lands on the first try. The target is therefore `shimTargeted` plus printed guidance.

## Why no DISPLAY injection

Cursor only attempts a clipboard read when `DISPLAY` or `WAYLAND_DISPLAY` is set in its shell — on a headless SSH session it never invokes `xclip` at all. The tempting fix (export a fake `DISPLAY` from the rc marker) is actively harmful: it leaks into the whole login shell and turns the shim's real-`xclip` fallback into a guaranteed failure for every other consumer. So the Cursor target prints a notice instead:

```
      Cursor CLI notes:
      1. Cursor only reads the clipboard when DISPLAY or WAYLAND_DISPLAY is set
         in the shell where it runs. Check with:  echo $DISPLAY
         ...
      2. Cursor stops waiting for clipboard helpers after about 4 seconds; the
         shim's default fetch timeout is 5. For large images over a slow link,
         add to your remote shell rc:  export CC_CLIP_FETCH_TIMEOUT_MS=3000
```

The timeout override already existed (`internal/shim/template.go`); this only documents it for Cursor's ~4s child-process kill.

## Deliberately not included

- **Notifications** — Cursor supports a `hooks.json` with a Stop event; tracked as the follow-up on #109. The README row says so.
- **DISPLAY provisioning via Xvfb** (option A) — remains open as an upgrade path if C proves insufficient; nothing here forecloses it.
- **DeployState changes** — target booleans are not persisted, so no schema change.

## Tests

Parse (`--cursor`, conflicts, `--all` membership), `Any()`, menu renumbering (5=cursor, 6=all, 7 invalid), target membership including `cursorTargeted` / `shimTargeted`, success summary mentions the DISPLAY prerequisite. Full race suite, vet, staticcheck clean.

## Docs

README target table + prerequisite paragraph; CLAUDE.md interception-patterns section. zh/ja README mirrors follow separately per the i18n convention.

Closes nothing yet — #109 stays open for the notify follow-up and for @hikmatelhaj to confirm the DISPLAY situation on a real host.