### PR TITLE
feat: cc-clip copy — reverse clipboard (#128 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 
 ### Data Flow
 
-1. **daemon** (`internal/daemon/`) — HTTP server on loopback, reads Mac clipboard via `pngpaste`, serves images at `GET /clipboard/type` and `GET /clipboard/image`. Auth via Bearer token + User-Agent whitelist.
+1. **daemon** (`internal/daemon/`) — HTTP server on loopback, reads Mac clipboard via `pngpaste`, serves images at `GET /clipboard/type` and `GET /clipboard/image`. Also accepts reverse text copies at `POST /clipboard/text` (`cc-clip copy` on the remote → local clipboard, #128): bytes are written verbatim via the platform writer (`clipwrite_{darwin,linux,windows}.go`), and every accepted write emits a calm notification naming the byte count but never the content. Auth via Bearer token + User-Agent whitelist.
 2. **tunnel** (`internal/tunnel/`) — Client-side HTTP calls through the SSH-forwarded port. `Probe()` checks TCP connectivity. `Client.FetchImage()` downloads and saves with timestamp+random filename.
 3. **shim** (`internal/shim/template.go`) — Bash script templates for xclip and wl-paste. Intercepts two specific invocation patterns Claude Code uses, fetches via curl through tunnel, falls back to real binary on any failure.
 4. **connect** (`cmd/cc-clip/main.go:cmdConnect`) — Orchestrates deployment via SSH master session: detect remote arch → incremental binary upload (hash-based skip) → install shim → sync token → verify tunnel. Supports `--force`, `--token-only` flags.

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ before using cc-clip on a shared or untrusted host.
 | `cc-clip connect HOST --force [target]` | Repair or fully redeploy a host |
 | `cc-clip connect HOST --token-only` | Sync a rotated or expired token |
 | `cc-clip doctor --host HOST` | End-to-end diagnosis |
+| `some-command \| cc-clip copy` (on the remote) | Copy remote output to your local clipboard, bypassing terminal soft-wrap |
 | `cc-clip status` | Local component status |
 | `cc-clip hosts list` | Known-host registry |
 | `cc-clip update --check` | Check the published release channel |

--- a/cmd/cc-clip/copy.go
+++ b/cmd/cc-clip/copy.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/exitcode"
+	"github.com/shunmei/cc-clip/internal/token"
+	"github.com/shunmei/cc-clip/internal/tunnel"
+)
+
+// cmdCopy implements `cc-clip copy` (#128): run ON THE REMOTE, it reads stdin
+// and places the bytes on the LOCAL machine's clipboard through the tunnel.
+// Text piped this way never passes through terminal rendering, so it carries
+// none of the soft-wrap newlines that mouse-selection copying injects.
+func cmdCopy() {
+	tok, err := token.ReadTokenFile()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: no session token on this host (%v)\n", err)
+		fmt.Fprintln(os.Stderr, "       run 'cc-clip connect <this-host>' from the local machine first")
+		os.Exit(exitcode.TokenInvalid)
+	}
+	client := tunnel.NewClient(fmt.Sprintf("http://127.0.0.1:%d", getPort()), tok, 15*time.Second)
+	os.Exit(runCopy(os.Stdin, client.SendText, os.Stderr))
+}
+
+// runCopy is the testable core of cmdCopy: read stdin up to the size cap, send
+// through the provided sender, and map failures onto the segmented business
+// exit codes so scripts can branch on WHY a copy failed.
+func runCopy(in io.Reader, send func(string) error, errOut io.Writer) int {
+	limit := tunnel.MaxSendTextSize()
+	data, err := io.ReadAll(io.LimitReader(in, int64(limit)+1))
+	if err != nil {
+		fmt.Fprintf(errOut, "error: reading stdin: %v\n", err)
+		return exitcode.InternalError
+	}
+	if len(data) == 0 {
+		fmt.Fprintln(errOut, "error: nothing on stdin; pipe the text to copy, e.g.:  cat file.txt | cc-clip copy")
+		return exitcode.InternalError
+	}
+	if len(data) > limit {
+		fmt.Fprintf(errOut, "error: input exceeds the %d MB copy limit (raise CC_CLIP_MAX_TEXT_MB on BOTH ends to lift it)\n", limit/(1024*1024))
+		return exitcode.InternalError
+	}
+
+	if err := send(string(data)); err != nil {
+		fmt.Fprintf(errOut, "error: %v\n", err)
+		switch {
+		case errors.Is(err, tunnel.ErrTokenInvalid):
+			fmt.Fprintln(errOut, "       token out of sync; run 'cc-clip connect <this-host> --token-only' from the local machine")
+			return exitcode.TokenInvalid
+		case errors.Is(err, tunnel.ErrDaemonUnreachable):
+			fmt.Fprintln(errOut, "       is an SSH session with the RemoteForward open, and 'cc-clip serve' running locally?")
+			return exitcode.TunnelUnreachable
+		default:
+			return exitcode.InternalError
+		}
+	}
+
+	fmt.Fprintf(errOut, "copied %d bytes to the local clipboard\n", len(data))
+	return exitcode.Success
+}

--- a/cmd/cc-clip/copy_test.go
+++ b/cmd/cc-clip/copy_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/shunmei/cc-clip/internal/exitcode"
+	"github.com/shunmei/cc-clip/internal/tunnel"
+)
+
+func TestRunCopySendsStdinVerbatim(t *testing.T) {
+	t.Parallel()
+	payload := "long command --with flags\nsecond line\n"
+	var sent string
+	var errOut bytes.Buffer
+
+	code := runCopy(strings.NewReader(payload), func(s string) error {
+		sent = s
+		return nil
+	}, &errOut)
+
+	if code != exitcode.Success {
+		t.Fatalf("exit = %d, want success; stderr:\n%s", code, errOut.String())
+	}
+	if sent != payload {
+		t.Fatalf("sent %q, want exactly %q (no newline normalization)", sent, payload)
+	}
+	if !strings.Contains(errOut.String(), "copied") {
+		t.Fatalf("success must be confirmed on stderr:\n%s", errOut.String())
+	}
+}
+
+func TestRunCopyEmptyStdinFailsWithUsageHint(t *testing.T) {
+	t.Parallel()
+	var errOut bytes.Buffer
+	code := runCopy(strings.NewReader(""), func(string) error {
+		t.Fatal("sender must not be called for empty stdin")
+		return nil
+	}, &errOut)
+	if code == exitcode.Success {
+		t.Fatal("empty stdin must fail")
+	}
+	if !strings.Contains(errOut.String(), "cc-clip copy") {
+		t.Fatalf("error must show a usage example:\n%s", errOut.String())
+	}
+}
+
+func TestRunCopyMapsBusinessExitCodes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"invalid token", tunnel.ErrTokenInvalid, exitcode.TokenInvalid},
+		{"tunnel down", tunnel.ErrDaemonUnreachable, exitcode.TunnelUnreachable},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var errOut bytes.Buffer
+			code := runCopy(strings.NewReader("text"), func(string) error { return tc.err }, &errOut)
+			if code != tc.want {
+				t.Fatalf("exit = %d, want %d; stderr:\n%s", code, tc.want, errOut.String())
+			}
+		})
+	}
+}
+
+func TestRunCopyRejectsOversizedInput(t *testing.T) {
+	t.Parallel()
+	var errOut bytes.Buffer
+	big := strings.Repeat("a", tunnel.MaxSendTextSize()+1)
+	code := runCopy(strings.NewReader(big), func(string) error {
+		t.Fatal("oversized input must not be sent")
+		return nil
+	}, &errOut)
+	if code == exitcode.Success {
+		t.Fatal("oversized input must fail")
+	}
+	if !strings.Contains(errOut.String(), "CC_CLIP_MAX_TEXT_MB") {
+		t.Fatalf("error must name the env override:\n%s", errOut.String())
+	}
+}

--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -74,6 +74,8 @@ func main() {
 		cmdUpdate()
 	case "notify":
 		cmdNotify()
+	case "copy":
+		cmdCopy()
 	case "plugin":
 		cmdPlugin()
 	case "x11-bridge":
@@ -176,6 +178,14 @@ Diagnostics:
   doctor             Local health check
   doctor --host H    Full end-to-end check via SSH
   version            Show version
+
+Copy (remote -> local):
+  copy               Read stdin and place it on the LOCAL machine's clipboard
+                     verbatim (run on the remote; needs the SSH tunnel). Piped
+                     text carries none of the soft-wrap newlines that mouse
+                     selection in a terminal injects:
+                       cat file.txt | cc-clip copy
+    --port           Tunnel port (default: 18339)
 
 Notifications:
   notify             Send a notification to the local daemon
@@ -297,6 +307,7 @@ func cmdServe() {
 	clipboard := daemon.NewClipboardReader()
 	store := session.NewStore(12 * time.Hour)
 	srv := daemon.NewServer(addr, clipboard, tm, store)
+	srv.SetTextWriter(daemon.NewClipboardTextWriter())
 	srv.EnableNoncePersistence()
 	if loaded, err := srv.LoadPersistedNonces(); err != nil {
 		log.Printf("WARN: failed to load notification nonces: %v", err)

--- a/internal/daemon/clipwrite.go
+++ b/internal/daemon/clipwrite.go
@@ -1,0 +1,73 @@
+package daemon
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ClipboardTextWriter writes text to the OS clipboard. The reverse of
+// ClipboardReader: it backs POST /clipboard/text, which lets the REMOTE side
+// of the tunnel put bytes on the LOCAL clipboard (`cc-clip copy`, #128) so
+// copied text never passes through terminal rendering and its soft-wrap
+// newlines.
+type ClipboardTextWriter interface {
+	WriteText(text string) error
+}
+
+// SetTextWriter enables the clipboard-write endpoint. Without a writer the
+// endpoint answers 501, so a platform with no writer implementation degrades
+// loudly instead of pretending success.
+func (s *Server) SetTextWriter(w ClipboardTextWriter) {
+	s.textWriter = w
+}
+
+// handleClipboardWrite accepts text from an authenticated remote and places it
+// on the local clipboard verbatim. Newlines are NOT normalized: preserving the
+// exact bytes is the point (#128) — the terminal's soft-wrap mangling is what
+// this endpoint exists to bypass.
+//
+// Every accepted write emits a calm notification. A remote that can write the
+// local clipboard is a paste-hijack primitive; the notification makes each
+// write visible so poisoning cannot happen silently. The clipboard CONTENT is
+// deliberately absent from the notification — it may be a secret, and
+// notification text reaches tmux status lines and notification centers.
+func (s *Server) handleClipboardWrite(w http.ResponseWriter, r *http.Request) {
+	if s.textWriter == nil {
+		http.Error(w, "clipboard write not supported by this daemon", http.StatusNotImplemented)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, int64(maxTextSize())+1))
+	if err != nil {
+		http.Error(w, "failed to read request body", http.StatusBadRequest)
+		return
+	}
+	if len(body) == 0 {
+		http.Error(w, "empty text", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxTextSize() {
+		http.Error(w, fmt.Sprintf("text exceeds %dMB limit", maxTextMB()), http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	if err := s.textWriter.WriteText(string(body)); err != nil {
+		http.Error(w, fmt.Sprintf("clipboard write failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	s.enqueueEnvelope(NotifyEnvelope{
+		Kind:      KindGenericMessage,
+		Source:    "clipboard-write",
+		Timestamp: time.Now().UTC(),
+		GenericMessage: &GenericMessagePayload{
+			Title:   "Clipboard set by remote",
+			Body:    fmt.Sprintf("A remote session copied %d bytes to this clipboard.", len(body)),
+			Urgency: 0,
+		},
+	})
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/daemon/clipwrite_darwin.go
+++ b/internal/daemon/clipwrite_darwin.go
@@ -1,0 +1,26 @@
+//go:build darwin
+
+package daemon
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+type darwinTextWriter struct{}
+
+// NewClipboardTextWriter returns the macOS clipboard writer. pbcopy ships with
+// the OS, so unlike pngpaste there is no install fallback to manage.
+func NewClipboardTextWriter() ClipboardTextWriter {
+	return &darwinTextWriter{}
+}
+
+func (w *darwinTextWriter) WriteText(text string) error {
+	cmd := exec.Command("pbcopy")
+	cmd.Stdin = strings.NewReader(text)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("pbcopy failed: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/internal/daemon/clipwrite_linux.go
+++ b/internal/daemon/clipwrite_linux.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type linuxTextWriter struct{}
+
+// NewClipboardTextWriter returns the Linux clipboard writer. Tool selection
+// mirrors NewClipboardReader: Wayland sessions prefer wl-copy, X11 falls back
+// to xclip. Resolution happens per write, not at construction, so a tool
+// installed after the daemon started is picked up.
+func NewClipboardTextWriter() ClipboardTextWriter {
+	return &linuxTextWriter{}
+}
+
+func (w *linuxTextWriter) WriteText(text string) error {
+	var cmd *exec.Cmd
+	switch {
+	case os.Getenv("WAYLAND_DISPLAY") != "" && lookPathOK("wl-copy"):
+		cmd = exec.Command("wl-copy")
+	case lookPathOK("xclip"):
+		cmd = exec.Command("xclip", "-selection", "clipboard", "-i")
+	case lookPathOK("wl-copy"):
+		cmd = exec.Command("wl-copy")
+	default:
+		return fmt.Errorf("no clipboard write tool found: install xclip or wl-clipboard")
+	}
+	cmd.Stdin = strings.NewReader(text)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s failed: %s: %w", cmd.Path, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func lookPathOK(name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}

--- a/internal/daemon/clipwrite_test.go
+++ b/internal/daemon/clipwrite_test.go
@@ -1,0 +1,164 @@
+package daemon
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shunmei/cc-clip/internal/session"
+	"github.com/shunmei/cc-clip/internal/token"
+)
+
+type mockTextWriter struct {
+	written []string
+	err     error
+}
+
+func (m *mockTextWriter) WriteText(text string) error {
+	m.written = append(m.written, text)
+	return m.err
+}
+
+func newWriteTestServer(t *testing.T) (*Server, *mockTextWriter, string) {
+	t.Helper()
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	store := session.NewStore(12 * time.Hour)
+	srv := NewServer("127.0.0.1:0", &mockClipboard{}, tm, store)
+	w := &mockTextWriter{}
+	srv.SetTextWriter(w)
+	return srv, w, s.Token
+}
+
+func postClipboardText(srv *Server, tok, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/clipboard/text", strings.NewReader(body))
+	if tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	req.Header.Set("User-Agent", "cc-clip/0.1")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	return w
+}
+
+// TestClipboardWriteEndpoint pins the phase-1 contract of #128: bytes reach
+// the local clipboard VERBATIM. Terminal soft-wrap corruption is the whole
+// reason the endpoint exists, so embedded and trailing newlines must survive
+// exactly as sent.
+func TestClipboardWriteEndpoint(t *testing.T) {
+	srv, writer, tok := newWriteTestServer(t)
+
+	payload := "line one\nline two with trailing\n"
+	w := postClipboardText(srv, tok, payload)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+	if len(writer.written) != 1 || writer.written[0] != payload {
+		t.Fatalf("writer got %q, want exactly %q", writer.written, payload)
+	}
+}
+
+func TestClipboardWriteRequiresAuth(t *testing.T) {
+	srv, writer, _ := newWriteTestServer(t)
+
+	if w := postClipboardText(srv, "", "text"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("missing auth: expected 401, got %d", w.Code)
+	}
+	if w := postClipboardText(srv, "wrong-token", "text"); w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad token: expected 401, got %d", w.Code)
+	}
+	if len(writer.written) != 0 {
+		t.Fatalf("unauthenticated requests must never reach the writer: %q", writer.written)
+	}
+}
+
+func TestClipboardWriteRejectsEmptyBody(t *testing.T) {
+	srv, writer, tok := newWriteTestServer(t)
+
+	if w := postClipboardText(srv, tok, ""); w.Code != http.StatusBadRequest {
+		t.Fatalf("empty body: expected 400, got %d", w.Code)
+	}
+	if len(writer.written) != 0 {
+		t.Fatalf("empty body must not reach the writer: %q", writer.written)
+	}
+}
+
+func TestClipboardWriteEnforcesSizeCap(t *testing.T) {
+	srv, writer, tok := newWriteTestServer(t)
+
+	over := strings.Repeat("a", maxTextSize()+1)
+	if w := postClipboardText(srv, tok, over); w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversize: expected 413, got %d", w.Code)
+	}
+	if len(writer.written) != 0 {
+		t.Fatalf("oversize body must not reach the writer: %q", writer.written)
+	}
+}
+
+// TestClipboardWriteWithoutWriterIsNotImplemented covers a daemon built for a
+// platform with no writer (or a test server without one): the route exists
+// but reports 501 rather than pretending success.
+func TestClipboardWriteWithoutWriterIsNotImplemented(t *testing.T) {
+	tm := token.NewManager(time.Hour)
+	s, _ := tm.Generate()
+	srv := NewServer("127.0.0.1:0", &mockClipboard{}, tm, session.NewStore(12*time.Hour))
+
+	if w := postClipboardText(srv, s.Token, "text"); w.Code != http.StatusNotImplemented {
+		t.Fatalf("no writer: expected 501, got %d", w.Code)
+	}
+}
+
+// TestClipboardWriteEmitsNotification pins the clipboard-poisoning boundary
+// from #128: a remote writing the LOCAL clipboard is a paste-hijack primitive,
+// so every accepted write must surface as a calm notification. Silent writes
+// are the failure mode this exists to prevent.
+func TestClipboardWriteEmitsNotification(t *testing.T) {
+	srv, _, tok := newWriteTestServer(t)
+
+	if w := postClipboardText(srv, tok, "some copied text"); w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	select {
+	case env := <-srv.notifyCh:
+		if env.Kind != KindGenericMessage || env.GenericMessage == nil {
+			t.Fatalf("expected a generic notification, got %+v", env)
+		}
+		if env.GenericMessage.Urgency != 0 {
+			t.Fatalf("clipboard-write notice must be calm (urgency 0), got %d", env.GenericMessage.Urgency)
+		}
+		text := env.GenericMessage.Title + " " + env.GenericMessage.Body
+		if !strings.Contains(strings.ToLower(text), "clipboard") {
+			t.Fatalf("notification must say the clipboard was set: %+v", env.GenericMessage)
+		}
+		// The clipboard CONTENT must never leak into the notification — it may
+		// be a secret, and notification text reaches tmux status lines and
+		// notification centers.
+		if strings.Contains(text, "some copied text") {
+			t.Fatalf("notification must not echo clipboard content: %+v", env.GenericMessage)
+		}
+	default:
+		t.Fatal("accepted clipboard write must enqueue a notification")
+	}
+}
+
+// TestClipboardWriteFailureIsReported: a writer error must produce a 5xx, not
+// a silent 204 — the remote user would otherwise paste stale content locally.
+func TestClipboardWriteFailureIsReported(t *testing.T) {
+	srv, writer, tok := newWriteTestServer(t)
+	writer.err = errTestWriteFailed
+
+	w := postClipboardText(srv, tok, "text")
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("writer failure: expected 500, got %d", w.Code)
+	}
+}
+
+var errTestWriteFailed = &writeFailedError{}
+
+type writeFailedError struct{}
+
+func (e *writeFailedError) Error() string { return "simulated clipboard write failure" }

--- a/internal/daemon/clipwrite_windows.go
+++ b/internal/daemon/clipwrite_windows.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/shunmei/cc-clip/internal/win32"
+)
+
+type windowsTextWriter struct{}
+
+// NewClipboardTextWriter returns the Windows clipboard writer. It reuses the
+// PowerShell SetDataObject($true) + OleFlushClipboard approach proven by the
+// send/hotkey path: a short-lived process must explicitly ask WinForms to
+// leave the data on the clipboard after it exits, or Windows destroys the
+// data with the owning window.
+func NewClipboardTextWriter() ClipboardTextWriter {
+	return &windowsTextWriter{}
+}
+
+const windowsWriteTextScript = `$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+if (-not ('CcClipDaemonOle' -as [type])) {
+  Add-Type -TypeDefinition @"
+using System.Runtime.InteropServices;
+public static class CcClipDaemonOle {
+    [DllImport("ole32.dll")]
+    public static extern int OleFlushClipboard();
+}
+"@
+}
+[System.Windows.Forms.Clipboard]::SetDataObject($env:CC_CLIP_WRITE_TEXT, $true)
+$hr = [CcClipDaemonOle]::OleFlushClipboard()
+if ($hr -ne 0) { throw "OleFlushClipboard failed with HRESULT 0x$($hr.ToString('X8'))" }`
+
+func (w *windowsTextWriter) WriteText(text string) error {
+	cmd := exec.Command("powershell", "-STA", "-NoProfile", "-Command", windowsWriteTextScript)
+	win32.HideConsoleWindow(cmd)
+	cmd.Env = append(os.Environ(), "CC_CLIP_WRITE_TEXT="+text)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to set clipboard text: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -77,6 +77,7 @@ type Server struct {
 	persistNonces     bool
 	addr              string
 	mux               *http.ServeMux
+	textWriter        ClipboardTextWriter // nil until SetTextWriter; POST /clipboard/text answers 501 without it
 }
 
 func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, sessions *session.Store) *Server {
@@ -96,6 +97,7 @@ func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, se
 	s.mux.HandleFunc("GET /clipboard/type", s.authMiddleware(s.handleClipboardType))
 	s.mux.HandleFunc("GET /clipboard/image", s.authMiddleware(s.handleClipboardImage))
 	s.mux.HandleFunc("GET /clipboard/text", s.authMiddleware(s.handleClipboardText))
+	s.mux.HandleFunc("POST /clipboard/text", s.authMiddleware(s.handleClipboardWrite))
 	s.mux.HandleFunc("POST /notify", s.handleNotify)
 	s.mux.HandleFunc("POST /register-nonce", s.authMiddleware(s.handleRegisterNonce))
 	return s

--- a/internal/tunnel/send_text.go
+++ b/internal/tunnel/send_text.go
@@ -1,0 +1,66 @@
+package tunnel
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// ErrDaemonUnreachable wraps transport-level SendText failures so callers can
+// map them to the TunnelUnreachable business exit code without string matching.
+var ErrDaemonUnreachable = errors.New("daemon unreachable through the tunnel")
+
+const defaultMaxSendTextMB = 1
+
+// MaxSendTextSize is the client-side cap for SendText bodies, mirroring the
+// daemon's CC_CLIP_MAX_TEXT_MB so an oversized copy fails on the remote with
+// a clear message instead of burning tunnel bandwidth to earn a 413.
+func MaxSendTextSize() int {
+	if env := os.Getenv("CC_CLIP_MAX_TEXT_MB"); env != "" {
+		if v, err := strconv.Atoi(env); err == nil && v > 0 {
+			return v * 1024 * 1024
+		}
+	}
+	return defaultMaxSendTextMB * 1024 * 1024
+}
+
+// SendText places text on the LOCAL machine's clipboard through the tunnel
+// (POST /clipboard/text, #128). The body is sent verbatim — no newline
+// normalization — because bypassing the terminal's soft-wrap mangling is the
+// reason the endpoint exists.
+func (c *Client) SendText(text string) error {
+	req, err := http.NewRequest("POST", c.baseURL+"/clipboard/text", strings.NewReader(text))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("User-Agent", defaultUserAgent)
+	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrDaemonUnreachable, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusUnauthorized:
+		return ErrTokenInvalid
+	case http.StatusRequestEntityTooLarge:
+		return fmt.Errorf("text exceeds the daemon's size limit (raise CC_CLIP_MAX_TEXT_MB on the local machine)")
+	case http.StatusMethodNotAllowed, http.StatusNotFound, http.StatusNotImplemented:
+		// 405/404: an older daemon that predates the write endpoint answers
+		// from its GET-only mux. 501: a daemon built without a platform
+		// writer. All three fix the same way — on the LOCAL side.
+		return fmt.Errorf("the daemon does not support clipboard write; upgrade cc-clip on the local machine and restart it (cc-clip update)")
+	default:
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("clipboard write failed: %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+}

--- a/internal/tunnel/send_text_test.go
+++ b/internal/tunnel/send_text_test.go
@@ -1,0 +1,79 @@
+package tunnel
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSendTextRoundTrip pins the client half of #128: the body reaches the
+// daemon VERBATIM (soft-wrap corruption is the whole point of the feature) and
+// carries the Bearer token + cc-clip User-Agent the daemon's auth requires.
+func TestSendTextRoundTrip(t *testing.T) {
+	const testToken = "test-token-123"
+	payload := "line one\nline two with trailing\n"
+
+	var gotBody, gotAuth, gotUA string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /clipboard/text", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody, gotAuth, gotUA = string(b), r.Header.Get("Authorization"), r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	client := NewClient(ts.URL, testToken, 5*time.Second)
+	if err := client.SendText(payload); err != nil {
+		t.Fatalf("SendText: %v", err)
+	}
+	if gotBody != payload {
+		t.Fatalf("daemon received %q, want exactly %q", gotBody, payload)
+	}
+	if gotAuth != "Bearer "+testToken {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.HasPrefix(gotUA, "cc-clip") {
+		t.Fatalf("User-Agent = %q, want cc-clip prefix", gotUA)
+	}
+}
+
+func TestSendTextErrorMapping(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		wantSub string
+		wantTok bool
+	}{
+		{"unauthorized maps to ErrTokenInvalid", http.StatusUnauthorized, "", true},
+		{"too large names the limit", http.StatusRequestEntityTooLarge, "size limit", false},
+		// An old local daemon has GET /clipboard/text but no POST pattern, so
+		// Go's ServeMux answers 405; a daemon built without a writer answers
+		// 501. Both mean the same thing to the user: upgrade the LOCAL side.
+		{"405 from an old daemon says upgrade local", http.StatusMethodNotAllowed, "local machine", false},
+		{"501 without writer says upgrade local", http.StatusNotImplemented, "local machine", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			mux.HandleFunc("POST /clipboard/text", func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "nope", tc.status)
+			})
+			ts := newIPv4TestServer(t, mux)
+			defer ts.Close()
+
+			err := NewClient(ts.URL, "tok", 5*time.Second).SendText("x")
+			if err == nil {
+				t.Fatal("want error")
+			}
+			if tc.wantTok && err != ErrTokenInvalid {
+				t.Fatalf("err = %v, want ErrTokenInvalid", err)
+			}
+			if tc.wantSub != "" && !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("err %q must mention %q", err, tc.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Phase 1 of #128. `some-command | cc-clip copy` on the remote puts the bytes on the **local** clipboard verbatim — text piped this way never passes through terminal rendering, so it carries none of the soft-wrap newlines that mouse-selection copying injects.

## Layers

- **daemon** — `POST /clipboard/text` behind the existing `authMiddleware` (Bearer + User-Agent allowlist, loopback only), capped at `CC_CLIP_MAX_TEXT_MB` (413 over, 400 empty, 501 when the platform has no writer). Platform writers beside the existing readers: `pbcopy` / `wl-copy`-or-`xclip -i` / the PowerShell `SetDataObject($true)`+`OleFlushClipboard` approach the send path already proved.
- **tunnel** — `Client.SendText`; 401 → `ErrTokenInvalid`, transport failure → new `ErrDaemonUnreachable` sentinel, and 404/405/501 collapse into one actionable message (an old local daemon answers **405** from its GET-only mux pattern; the fix for all three is the same — upgrade the local side).
- **cmd** — `copy` subcommand; testable core maps failures to the segmented business exit codes (`TokenInvalid` / `TunnelUnreachable`) with remediation lines naming the exact command to run.

## The security boundary ships in phase 1

A remote that can write the local clipboard is a paste-hijack primitive. Every accepted write emits a **calm notification** through the existing delivery chain — byte count only, never the content (clipboard text may be a secret, and notification text reaches tmux status lines and notification centers). Tested: content-leak assertion included.

## Verified live, not just in tests

- Against the **running v0.9.1 daemon**: correctly fails with `the daemon does not support clipboard write; upgrade cc-clip on the local machine` (the 405 path).
- Against a **fresh daemon** on a spare port: `copied 31 bytes to the local clipboard`, `pbpaste` shows the exact bytes including embedded and trailing newlines.

Plus: full race suite, vet, staticcheck, GOOS=windows/linux builds.

## Not in this PR

Phase 2 (shim write-shape interception — `xclip` without `-o`, `wl-copy` — so remote TUIs' own copy actions land locally) and reverse **image** copy stay tracked on #128. No `DeployState` change; the remote side needs only the binary users already deploy.

Requires the local daemon to be restarted on the new binary (`cc-clip update` does this) — old daemons fail closed with the upgrade message.