### PR TITLE
test: lift cmd/cc-clip coverage past the 30% target (#20 I4)

### DIFF
--- a/cmd/cc-clip/hosts_test.go
+++ b/cmd/cc-clip/hosts_test.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/shunmei/cc-clip/internal/hosts"
+)
+
+// withRegistryOverride points the host registry at a per-test file so these
+// tests never touch the real ~/.cache/cc-clip registry.
+func withRegistryOverride(t *testing.T) {
+	t.Helper()
+	old := hosts.RegistryPathOverride
+	hosts.RegistryPathOverride = filepath.Join(t.TempDir(), "hosts.json")
+	t.Cleanup(func() { hosts.RegistryPathOverride = old })
+}
+
+func TestRecordHostConnectRoundTrip(t *testing.T) {
+	withRegistryOverride(t)
+
+	recordHostConnect("venus", "v0.9.3", false)
+
+	reg, err := hosts.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	entries := reg.Sorted()
+	if len(entries) != 1 || entries[0].Host != "venus" {
+		t.Fatalf("entries = %+v, want exactly venus", entries)
+	}
+	if entries[0].LastDeployedVersion != "v0.9.3" {
+		t.Fatalf("version = %q, want v0.9.3", entries[0].LastDeployedVersion)
+	}
+	if entries[0].Codex {
+		t.Fatal("codex must be false for a plain connect")
+	}
+}
+
+// TestRecordHostConnectCodexIsSticky pins the documented registry contract: a
+// later non-Codex connect must not downgrade a previously recorded Codex=true
+// entry, or a plain reconnect would silently drop the host from Codex-aware
+// update reminders.
+func TestRecordHostConnectCodexIsSticky(t *testing.T) {
+	withRegistryOverride(t)
+
+	recordHostConnect("venus", "v0.9.2", true)
+	recordHostConnect("venus", "v0.9.3", false)
+
+	reg, _ := hosts.Load()
+	entries := reg.Sorted()
+	if len(entries) != 1 || !entries[0].Codex {
+		t.Fatalf("codex flag must stay sticky across plain connects: %+v", entries)
+	}
+	if entries[0].LastDeployedVersion != "v0.9.3" {
+		t.Fatalf("version must still update: %q", entries[0].LastDeployedVersion)
+	}
+}
+
+func TestRecordHostConnectIgnoresEmptyHost(t *testing.T) {
+	withRegistryOverride(t)
+
+	recordHostConnect("", "v0.9.3", false)
+
+	reg, _ := hosts.Load()
+	if got := len(reg.Sorted()); got != 0 {
+		t.Fatalf("empty host must not be recorded, got %d entries", got)
+	}
+}
+
+func TestClearHostCodex(t *testing.T) {
+	withRegistryOverride(t)
+
+	recordHostConnect("venus", "v0.9.3", true)
+	clearHostCodex("venus")
+
+	reg, _ := hosts.Load()
+	entries := reg.Sorted()
+	if len(entries) != 1 || entries[0].Codex {
+		t.Fatalf("clearHostCodex must flip the sticky flag off: %+v", entries)
+	}
+
+	// Unknown host and empty host are both silent no-ops.
+	clearHostCodex("unknown-host")
+	clearHostCodex("")
+}
+
+func TestPrintPerHostRedeployReminders(t *testing.T) {
+	withRegistryOverride(t)
+
+	if printPerHostRedeployReminders() {
+		t.Fatal("empty registry must report false so the caller falls back to the generic reminder")
+	}
+
+	recordHostConnect("venus", "v0.9.3", false)
+	if !printPerHostRedeployReminders() {
+		t.Fatal("non-empty registry must report true")
+	}
+}
+
+func TestRegistryVersionOrEmpty(t *testing.T) {
+	// main.version is "dev" in test builds; the registry must receive "" so a
+	// dev build never pollutes recorded release versions.
+	if got := registryVersionOrEmpty(); got != normalizeVersion(version) {
+		t.Fatalf("registryVersionOrEmpty() = %q, want normalizeVersion(version) = %q", got, normalizeVersion(version))
+	}
+}
+
+// TestHostsListAndForget covers the happy paths of the two subcommands (the
+// error paths call os.Exit and stay out of unit-test reach by design).
+func TestHostsListAndForget(t *testing.T) {
+	withRegistryOverride(t)
+
+	hostsList() // empty registry prints the "no known hosts" hint
+
+	recordHostConnect("venus", "v0.9.3", true)
+	hostsList() // with an entry prints the table
+
+	hostsForget([]string{"venus"})
+	reg, _ := hosts.Load()
+	if got := len(reg.Sorted()); got != 0 {
+		t.Fatalf("forget must remove the entry, %d left", got)
+	}
+}

--- a/cmd/cc-clip/send_helpers_test.go
+++ b/cmd/cc-clip/send_helpers_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestResolveRemoteDir(t *testing.T) {
+	t.Parallel()
+	const home = "/home/u"
+	tests := []struct {
+		remoteDir string
+		want      string
+	}{
+		{"~", home},
+		{"~/.cache/cc-clip/uploads", "/home/u/.cache/cc-clip/uploads"},
+		{"/var/tmp/up", "/var/tmp/up"},
+		{"/var//tmp/../tmp/up", "/var/tmp/up"},
+		{"uploads", "/home/u/uploads"},
+	}
+	for _, tt := range tests {
+		if got := resolveRemoteDir(home, tt.remoteDir); got != tt.want {
+			t.Errorf("resolveRemoteDir(%q,%q) = %q, want %q", home, tt.remoteDir, got, tt.want)
+		}
+	}
+}
+
+func TestImageExt(t *testing.T) {
+	t.Parallel()
+	tests := []struct{ format, want string }{
+		{"jpeg", "jpg"},
+		{"JPG", "jpg"},
+		{" jpeg ", "jpg"},
+		{"png", "png"},
+		{"tiff", "png"}, // anything non-jpeg serves as png
+		{"", "png"},
+	}
+	for _, tt := range tests {
+		if got := imageExt(tt.format); got != tt.want {
+			t.Errorf("imageExt(%q) = %q, want %q", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestRandomFilename(t *testing.T) {
+	t.Parallel()
+	a, err := randomFilename("png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := randomFilename("png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(a, "clip-") || !strings.HasSuffix(a, ".png") {
+		t.Fatalf("filename shape: %q", a)
+	}
+	// The 4 random bytes exist precisely so two pastes in the same second
+	// cannot collide on the remote.
+	if a == b {
+		t.Fatalf("two filenames must differ: %q", a)
+	}
+}
+
+func TestWriteTempImage(t *testing.T) {
+	t.Parallel()
+	data := []byte{0x89, 0x50, 0x4E, 0x47}
+	path, err := writeTempImage(data, "png")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+
+	if !strings.HasSuffix(path, ".png") {
+		t.Fatalf("temp image must carry the extension: %q", path)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("content mismatch: %v", got)
+	}
+}
+
+func TestDescribeFileMode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mode os.FileMode
+		want string
+	}{
+		{os.ModeDir, "directory"},
+		{os.ModeSymlink, "symlink"},
+		{os.ModeNamedPipe, "named pipe (FIFO)"},
+		{os.ModeSocket, "socket"},
+		{os.ModeDevice, "device"},
+		{os.ModeCharDevice, "device"},
+		{os.ModeIrregular, "irregular file"},
+		{0, "non-regular file"},
+	}
+	for _, tt := range tests {
+		if got := describeFileMode(tt.mode); got != tt.want {
+			t.Errorf("describeFileMode(%v) = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}

--- a/cmd/cc-clip/update_helpers_test.go
+++ b/cmd/cc-clip/update_helpers_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestParseUpdateFlags(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want updateOptions
+	}{
+		{"no flags", nil, updateOptions{}},
+		{"check only", []string{"--check"}, updateOptions{check: true}},
+		{"force and target", []string{"--force", "--to", "v0.6.0"}, updateOptions{force: true, toVer: "v0.6.0"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseUpdateFlags(tt.args); got != tt.want {
+				t.Fatalf("parseUpdateFlags(%v) = %+v, want %+v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisplayVersion(t *testing.T) {
+	t.Parallel()
+	if got := displayVersion(""); !strings.Contains(got, "dev build") {
+		t.Fatalf("empty version must be labeled a dev build: %q", got)
+	}
+	if got := displayVersion("v0.9.3"); got != "v0.9.3" {
+		t.Fatalf("real version must pass through: %q", got)
+	}
+}
+
+func TestDescribeServiceState(t *testing.T) {
+	t.Parallel()
+	running, stopped := describeServiceState(true), describeServiceState(false)
+	if runtime.GOOS == "darwin" {
+		if !strings.Contains(running, "running") || !strings.Contains(stopped, "not running") {
+			t.Fatalf("darwin states: running=%q stopped=%q", running, stopped)
+		}
+		return
+	}
+	if !strings.Contains(running, "not managed") {
+		t.Fatalf("non-darwin must report unmanaged: %q", running)
+	}
+}
+
+// writeChecksums writes a goreleaser-style checksums.txt ("<hash>  <name>").
+func writeChecksums(t *testing.T, dir string, entries map[string]string) string {
+	t.Helper()
+	var b strings.Builder
+	for name, hash := range entries {
+		fmt.Fprintf(&b, "%s  %s\n", hash, name)
+	}
+	path := filepath.Join(dir, "checksums.txt")
+	if err := os.WriteFile(path, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestVerifySHA256(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "cc-clip_0.9.3_darwin_arm64.tar.gz")
+	content := []byte("archive-bytes")
+	if err := os.WriteFile(archive, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	good := hex.EncodeToString(sum[:])
+
+	t.Run("match", func(t *testing.T) {
+		checksums := writeChecksums(t, t.TempDir(), map[string]string{"cc-clip_0.9.3_darwin_arm64.tar.gz": good})
+		if err := verifySHA256(archive, checksums, "cc-clip_0.9.3_darwin_arm64.tar.gz"); err != nil {
+			t.Fatalf("verifySHA256: %v", err)
+		}
+	})
+	t.Run("mismatch is rejected", func(t *testing.T) {
+		checksums := writeChecksums(t, t.TempDir(), map[string]string{"cc-clip_0.9.3_darwin_arm64.tar.gz": strings.Repeat("0", 64)})
+		if err := verifySHA256(archive, checksums, "cc-clip_0.9.3_darwin_arm64.tar.gz"); err == nil || !strings.Contains(err.Error(), "mismatch") {
+			t.Fatalf("want checksum mismatch, got %v", err)
+		}
+	})
+	t.Run("missing entry is rejected", func(t *testing.T) {
+		checksums := writeChecksums(t, t.TempDir(), map[string]string{"other.tar.gz": good})
+		if err := verifySHA256(archive, checksums, "cc-clip_0.9.3_darwin_arm64.tar.gz"); err == nil {
+			t.Fatal("want error for archive absent from checksums.txt")
+		}
+	})
+}
+
+// writeTarGz builds a tar.gz with the given name->content entries.
+func writeTarGz(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+	for name, content := range entries {
+		if err := tw.WriteHeader(&tar.Header{Name: name, Mode: 0o755, Size: int64(len(content)), Typeflag: tar.TypeReg}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestExtractBinary(t *testing.T) {
+	t.Parallel()
+
+	t.Run("finds cc-clip among other entries", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "rel.tar.gz")
+		writeTarGz(t, archive, map[string]string{
+			"README.md":    "docs",
+			"dist/cc-clip": "binary-bytes",
+			"dist/LICENSE": "license",
+		})
+		dest, cleanup, err := extractBinary(archive)
+		if err != nil {
+			t.Fatalf("extractBinary: %v", err)
+		}
+		defer cleanup()
+		got, err := os.ReadFile(dest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != "binary-bytes" {
+			t.Fatalf("extracted content = %q", got)
+		}
+		if info, _ := os.Stat(dest); info.Mode().Perm()&0o100 == 0 {
+			t.Fatalf("extracted binary must be executable, mode=%v", info.Mode())
+		}
+	})
+
+	t.Run("archive without the binary errors", func(t *testing.T) {
+		archive := filepath.Join(t.TempDir(), "rel.tar.gz")
+		writeTarGz(t, archive, map[string]string{"README.md": "docs"})
+		_, cleanup, err := extractBinary(archive)
+		defer cleanup()
+		if err == nil || !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("want not-found error, got %v", err)
+		}
+	})
+}
+
+func TestRenameAtomic(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := renameAtomic(src, dst); err != nil {
+		t.Fatalf("renameAtomic: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("dst content = %q, err=%v", got, err)
+	}
+	if err := renameAtomic(filepath.Join(dir, "missing"), dst); err == nil {
+		t.Fatal("missing source must error")
+	}
+}
+
+func TestResolveSelfPath(t *testing.T) {
+	t.Parallel()
+	p, err := resolveSelfPath()
+	if err != nil {
+		t.Fatalf("resolveSelfPath: %v", err)
+	}
+	if !filepath.IsAbs(p) {
+		t.Fatalf("path must be absolute: %q", p)
+	}
+}


### PR DESCRIPTION
Closes item **I4** of #20: `cmd/cc-clip` was the remaining coverage target (30%), sitting at 24.2% — now **30.5%** (`go test ./cmd/cc-clip -cover -count=1`). `internal/shim` already met its 60% target at 65.9%, so I4 is done entirely.

Tests pin real contracts, not just lines:

- **`hosts.go`** (was 0%): `recordHostConnect` round trip; the **sticky codex flag** — a later plain connect must not downgrade `Codex=true`, which is the documented registry contract; `clearHostCodex` incl. unknown host; `printPerHostRedeployReminders`' false-on-empty fallback; `hostsList` / `hostsForget` happy paths. All behind `hosts.RegistryPathOverride` — the real registry is never touched.
- **`update.go` helpers**: `parseUpdateFlags`, `displayVersion` dev-build labeling, `describeServiceState` per GOOS, `verifySHA256` (match / **mismatch rejected** / archive absent from checksums.txt), `extractBinary` (finds `cc-clip` among other tar entries, preserves the executable bit, errors when absent), `renameAtomic`, `resolveSelfPath`.
- **`send.go` helpers**: `resolveRemoteDir` (`~`, `~/x`, absolute with path cleaning, relative), `imageExt`, `randomFilename` shape + non-collision, `writeTempImage`, `describeFileMode` across every mode bit.

Error paths that call `os.Exit` stay uncovered by design — they are the CLI's crash surface, not logic.

After this merges, #20 has exactly one item left: **I1** (the `main.go` split), which needs its target restated first — the file is 2416 lines now, so the issue's "1624 → ~800" framing is stale on both ends.

Test-only change; full race suite, vet, staticcheck clean.