### PR TITLE
feat(doctor): cover the notification bridge (#22 P1)

### DIFF
--- a/internal/doctor/notify_checks.go
+++ b/internal/doctor/notify_checks.go
@@ -1,0 +1,108 @@
+package doctor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shunmei/cc-clip/internal/shim"
+)
+
+// Notification-bridge checks (#22 P1). Each probe prints exactly one marker
+// (the tunnel-probe pattern) so classification survives shell noise, and the
+// detection keys come from the shim package — the same strings connect
+// installs — so doctor can never drift from the deploy.
+//
+// Classification philosophy, informed by real field states: a bare
+// user-authored "cc-clip-hook" and a pre-managed-era codex notify line both
+// WORK — they are reported OK with a migration note, not as failures. Failures
+// are reserved for states where notifications demonstrably cannot fire.
+
+// claudeHooksProbeCommand classifies how (or whether) Claude Code notification
+// hooks are wired on the remote. Managed is checked before user-authored:
+// both patterns can appear in one file and managed is the stronger claim.
+var claudeHooksProbeCommand = fmt.Sprintf(`f="$HOME/.claude/settings.json"
+if [ ! -f "$f" ]; then
+    echo 'claude-hooks:no-file'
+elif grep -qF '%s' "$f"; then
+    echo 'claude-hooks:managed'
+elif grep -qF 'cc-clip-hook' "$f"; then
+    echo 'claude-hooks:user-authored'
+else
+    echo 'claude-hooks:none'
+fi`, shim.ClaudeManagedOwnerPrefix)
+
+// codexNotifyProbeCommand classifies the notify wiring in ~/.codex/config.toml.
+var codexNotifyProbeCommand = fmt.Sprintf(`f="$HOME/.codex/config.toml"
+if [ ! -f "$f" ]; then
+    echo 'codex-notify:no-codex'
+elif grep -qF '%s' "$f"; then
+    echo 'codex-notify:managed'
+elif grep -E '^[[:space:]]*("notify"|notify)[[:space:]]*=' "$f" | grep -q 'cc-clip'; then
+    echo 'codex-notify:unmanaged-cc-clip'
+elif grep -qE '^[[:space:]]*("notify"|notify)[[:space:]]*=' "$f"; then
+    echo 'codex-notify:foreign'
+else
+    echo 'codex-notify:none'
+fi`, shim.CodexNotifyMarkerStart)
+
+const notifyNonceProbeCommand = `test -f "$HOME/.cache/cc-clip/notify.nonce" && echo present || echo missing`
+
+const hookScriptProbeCommand = `test -x "$HOME/.local/bin/cc-clip-hook" && echo installed || echo missing`
+
+func classifyClaudeHooksCheck(out string, err error) CheckResult {
+	if err != nil {
+		return CheckResult{"claude-hooks", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	switch {
+	case strings.Contains(out, "claude-hooks:managed"):
+		return CheckResult{"claude-hooks", true, "managed notify runner wired in ~/.claude/settings.json"}
+	case strings.Contains(out, "claude-hooks:user-authored"):
+		return CheckResult{"claude-hooks", true, "user-authored cc-clip-hook wired (works via the fallback script; delete it and re-run 'cc-clip connect <host> --claude' to migrate to the managed runner)"}
+	case strings.Contains(out, "claude-hooks:no-file"):
+		return CheckResult{"claude-hooks", true, "~/.claude/settings.json not found (Claude Code not set up; skipped)"}
+	case strings.Contains(out, "claude-hooks:none"):
+		return CheckResult{"claude-hooks", false, "Claude Code is set up but no cc-clip notification hooks are wired; run 'cc-clip connect <host> --claude'"}
+	default:
+		return CheckResult{"claude-hooks", false, "check did not complete (unrecognized probe output)"}
+	}
+}
+
+func classifyCodexNotifyCheck(out string, err error) CheckResult {
+	if err != nil {
+		return CheckResult{"codex-notify", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	switch {
+	case strings.Contains(out, "codex-notify:no-codex"):
+		return CheckResult{"codex-notify", true, "~/.codex/config.toml not found (Codex not set up; skipped)"}
+	case strings.Contains(out, "codex-notify:managed"):
+		return CheckResult{"codex-notify", true, "managed notify block present in ~/.codex/config.toml"}
+	case strings.Contains(out, "codex-notify:unmanaged-cc-clip"):
+		return CheckResult{"codex-notify", true, "an unmanaged cc-clip notify line is configured (functional; remove it and re-run 'cc-clip connect <host> --codex' to adopt the managed block)"}
+	case strings.Contains(out, "codex-notify:foreign"):
+		return CheckResult{"codex-notify", true, "a non-cc-clip notify setting is configured; cc-clip respects it and will refuse to inject over it"}
+	case strings.Contains(out, "codex-notify:none"):
+		return CheckResult{"codex-notify", false, "Codex is set up but notifications are not wired; run 'cc-clip connect <host> --codex'"}
+	default:
+		return CheckResult{"codex-notify", false, "check did not complete (unrecognized probe output)"}
+	}
+}
+
+func classifyNotifyNonceCheck(out string, err error) CheckResult {
+	if err != nil {
+		return CheckResult{"notify-nonce", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	if strings.Contains(out, "present") {
+		return CheckResult{"notify-nonce", true, "notification nonce present"}
+	}
+	return CheckResult{"notify-nonce", false, "notification nonce missing — notifications cannot authenticate; run 'cc-clip connect <host>'"}
+}
+
+func classifyHookScriptCheck(out string, err error) CheckResult {
+	if err != nil {
+		return CheckResult{"notify-hook-script", false, fmt.Sprintf("remote check could not run over SSH: %v (%s)", err, strings.TrimSpace(out))}
+	}
+	if strings.Contains(out, "installed") {
+		return CheckResult{"notify-hook-script", true, "fallback hook script installed at ~/.local/bin/cc-clip-hook"}
+	}
+	return CheckResult{"notify-hook-script", false, "cc-clip-hook missing from ~/.local/bin; run 'cc-clip connect <host>'"}
+}

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -83,6 +83,17 @@ func RunRemote(host string, port int) []CheckResult {
 	// Check PATH fix (rc file marker)
 	results = append(results, checkPathFix(host)...)
 
+	// Notification bridge (#22 P1): four checks that were previously only
+	// observable during connect's N-steps.
+	out, err = remoteExecNoForward(host, hookScriptProbeCommand)
+	results = append(results, classifyHookScriptCheck(out, err))
+	out, err = remoteExecNoForward(host, notifyNonceProbeCommand)
+	results = append(results, classifyNotifyNonceCheck(out, err))
+	out, err = remoteExecNoForward(host, claudeHooksProbeCommand)
+	results = append(results, classifyClaudeHooksCheck(out, err))
+	out, err = remoteExecNoForward(host, codexNotifyProbeCommand)
+	results = append(results, classifyCodexNotifyCheck(out, err))
+
 	// End-to-end image round-trip (only if tunnel is up)
 	if tunnelOK(results) {
 		results = append(results, runImageProbe(host, port)...)

--- a/internal/doctor/remote_test.go
+++ b/internal/doctor/remote_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/shunmei/cc-clip/internal/shim"
 )
 
 func TestImageProbeCommandKeepsTokenOutOfCurlArgv(t *testing.T) {
@@ -165,5 +167,147 @@ func TestRemoteBinProbeCommand(t *testing.T) {
 	}
 	if !strings.Contains(cmd, `"$bin"`) || !strings.Contains(cmd, `($bin)`) {
 		t.Fatalf("probe output must include the resolved path so the operator sees which binary answered:\n%s", cmd)
+	}
+}
+
+// TestNotifyBridgeProbeCommands pins the four notification-bridge probes
+// (#22 P1). Marker-based outputs follow the tunnel-probe pattern; detection
+// keys come from the shim package so doctor can never drift from what
+// connect actually installs.
+func TestNotifyBridgeProbeCommands(t *testing.T) {
+	t.Parallel()
+
+	t.Run("claude hooks probe", func(t *testing.T) {
+		cmd := claudeHooksProbeCommand
+		for _, want := range []string{
+			`$HOME/.claude/settings.json`,
+			shim.ClaudeManagedOwnerPrefix, // managed-runner detection key
+			"cc-clip-hook",                // user-authored fallback detection
+			"claude-hooks:no-file", "claude-hooks:managed", "claude-hooks:user-authored", "claude-hooks:none",
+			"grep -qF", // fixed-string match; the keys contain shell/regex metachars
+		} {
+			if !strings.Contains(cmd, want) {
+				t.Fatalf("claude hooks probe must contain %q:\n%s", want, cmd)
+			}
+		}
+		// Managed must be checked BEFORE user-authored: the managed command is
+		// itself matched by a bare "cc-clip-hook"-style substring sweep only if
+		// ordered wrong... more precisely, both patterns can coexist in one
+		// file and managed is the stronger claim.
+		if strings.Index(cmd, "claude-hooks:managed") > strings.Index(cmd, "claude-hooks:user-authored") {
+			t.Fatalf("managed detection must precede user-authored:\n%s", cmd)
+		}
+	})
+
+	t.Run("codex notify probe", func(t *testing.T) {
+		cmd := codexNotifyProbeCommand
+		for _, want := range []string{
+			`$HOME/.codex/config.toml`,
+			shim.CodexNotifyMarkerStart,
+			"codex-notify:no-codex", "codex-notify:managed", "codex-notify:unmanaged-cc-clip",
+			"codex-notify:foreign", "codex-notify:none",
+		} {
+			if !strings.Contains(cmd, want) {
+				t.Fatalf("codex notify probe must contain %q:\n%s", want, cmd)
+			}
+		}
+	})
+
+	t.Run("nonce and hook script probes", func(t *testing.T) {
+		if !strings.Contains(notifyNonceProbeCommand, "notify.nonce") {
+			t.Fatalf("nonce probe must check the nonce file:\n%s", notifyNonceProbeCommand)
+		}
+		if !strings.Contains(hookScriptProbeCommand, ".local/bin/cc-clip-hook") {
+			t.Fatalf("hook script probe must check the installed path:\n%s", hookScriptProbeCommand)
+		}
+	})
+}
+
+// TestClassifyClaudeHooksCheck: the venus field case — a bare user-authored
+// cc-clip-hook — must classify as OK (notifications work through the bash
+// fallback) with a migration hint, NOT as a failure.
+func TestClassifyClaudeHooksCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		out         string
+		err         error
+		wantOK      bool
+		wantContain string
+	}{
+		{"ssh transport failure", "boom", fmt.Errorf("exit status 255"), false, "could not run over SSH"},
+		{"managed runner wired", "claude-hooks:managed", nil, true, "managed"},
+		{"user-authored fallback works but can migrate", "claude-hooks:user-authored", nil, true, "user-authored"},
+		{"settings file absent is a skip", "claude-hooks:no-file", nil, true, "skipped"},
+		{"claude present but unwired", "claude-hooks:none", nil, false, "connect"},
+		{"unrecognized output fails closed", "bash: whatever", nil, false, "did not complete"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyClaudeHooksCheck(tt.out, tt.err)
+			if got.OK != tt.wantOK {
+				t.Fatalf("OK = %v, want %v (msg=%q)", got.OK, tt.wantOK, got.Message)
+			}
+			if !strings.Contains(got.Message, tt.wantContain) {
+				t.Fatalf("message %q must contain %q", got.Message, tt.wantContain)
+			}
+		})
+	}
+}
+
+// TestClassifyCodexNotifyCheck: the venus field case — an old unmanaged
+// cc-clip notify line — is functional and must be OK with a note, not a
+// failure; a foreign notify must be OK (the guard refusing to inject over it
+// is by design) but named.
+func TestClassifyCodexNotifyCheck(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		out         string
+		err         error
+		wantOK      bool
+		wantContain string
+	}{
+		{"ssh transport failure", "", fmt.Errorf("exit status 255"), false, "could not run over SSH"},
+		{"codex absent is a skip", "codex-notify:no-codex", nil, true, "skipped"},
+		{"managed block", "codex-notify:managed", nil, true, "managed"},
+		{"unmanaged cc-clip line still works", "codex-notify:unmanaged-cc-clip", nil, true, "unmanaged"},
+		{"foreign notify named but respected", "codex-notify:foreign", nil, true, "non-cc-clip"},
+		{"codex present but unwired", "codex-notify:none", nil, false, "--codex"},
+		{"unrecognized output fails closed", "garbage", nil, false, "did not complete"},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyCodexNotifyCheck(tt.out, tt.err)
+			if got.OK != tt.wantOK {
+				t.Fatalf("OK = %v, want %v (msg=%q)", got.OK, tt.wantOK, got.Message)
+			}
+			if !strings.Contains(got.Message, tt.wantContain) {
+				t.Fatalf("message %q must contain %q", got.Message, tt.wantContain)
+			}
+		})
+	}
+}
+
+func TestClassifyNotifyPresenceChecks(t *testing.T) {
+	t.Parallel()
+	if got := classifyNotifyNonceCheck("present", nil); !got.OK {
+		t.Fatalf("present nonce must be OK: %+v", got)
+	}
+	if got := classifyNotifyNonceCheck("missing", nil); got.OK || !strings.Contains(got.Message, "connect") {
+		t.Fatalf("missing nonce must fail with the sync command: %+v", got)
+	}
+	if got := classifyNotifyNonceCheck("", fmt.Errorf("exit 255")); got.OK || !strings.Contains(got.Message, "could not run over SSH") {
+		t.Fatalf("ssh failure must be distinct: %+v", got)
+	}
+	if got := classifyHookScriptCheck("installed", nil); !got.OK {
+		t.Fatalf("installed hook script must be OK: %+v", got)
+	}
+	if got := classifyHookScriptCheck("missing", nil); got.OK {
+		t.Fatalf("missing hook script must fail: %+v", got)
 	}
 }

--- a/internal/shim/settings.go
+++ b/internal/shim/settings.go
@@ -20,6 +20,12 @@ const claudeManagedHookCommand = "env CC_CLIP_MANAGED=1 cc-clip plugin run claud
 // "cc-clip-hook" lacks this prefix and is therefore never matched or stripped.
 const claudeManagedHookOwnerPrefix = "env CC_CLIP_MANAGED=1"
 
+// ClaudeManagedOwnerPrefix exposes the ownership marker to other packages
+// (doctor's remote checks) so their detection can never drift from what the
+// settings merge actually installs. Same permanence contract as the
+// unexported constant it aliases.
+const ClaudeManagedOwnerPrefix = claudeManagedHookOwnerPrefix
+
 var claudeManagedEvents = []string{"Stop", "Notification"}
 
 // isManagedClaudeCommand reports whether command is cc-clip-owned, keying off the

--- a/internal/shim/ssh.go
+++ b/internal/shim/ssh.go
@@ -487,8 +487,14 @@ func RemoteHasCodex(session RemoteExecutor) (bool, error) {
 // trap, so any internal failure (mktemp, sed, mv) propagates to a
 // non-zero SSH exit code instead of being masked by the trailing
 // `rm -f` of the temp file.
+
+// CodexNotifyMarkerStart opens the cc-clip-managed block in ~/.codex/config.toml.
+// Exported so doctor's remote checks detect the managed block with the exact
+// string this injector writes, never a drifted copy.
+const CodexNotifyMarkerStart = "# >>> cc-clip notify (do not edit) >>>"
+
 func EnsureRemoteCodexNotifyConfig(session RemoteExecutor, port int) error {
-	const markerStart = "# >>> cc-clip notify (do not edit) >>>"
+	const markerStart = CodexNotifyMarkerStart
 	const markerEnd = "# <<< cc-clip notify (do not edit) <<<"
 
 	managedBlock := codexNotifyManagedBlock(markerStart, markerEnd, port)
@@ -558,7 +564,7 @@ trap - EXIT
 // EnsureRemoteCodexNotifyConfig so a crash mid-write leaves either the
 // original file or the cleaned file — never a partial state.
 func StripRemoteCodexNotifyConfig(session RemoteExecutor) error {
-	const markerStart = "# >>> cc-clip notify (do not edit) >>>"
+	const markerStart = CodexNotifyMarkerStart
 	const markerEnd = "# <<< cc-clip notify (do not edit) <<<"
 
 	script := fmt.Sprintf(`set -e


### PR DESCRIPTION
Closes the last open item of #22.

`doctor --host` checked the clipboard path only — the notification bridge had zero coverage (`grep -iE 'hook|notify|nonce|codex'` across `internal/doctor/` returned nothing), so states like "hooks wired through the legacy fallback" were observable exclusively in `connect`'s N-step output. Four remote checks close that gap:

| Check | States |
|---|---|
| `notify-hook-script` | installed / missing |
| `notify-nonce` | present / missing |
| `claude-hooks` | managed / **user-authored** / none / no-file |
| `codex-notify` | managed / **unmanaged-cc-clip** / foreign / none / no-codex |

## Calibrated against a real field host

The two bolded states come from an actual deployment inspected today: a bare user-authored `cc-clip-hook` entry in `settings.json`, and a pre-managed-era `notify = ["cc-clip", "notify", "--from-codex-stdin"]` line in `config.toml`. **Both work** — so they classify OK with a migration command, not as failures. Failures are reserved for states where notifications demonstrably cannot fire (nonce missing; hooks absent while the tool is installed). A foreign (non-cc-clip) notify setting is respected and named, mirroring the injector's own refusal to overwrite it.

## No drift by construction

Detection keys are the shim package's own strings, newly exported: `shim.ClaudeManagedOwnerPrefix` and `shim.CodexNotifyMarkerStart` (the latter replacing two duplicated function-local consts in `ssh.go`). Probes emit single markers per the tunnel-probe pattern; unrecognized output fails closed as "did not complete", and SSH transport failures stay distinct from check outcomes, consistent with the existing classifiers.

## Remediation model

Per the agreed direction, doctor stays **read-only**: every failing or migratable state names the exact command to run (`cc-clip connect <host> --claude` / `--codex`), never mutating anything itself.

Tests: probe-content assertions (including managed-before-user-authored ordering), full classification tables for both multi-state checks incl. fail-closed defaults, presence checks, SSH-failure distinctness. Full race suite, vet, staticcheck, GOOS=linux build clean.