### PR TITLE
docs: the /health version field ships in v0.10.0, not v0.9.3

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,7 +14,7 @@ If image paste isn't working, run these checks **in order** to isolate the probl
 # 1. Local: Is the daemon running?
 curl -s http://127.0.0.1:18339/health
 # Expected: {"service":"cc-clip","status":"ok","version":"..."}
-# ("version" appears from v0.9.3; older daemons omit it)
+# ("version" appears from v0.10.0; older daemons omit it)
 
 # 2. Remote: Is the tunnel forwarding?
 ssh myserver "curl -s http://127.0.0.1:18339/health"


### PR DESCRIPTION
One-line release blocker for the upcoming tag: docs/troubleshooting.md said the `/health` `version` field appears from v0.9.3, written before the release number was decided. The delta since v0.9.2 carries three features (`--use-remote-bin`, `--cursor`, `cc-clip copy`), so per semver the next tag is a **minor** bump — v0.10.0.