### PR TITLE
feat: daemon version consistency check and LocalCommand docs (#22 P2+P3)

### DIFF
--- a/cmd/cc-clip/main.go
+++ b/cmd/cc-clip/main.go
@@ -310,6 +310,7 @@ func cmdServe() {
 	store := session.NewStore(12 * time.Hour)
 	srv := daemon.NewServer(addr, clipboard, tm, store)
 	srv.SetTextWriter(daemon.NewClipboardTextWriter())
+	srv.SetVersion(version)
 	srv.EnableNoncePersistence()
 	if loaded, err := srv.LoadPersistedNonces(); err != nil {
 		log.Printf("WARN: failed to load notification nonces: %v", err)
@@ -2179,6 +2180,14 @@ func cmdStatus() {
 		fmt.Printf("daemon:  not running on :%d\n", port)
 	} else {
 		fmt.Printf("daemon:  running on :%d\n", port)
+		// Detect a daemon still running a pre-upgrade binary (#22 P2). An
+		// in-place binary replacement does not restart the service, so the
+		// running daemon can silently lag this binary.
+		if h, err := tunnel.FetchHealth(addr, probeTimeout); err == nil {
+			if notice := daemonVersionNotice(h.Version, version); notice != "" {
+				fmt.Println(notice)
+			}
+		}
 	}
 
 	tok, err := token.ReadTokenFile()

--- a/cmd/cc-clip/status_version.go
+++ b/cmd/cc-clip/status_version.go
@@ -1,0 +1,25 @@
+package main
+
+import "fmt"
+
+// daemonVersionNotice compares the RUNNING daemon's /health version against
+// this binary's and returns a warning line when they demonstrably differ, or
+// "" when no honest claim can be made (#22 P2).
+//
+// Silence over guessing: an empty runningVersion means a pre-#22 daemon and
+// an empty ownVersion means a dev build — in both cases a mismatch cannot be
+// proven, and a false "stale daemon" warning would send the operator on a
+// pointless restart. This is why the daemon fix in a release only takes
+// effect after `cc-clip update` reinstalls the service; replacing the binary
+// in place leaves the old daemon running with no visible sign until now.
+func daemonVersionNotice(runningVersion, ownVersion string) string {
+	running := normalizeVersion(runningVersion)
+	own := normalizeVersion(ownVersion)
+	if running == "" || own == "" || running == own {
+		return ""
+	}
+	return fmt.Sprintf(
+		"daemon:  WARNING: running daemon is %s but this binary is %s; restart it with 'cc-clip update' (or 'cc-clip service uninstall && cc-clip service install')",
+		running, own,
+	)
+}

--- a/cmd/cc-clip/status_version_test.go
+++ b/cmd/cc-clip/status_version_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDaemonVersionNotice pins the fail-silent contract: a warning only when a
+// mismatch is provable. False "stale daemon" warnings would train operators to
+// ignore the real one.
+func TestDaemonVersionNotice(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		running  string
+		own      string
+		wantWarn bool
+	}{
+		{"provable mismatch warns", "0.9.2", "0.9.3", true},
+		{"same version silent", "0.9.3", "0.9.3", false},
+		{"same after normalization silent", "v0.9.3", "0.9.3", false},
+		{"pre-#22 daemon (no version) silent", "", "0.9.3", false},
+		{"dev build silent", "0.9.2", "dev", false},
+		{"both unknown silent", "", "dev", false},
+		{"garbage running version silent", "not-a-version", "0.9.3", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := daemonVersionNotice(tt.running, tt.own)
+			if tt.wantWarn {
+				if got == "" {
+					t.Fatal("expected a warning")
+				}
+				for _, want := range []string{"WARNING", "cc-clip update"} {
+					if !strings.Contains(got, want) {
+						t.Fatalf("warning %q must mention %q", got, want)
+					}
+				}
+				return
+			}
+			if got != "" {
+				t.Fatalf("expected silence, got %q", got)
+			}
+		})
+	}
+}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,11 +13,12 @@ If image paste isn't working, run these checks **in order** to isolate the probl
 ```bash
 # 1. Local: Is the daemon running?
 curl -s http://127.0.0.1:18339/health
-# Expected: {"status":"ok"}
+# Expected: {"service":"cc-clip","status":"ok","version":"..."}
+# ("version" appears from v0.9.3; older daemons omit it)
 
 # 2. Remote: Is the tunnel forwarding?
 ssh myserver "curl -s http://127.0.0.1:18339/health"
-# Expected: {"status":"ok"}
+# Expected: the same body as step 1
 
 # 3. Remote: Is the shim taking priority over real xclip?
 ssh myserver "which xclip"
@@ -84,6 +85,35 @@ curl -s http://127.0.0.1:18339/health
 ```
 
 **Prevention:** Update to the latest cc-clip. The `connect` command uses `ClearAllForwardings=yes` for its internal SSH session, so it never competes for the RemoteForward port.
+
+---
+
+## Auto-Starting the Daemon with SSH LocalCommand
+
+If you skip the launchd service (`cc-clip service install`) and keep forgetting
+to run `cc-clip serve` before SSHing, OpenSSH can start it for you. Add to the
+host's block in `~/.ssh/config`:
+
+```ssh-config
+Host myserver
+    RemoteForward 18339 127.0.0.1:18339
+    PermitLocalCommand yes
+    LocalCommand pgrep -f 'cc-clip serve' >/dev/null || (cc-clip serve >/dev/null 2>&1 &)
+```
+
+`LocalCommand` runs **on your local machine** after each successful connection
+to that host; the `pgrep` guard makes it a no-op when the daemon is already
+up. Notes:
+
+- `PermitLocalCommand` is required — without it `LocalCommand` is silently
+  ignored.
+- This starts the daemon *after* the SSH connection is established, so the
+  very first clipboard request may race the daemon's startup; a retry pastes
+  fine. The launchd service does not have this race and remains the
+  recommended path on macOS.
+- Scope it to specific `Host` blocks rather than `Host *`: `LocalCommand`
+  executes for every match, and a global one runs on every connection you
+  make, including ones that have nothing to do with cc-clip.
 
 ---
 

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -78,6 +78,7 @@ type Server struct {
 	addr              string
 	mux               *http.ServeMux
 	textWriter        ClipboardTextWriter // nil until SetTextWriter; POST /clipboard/text answers 501 without it
+	version           string              // reported by /health when set via SetVersion (#22 P2)
 }
 
 func NewServer(addr string, clipboard ClipboardReader, tokens *token.Manager, sessions *session.Store) *Server {
@@ -441,9 +442,21 @@ func (s *Server) authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	}
 }
 
+// SetVersion sets the version string /health reports (#22 P2), letting
+// `cc-clip status` detect a running daemon that predates an in-place binary
+// upgrade. The field is additive: tunnel.ProbeHealth decodes service/status
+// only, so older clients ignore it, and it is omitted entirely when unset.
+func (s *Server) SetVersion(v string) {
+	s.version = v
+}
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok", "service": "cc-clip"})
+	body := map[string]string{"status": "ok", "service": "cc-clip"}
+	if s.version != "" {
+		body["version"] = s.version
+	}
+	json.NewEncoder(w).Encode(body)
 }
 
 // handleRegisterNonce accepts a notification nonce from an authenticated

--- a/internal/daemon/server_test.go
+++ b/internal/daemon/server_test.go
@@ -1181,3 +1181,37 @@ func TestDedupDoesNotSuppressCriticalPermissionPrompt(t *testing.T) {
 		t.Fatalf("expected 2 critical envelopes, got %d", count)
 	}
 }
+
+// TestHealthEndpointReportsVersion pins #22 P2: /health carries the daemon's
+// version once set, so `cc-clip status` can detect a stale running daemon
+// after an in-place binary upgrade. Absent when unset (old behavior), and the
+// field is additive — tunnel.ProbeHealth parses service/status only, so older
+// clients are unaffected.
+func TestHealthEndpointReportsVersion(t *testing.T) {
+	srv, _ := newTestServer(&mockClipboard{})
+
+	get := func() map[string]string {
+		req := httptest.NewRequest("GET", "/health", nil)
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+		var body map[string]string
+		json.NewDecoder(w.Body).Decode(&body)
+		return body
+	}
+
+	if v, ok := get()["version"]; ok {
+		t.Fatalf("version must be absent before SetVersion, got %q", v)
+	}
+
+	srv.SetVersion("0.9.3")
+	body := get()
+	if body["version"] != "0.9.3" {
+		t.Fatalf("version = %q, want 0.9.3", body["version"])
+	}
+	if body["service"] != "cc-clip" || body["status"] != "ok" {
+		t.Fatalf("existing fields must be preserved: %v", body)
+	}
+}

--- a/internal/tunnel/probe.go
+++ b/internal/tunnel/probe.go
@@ -64,3 +64,32 @@ func ProbeHealth(addr string, timeout time.Duration) error {
 	}
 	return nil
 }
+
+// HealthInfo is the decoded body of the daemon's GET /health endpoint.
+// Version is empty on daemons that predate #22 P2.
+type HealthInfo struct {
+	Service string `json:"service"`
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+// FetchHealth returns the daemon's /health identity. Unlike ProbeHealth it
+// does not judge — it hands the decoded body to the caller, which is what
+// `cc-clip status` needs to compare the running daemon's version against its
+// own binary after an in-place upgrade.
+func FetchHealth(addr string, timeout time.Duration) (HealthInfo, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get("http://" + addr + "/health")
+	if err != nil {
+		return HealthInfo{}, fmt.Errorf("GET /health: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return HealthInfo{}, fmt.Errorf("GET /health -> %d", resp.StatusCode)
+	}
+	var h HealthInfo
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1024)).Decode(&h); err != nil {
+		return HealthInfo{}, fmt.Errorf("invalid /health body: %w", err)
+	}
+	return h, nil
+}

--- a/internal/tunnel/send_text_test.go
+++ b/internal/tunnel/send_text_test.go
@@ -77,3 +77,41 @@ func TestSendTextErrorMapping(t *testing.T) {
 		})
 	}
 }
+
+// TestFetchHealth pins the /health probe used by `cc-clip status` for the
+// daemon-version mismatch check (#22 P2). Unknown fields must not break older
+// daemons' responses (version absent -> empty string).
+func TestFetchHealth(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"service":"cc-clip","status":"ok","version":"0.9.3"}`))
+	})
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	h, err := FetchHealth(strings.TrimPrefix(ts.URL, "http://"), 2*time.Second)
+	if err != nil {
+		t.Fatalf("FetchHealth: %v", err)
+	}
+	if h.Service != "cc-clip" || h.Status != "ok" || h.Version != "0.9.3" {
+		t.Fatalf("health = %+v", h)
+	}
+}
+
+func TestFetchHealthOldDaemonWithoutVersion(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"service":"cc-clip","status":"ok"}`))
+	})
+	ts := newIPv4TestServer(t, mux)
+	defer ts.Close()
+
+	h, err := FetchHealth(strings.TrimPrefix(ts.URL, "http://"), 2*time.Second)
+	if err != nil {
+		t.Fatalf("FetchHealth: %v", err)
+	}
+	if h.Version != "" {
+		t.Fatalf("old daemon must yield empty version, got %q", h.Version)
+	}
+}


### PR DESCRIPTION
Clears the two remaining self-contained items of #22 (P0 shipped in v0.9.2 via #114; P1 doctor notification-bridge coverage stays open).

## P2 — detect a stale running daemon

Replacing the cc-clip binary in place does not restart the launchd service, so the running daemon silently lags the binary — the reason the v0.9.2 notes had to insist on `cc-clip update` over a manual copy. Now it is visible:

- `GET /health` reports `version` once `serve` sets it. **Additive**: `tunnel.ProbeHealth` decodes `service`/`status` only, older daemons omit the field, nothing breaks in either direction.
- `tunnel.FetchHealth` returns the decoded body.
- `cc-clip status` compares and warns:

```
daemon:  running on :18339
daemon:  WARNING: running daemon is v0.9.2 but this binary is v0.9.3; restart it with 'cc-clip update' ...
```

**Fail-silent by design**: an empty running version (pre-upgrade daemon) or a `dev` build cannot prove a mismatch, so no warning is printed — a false "stale daemon" warning trains operators to ignore the real one. Table-tested in `status_version_test.go`, including the garbage-version and both-unknown cases.

## P3 — SSH LocalCommand docs

New troubleshooting section: per-host `PermitLocalCommand yes` + a `pgrep`-guarded `LocalCommand` that auto-starts `cc-clip serve` on connection, with the caveats that earned this P3 rather than default status — the first paste can race daemon startup, and a `Host *`-scoped `LocalCommand` fires on every SSH connection you make.

## Also

The troubleshooting `/health` expected output was stale since v0.8.0 added the `service` field; updated alongside.

Full race suite, vet, staticcheck clean.