### PR TITLE
feat(shim): transparent reverse copy — clipboard writes land locally (#128 phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,8 @@ goreleaser config: `.goreleaser.yaml`. Release is published automatically (not d
 The shim intercepts these invocation shapes (covers Claude Code, opencode, and Cursor CLI; other consumers that use the same flags get interception for free):
 - xclip: `*"-selection clipboard"*"-t TARGETS"*"-o"*` and `*"-selection clipboard"*"-t image/"*"-o"*`
 - wl-paste: `*"--list-types"*` (type listing — Claude) and `*"--type"*"image/"*`, `*"-t image/"*` (image read — Claude and Cursor use `--type`, opencode uses `-t`)
+- xclip WRITE (#128 phase 2): `*"-selection clipboard"*` without `-o`/`-out` in argv — dual-write: the payload is POSTed to the local daemon (`/clipboard/text`) AND replayed into the real xclip, so the remote clipboard behaves exactly as before. Success if EITHER side takes the copy (headless remotes have no real xclip). `-selection primary` and unmatched `-o` read shapes fall through untouched.
+- wl-copy (separate companion shim, installed with the wl-paste target): forwards plain clipboard TEXT writes the same dual-write way; `--primary`, `--clear`, non-text `--type`, `-v`/`-h` and unknown options pass through to the real binary. `-n/--trim-newline` is mirrored on the forwarded payload so both clipboards end up byte-identical.
 
 Cursor reads via `xclip -selection clipboard -t <mime> -o` / `wl-paste --type <mime>` over image/png,jpeg,gif,webp — all four hit the existing image branches, so the transport needs no new shim code. Its gate is environmental: Cursor only attempts a clipboard read when `DISPLAY` or `WAYLAND_DISPLAY` is set in its shell, and cc-clip deliberately does not inject one (issue #109, option C). It also kills clipboard children after ~4s, hence the `CC_CLIP_FETCH_TIMEOUT_MS=3000` guidance printed by the Cursor target.
 

--- a/internal/daemon/clipwrite.go
+++ b/internal/daemon/clipwrite.go
@@ -63,8 +63,14 @@ func (s *Server) handleClipboardWrite(w http.ResponseWriter, r *http.Request) {
 		Source:    "clipboard-write",
 		Timestamp: time.Now().UTC(),
 		GenericMessage: &GenericMessagePayload{
-			Title:   "Clipboard set by remote",
-			Body:    fmt.Sprintf("A remote session copied %d bytes to this clipboard.", len(body)),
+			Title: "Clipboard set by remote",
+			// Deliberately STABLE text (no byte count): the dedup window keys
+			// on the envelope fingerprint, so a constant body lets a burst of
+			// writes — every neovim yank on the transparent shim path (#128
+			// phase 2) is one write — collapse into a single notification
+			// instead of spamming one per yank. Poisoning visibility is
+			// preserved: at least one notification always fires per window.
+			Body:    "A remote session wrote to this clipboard.",
 			Urgency: 0,
 		},
 	})

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 )
 
-
 type Target string
 
 const (
@@ -18,10 +17,10 @@ const (
 )
 
 type InstallResult struct {
-	Target       Target
-	ShimPath     string
-	RealBinPath  string
-	InstallDir   string
+	Target      Target
+	ShimPath    string
+	RealBinPath string
+	InstallDir  string
 }
 
 func DetectTarget() Target {
@@ -129,6 +128,24 @@ func Install(target Target, installDir string, port int) (InstallResult, error) 
 		return InstallResult{}, fmt.Errorf("failed to write shim: %w", err)
 	}
 
+	// Wayland writes go through wl-copy, a separate binary from wl-paste, so
+	// the wayland target ships a write-side companion shim (#128 phase 2).
+	// xclip needs none: reads and writes share one binary, and the write
+	// branch lives in the same script. Best-effort like the main shim: a
+	// missing real wl-copy still installs the shim (forward-only remote).
+	if resolved == TargetWlPaste {
+		wlCopyPath := filepath.Join(installDir, "wl-copy")
+		if !isOurShim(wlCopyPath) {
+			realWlCopy, err := findRealBinary("wl-copy", installDir)
+			if err != nil {
+				realWlCopy = "/usr/bin/wl-copy"
+			}
+			if err := os.WriteFile(wlCopyPath, []byte(WlCopyShim(port, realWlCopy)), 0755); err != nil {
+				return InstallResult{}, fmt.Errorf("failed to write wl-copy shim: %w", err)
+			}
+		}
+	}
+
 	return InstallResult{
 		Target:      resolved,
 		ShimPath:    shimPath,
@@ -153,6 +170,17 @@ func Uninstall(target Target, installDir string) error {
 
 	if err := os.Remove(shimPath); err != nil {
 		return fmt.Errorf("failed to remove shim: %w", err)
+	}
+
+	// The wayland install ships a wl-copy companion; remove it with its
+	// wl-paste sibling, but only when it is genuinely ours.
+	if resolved == TargetWlPaste {
+		wlCopyPath := filepath.Join(installDir, "wl-copy")
+		if isOurShim(wlCopyPath) {
+			if err := os.Remove(wlCopyPath); err != nil {
+				return fmt.Errorf("failed to remove wl-copy shim: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/shim/template.go
+++ b/internal/shim/template.go
@@ -156,6 +156,23 @@ _cc_clip_fetch_binary() {
     fi
 }
 
+# Forward a captured clipboard write to the LOCAL machine, byte-exact
+# (--data-binary from a file: no shell-variable NUL/newline mangling).
+_cc_clip_post_text() {
+    local file="$1"
+    local token
+    token=$(_cc_clip_read_token) || return 12
+    local timeout_s
+    timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
+    _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
+        -X POST -H "Content-Type: text/plain; charset=utf-8" \
+        --data-binary @"$file" \
+        -K - \
+        "http://${CC_CLIP_ADDR}/clipboard/text" >/dev/null
+}
+
 # Parse arguments to detect Claude Code invocation patterns
 ARGS="$*"
 
@@ -215,6 +232,49 @@ case "$ARGS" in
             _cc_clip_log "tunnel not reachable"
             _cc_clip_fallback "$@"
         fi
+        ;;
+
+    *"-selection clipboard"*)
+        # Clipboard WRITE (xclip's default mode is -in: stdin -> selection).
+        # This is the reverse-clipboard transparent path (#128 phase 2):
+        # remote tools that copy via xclip (neovim unnamedplus, tmux
+        # copy-command, TUI copy actions) land on the LOCAL clipboard too.
+        # Unrecognized READ shapes carrying -o must keep the old fallback,
+        # so scan argv for the output flag first.
+        for _cc_clip_arg in "$@"; do
+            case "$_cc_clip_arg" in
+                -o|-out) _cc_clip_fallback "$@" ;;
+            esac
+        done
+        _cc_clip_log "intercepting clipboard write (dual-write)"
+        _cc_clip_wtmp=$(mktemp 2>/dev/null) || _cc_clip_fallback "$@"
+        cat > "$_cc_clip_wtmp"
+        # Best-effort local forward; the REMOTE clipboard behavior below is
+        # never blocked by it.
+        _cc_clip_forwarded=0
+        if _cc_clip_probe && _cc_clip_post_text "$_cc_clip_wtmp"; then
+            _cc_clip_forwarded=1
+            _cc_clip_log "forwarded to local clipboard"
+        else
+            _cc_clip_log "local forward failed or tunnel down"
+        fi
+        # Replay into the real xclip so the remote clipboard is populated
+        # exactly as without the shim. xclip daemonizes to own the selection,
+        # so this returns promptly.
+        _cc_clip_real_rc=0
+        if _cc_clip_wreal="$(_cc_clip_resolve_real_xclip)"; then
+            "$_cc_clip_wreal" "$@" < "$_cc_clip_wtmp" || _cc_clip_real_rc=$?
+        else
+            _cc_clip_real_rc=127
+        fi
+        rm -f "$_cc_clip_wtmp"
+        # Success if EITHER side took the copy: a headless remote (no real
+        # xclip / no DISPLAY) with a working tunnel is the primary use case,
+        # and must not fail the caller.
+        if [ "$_cc_clip_real_rc" -eq 0 ] || [ "$_cc_clip_forwarded" -eq 1 ]; then
+            exit 0
+        fi
+        exit "$_cc_clip_real_rc"
         ;;
 
     *)

--- a/internal/shim/template_wlcopy.go
+++ b/internal/shim/template_wlcopy.go
@@ -1,0 +1,226 @@
+package shim
+
+import "fmt"
+
+// wlCopyShimTemplate is the Wayland WRITE-side companion to the wl-paste shim
+// (#128 phase 2). wl-paste covers reads; remote tools COPY through wl-copy
+// (neovim's wl-clipboard provider, tmux copy-command, TUI copy actions), so a
+// wayland install ships both shims. Dual-write: the payload is forwarded to
+// the LOCAL clipboard through the tunnel, then replayed into the real wl-copy
+// so remote behavior is unchanged. Only plain clipboard TEXT writes are
+// forwarded — --primary, --clear, non-text --type, -v/-h and unknown options
+// pass through untouched.
+const wlCopyShimTemplate = `#!/bin/bash
+# cc-clip wl-copy shim - forwards remote clipboard writes to the local machine (Wayland)
+# Installed by: cc-clip install
+# Remove with:  cc-clip uninstall
+
+set -euo pipefail
+
+CC_CLIP_PORT="${CC_CLIP_PORT:-%d}"
+CC_CLIP_ADDR="127.0.0.1:${CC_CLIP_PORT}"
+CC_CLIP_TOKEN_FILE="${CC_CLIP_TOKEN_FILE:-${HOME}/.cache/cc-clip/session.token}"
+CC_CLIP_SESSION_FILE="${CC_CLIP_SESSION_FILE:-${HOME}/.cache/cc-clip/session.id}"
+CC_CLIP_PROBE_TIMEOUT_MS="${CC_CLIP_PROBE_TIMEOUT_MS:-500}"
+CC_CLIP_FETCH_TIMEOUT_MS="${CC_CLIP_FETCH_TIMEOUT_MS:-5000}"
+REAL_WL_COPY="%s"
+_CC_CLIP_SELF_PATH="${BASH_SOURCE[0]:-$0}"
+case "$_CC_CLIP_SELF_PATH" in
+    */*) _CC_CLIP_SELF_DIR="${_CC_CLIP_SELF_PATH%%/*}" ;;
+    *) _CC_CLIP_SELF_DIR="$(pwd)" ;;
+esac
+if ! _CC_CLIP_SELF_DIR="$(cd "$_CC_CLIP_SELF_DIR" 2>/dev/null && pwd)"; then
+    _CC_CLIP_SELF_DIR="$(pwd)"
+fi
+_CC_CLIP_SELF_FILE="$_CC_CLIP_SELF_DIR/${_CC_CLIP_SELF_PATH##*/}"
+
+_cc_clip_log() {
+    if [ "${CC_CLIP_DEBUG:-}" = "1" ]; then
+        echo "cc-clip-shim: $*" >&2
+    fi
+}
+
+_cc_clip_resolve_real_wl_copy() {
+    if [ -n "${REAL_WL_COPY:-}" ] && [ -x "$REAL_WL_COPY" ]; then
+        local real_parent real_name real_dir real_path
+        case "$REAL_WL_COPY" in
+            */*) real_parent="${REAL_WL_COPY%%/*}"; real_name="${REAL_WL_COPY##*/}" ;;
+            *) real_parent="."; real_name="$REAL_WL_COPY" ;;
+        esac
+        real_dir="$(cd "$real_parent" 2>/dev/null && pwd)" || real_dir=""
+        real_path="$real_dir/$real_name"
+        if [ "$real_path" != "$_CC_CLIP_SELF_FILE" ]; then
+            printf '%%s\n' "$REAL_WL_COPY"
+            return 0
+        fi
+    fi
+
+    local old_ifs="$IFS"
+    IFS=:
+    local dir
+    for dir in $PATH; do
+        [ -n "$dir" ] || dir="."
+        local abs_dir
+        abs_dir="$(cd "$dir" 2>/dev/null && pwd)" || continue
+        [ "$abs_dir" = "$_CC_CLIP_SELF_DIR" ] && continue
+        if [ -x "$abs_dir/wl-copy" ] && [ ! -d "$abs_dir/wl-copy" ]; then
+            IFS="$old_ifs"
+            printf '%%s\n' "$abs_dir/wl-copy"
+            return 0
+        fi
+    done
+    IFS="$old_ifs"
+    return 1
+}
+
+_cc_clip_fallback() {
+    local real_wl_copy
+    if ! real_wl_copy="$(_cc_clip_resolve_real_wl_copy)"; then
+        echo "cc-clip-shim: real wl-copy binary not found; install wl-clipboard or remove the cc-clip shim" >&2
+        exit 127
+    fi
+    _cc_clip_log "falling back to real wl-copy: $real_wl_copy $*"
+    exec "$real_wl_copy" "$@"
+}
+
+_cc_clip_read_token() {
+    if [ ! -f "$CC_CLIP_TOKEN_FILE" ]; then
+        return 1
+    fi
+    cat "$CC_CLIP_TOKEN_FILE"
+}
+
+_cc_clip_session_header() {
+    if [ -f "$CC_CLIP_SESSION_FILE" ]; then
+        echo "X-CC-Clip-Session: $(cat "$CC_CLIP_SESSION_FILE" 2>/dev/null)"
+    fi
+}
+
+_cc_clip_curl_config() {
+    local token="$1"
+    local session_hdr="${2:-}"
+    printf 'header = "Authorization: Bearer %%s"\n' "$token"
+    printf 'header = "User-Agent: cc-clip/0.1"\n'
+    if [ -n "$session_hdr" ]; then
+        printf 'header = "%%s"\n' "$session_hdr"
+    fi
+}
+
+_cc_clip_probe() {
+    local timeout_s
+    timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_PROBE_TIMEOUT_MS}/1000}")
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeout_s" bash -c "echo >/dev/tcp/${CC_CLIP_ADDR%%%%:*}/${CC_CLIP_ADDR##*:}" 2>/dev/null
+    elif command -v nc >/dev/null 2>&1; then
+        nc -z -w 1 "${CC_CLIP_ADDR%%%%:*}" "${CC_CLIP_ADDR##*:}" 2>/dev/null
+    else
+        bash -c "echo >/dev/tcp/${CC_CLIP_ADDR%%%%:*}/${CC_CLIP_ADDR##*:}" 2>/dev/null
+    fi
+}
+
+_cc_clip_post_text() {
+    local file="$1"
+    local token
+    token=$(_cc_clip_read_token) || return 12
+    local timeout_s
+    timeout_s=$(awk "BEGIN {printf \"%%f\", ${CC_CLIP_FETCH_TIMEOUT_MS}/1000}")
+    local session_hdr
+    session_hdr=$(_cc_clip_session_header)
+    _cc_clip_curl_config "$token" "$session_hdr" | curl -sf --max-time "$timeout_s" \
+        -X POST -H "Content-Type: text/plain; charset=utf-8" \
+        --data-binary @"$file" \
+        -K - \
+        "http://${CC_CLIP_ADDR}/clipboard/text" >/dev/null
+}
+
+# --- option scan (wl-copy semantics) ---
+_ORIG=("$@")
+primary=0
+clear=0
+trim=0
+mime=""
+passthrough=0
+positional=()
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -p|--primary) primary=1 ;;
+        -c|--clear) clear=1 ;;
+        -n|--trim-newline) trim=1 ;;
+        -t|--type) mime="${2:-}"; shift ;;
+        --type=*) mime="${1#--type=}" ;;
+        -s|--seat) shift ;;
+        --seat=*) ;;
+        -f|--foreground|-o|--paste-once) ;;
+        -v|--version|-h|--help) passthrough=1 ;;
+        --) shift; while [ $# -gt 0 ]; do positional+=("$1"); shift; done; break ;;
+        -*) passthrough=1 ;;
+        *) positional+=("$1") ;;
+    esac
+    if [ $# -gt 0 ]; then shift; fi
+done
+
+# Only plain clipboard text writes are forwarded; everything else keeps the
+# exact real-binary behavior.
+if [ "$passthrough" -eq 1 ] || [ "$primary" -eq 1 ] || [ "$clear" -eq 1 ]; then
+    _cc_clip_fallback ${_ORIG[@]+"${_ORIG[@]}"}
+fi
+case "$mime" in
+    ""|text/*|TEXT|STRING|UTF8_STRING) ;;
+    *) _cc_clip_fallback ${_ORIG[@]+"${_ORIG[@]}"} ;;
+esac
+
+_cc_clip_log "intercepting wl-copy clipboard write (dual-write)"
+wtmp=$(mktemp 2>/dev/null) || _cc_clip_fallback ${_ORIG[@]+"${_ORIG[@]}"}
+stdin_replay=1
+if [ "${#positional[@]}" -gt 0 ]; then
+    # wl-copy joins text arguments with single spaces, no trailing newline.
+    printf '%%s' "${positional[*]}" > "$wtmp"
+    stdin_replay=0
+else
+    cat > "$wtmp"
+fi
+
+# -n/--trim-newline: mirror it on the forwarded payload so local and remote
+# clipboards end up byte-identical. The replay below feeds the ORIGINAL bytes
+# and lets the real wl-copy apply its own trim.
+posttmp="$wtmp"
+if [ "$trim" -eq 1 ] && [ -s "$wtmp" ] && [ -z "$(tail -c 1 "$wtmp")" ]; then
+    posttmp=$(mktemp 2>/dev/null) || posttmp="$wtmp"
+    if [ "$posttmp" != "$wtmp" ]; then
+        head -c "$(( $(wc -c < "$wtmp") - 1 ))" "$wtmp" > "$posttmp"
+    fi
+fi
+
+forwarded=0
+if _cc_clip_probe && _cc_clip_post_text "$posttmp"; then
+    forwarded=1
+    _cc_clip_log "forwarded to local clipboard"
+else
+    _cc_clip_log "local forward failed or tunnel down"
+fi
+
+real_rc=0
+if wreal="$(_cc_clip_resolve_real_wl_copy)"; then
+    if [ "$stdin_replay" -eq 1 ]; then
+        "$wreal" ${_ORIG[@]+"${_ORIG[@]}"} < "$wtmp" || real_rc=$?
+    else
+        "$wreal" ${_ORIG[@]+"${_ORIG[@]}"} || real_rc=$?
+    fi
+else
+    real_rc=127
+fi
+if [ "$posttmp" != "$wtmp" ]; then rm -f "$posttmp"; fi
+rm -f "$wtmp"
+
+# Success if EITHER side took the copy: a headless remote with a working
+# tunnel is the primary use case and must not fail the caller.
+if [ "$real_rc" -eq 0 ] || [ "$forwarded" -eq 1 ]; then
+    exit 0
+fi
+exit "$real_rc"
+`
+
+// WlCopyShim renders the wl-copy shim script.
+func WlCopyShim(port int, realWlCopyPath string) string {
+	return fmt.Sprintf(wlCopyShimTemplate, port, realWlCopyPath)
+}

--- a/internal/shim/template_write_test.go
+++ b/internal/shim/template_write_test.go
@@ -1,0 +1,334 @@
+package shim
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// writeMockDaemon records POST /clipboard/text bodies so tests can assert the
+// forwarded payload byte-for-byte.
+type writeMockDaemon struct {
+	mu     sync.Mutex
+	bodies []string
+}
+
+func (m *writeMockDaemon) posts() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.bodies...)
+}
+
+func startWriteMockDaemon(t *testing.T) (*writeMockDaemon, int) {
+	t.Helper()
+	m := &writeMockDaemon{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method == http.MethodPost && r.URL.Path == "/clipboard/text" {
+			b := make([]byte, 0, 1024)
+			buf := make([]byte, 4096)
+			for {
+				n, err := r.Body.Read(buf)
+				b = append(b, buf[:n]...)
+				if err != nil {
+					break
+				}
+			}
+			m.mu.Lock()
+			m.bodies = append(m.bodies, string(b))
+			m.mu.Unlock()
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m, port
+}
+
+// writeFakeReal writes a stand-in real binary that records argv and stdin.
+func writeFakeReal(t *testing.T, dir, name string) (bin, argvLog, stdinLog string) {
+	t.Helper()
+	argvLog = filepath.Join(dir, name+".argv")
+	stdinLog = filepath.Join(dir, name+".stdin")
+	bin = filepath.Join(dir, name)
+	script := "#!/bin/bash\nprintf '%s\\n' \"$*\" > " + bashPath(argvLog) + "\ncat > " + bashPath(stdinLog) + "\nexit 0\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create logs so "never invoked" is distinguishable from "invoked
+	// with empty input".
+	for _, f := range []string{argvLog, stdinLog} {
+		if err := os.WriteFile(f, []byte("<never-invoked>"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return bin, argvLog, stdinLog
+}
+
+type writeShimRun struct {
+	daemon   *writeMockDaemon
+	argvLog  string
+	stdinLog string
+	exitCode int
+	output   string
+}
+
+// runWriteShim renders a shim (with realName as the fake real binary), feeds
+// stdin, and executes it against a mock daemon (or a closed port when
+// daemonUp=false).
+func runWriteShim(t *testing.T, render func(port int, real string) string, realName string, realExists, daemonUp bool, stdin string, args ...string) writeShimRun {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("bash semantics not reliable on windows test dirs")
+	}
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available")
+	}
+
+	tmp := t.TempDir()
+	daemon, port := startWriteMockDaemon(t)
+	if !daemonUp {
+		// Grab a port with nothing listening.
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Skip("cannot bind loopback")
+		}
+		port = l.Addr().(*net.TCPAddr).Port
+		l.Close()
+	}
+
+	tokenFile := filepath.Join(tmp, "session.token")
+	if err := os.WriteFile(tokenFile, []byte("tok\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	realBin, argvLog, stdinLog := writeFakeReal(t, tmp, realName)
+	realPath := bashPath(realBin)
+	if !realExists {
+		os.Remove(realBin)
+		realPath = bashPath(filepath.Join(tmp, "no-such-real"))
+	}
+
+	shimPath := filepath.Join(tmp, "shim.sh")
+	if err := os.WriteFile(shimPath, []byte(render(port, realPath)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("bash", append([]string{bashPath(shimPath)}, args...)...)
+	cmd.Stdin = strings.NewReader(stdin)
+	// PATH deliberately excludes the tmp dir so fallback resolution cannot
+	// find a real binary by search when realExists=false.
+	cmd.Env = append(os.Environ(),
+		"PATH=/usr/bin:/bin",
+		"CC_CLIP_PORT="+strconv.Itoa(port),
+		"CC_CLIP_TOKEN_FILE="+bashPath(tokenFile),
+		"CC_CLIP_PROBE_TIMEOUT_MS=2000",
+		"CC_CLIP_FETCH_TIMEOUT_MS=5000",
+	)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			code = ee.ExitCode()
+		} else {
+			t.Fatalf("shim execution failed: %v output=%q", err, out)
+		}
+	}
+	return writeShimRun{daemon: daemon, argvLog: argvLog, stdinLog: stdinLog, exitCode: code, output: string(out)}
+}
+
+func readLog(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestXclipShimWriteDualWrite pins #128 phase 2 on X11: a clipboard write is
+// forwarded to the local daemon byte-for-byte AND replayed into the real
+// xclip with identical stdin and argv, so remote behavior is unchanged.
+func TestXclipShimWriteDualWrite(t *testing.T) {
+	payload := "line one\nlong command --with flags\ntrailing newline kept\n"
+	r := runWriteShim(t, XclipShim, "xclip", true, true, payload, "-selection", "clipboard")
+
+	if r.exitCode != 0 {
+		t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+	}
+	posts := r.daemon.posts()
+	if len(posts) != 1 || posts[0] != payload {
+		t.Fatalf("daemon got %q, want exactly %q", posts, payload)
+	}
+	if got := readLog(t, r.stdinLog); got != payload {
+		t.Fatalf("real xclip stdin %q, want %q", got, payload)
+	}
+	if got := readLog(t, r.argvLog); !strings.Contains(got, "-selection clipboard") {
+		t.Fatalf("real xclip argv %q must keep the original args", got)
+	}
+}
+
+// TestXclipShimWriteTunnelDownStillCopiesRemotely: the local forward is
+// best-effort; with the daemon unreachable the remote clipboard write must
+// succeed exactly as without the shim.
+func TestXclipShimWriteTunnelDownStillCopiesRemotely(t *testing.T) {
+	payload := "remote-only\n"
+	r := runWriteShim(t, XclipShim, "xclip", true, false, payload, "-selection", "clipboard", "-i")
+
+	if r.exitCode != 0 {
+		t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+	}
+	if got := readLog(t, r.stdinLog); got != payload {
+		t.Fatalf("real xclip stdin %q, want %q", got, payload)
+	}
+}
+
+// TestXclipShimWriteHeadlessForwardOnly: no real xclip at all (headless box).
+// The forward alone must count as success — this is the primary use case.
+func TestXclipShimWriteHeadlessForwardOnly(t *testing.T) {
+	payload := "headless copy\n"
+	r := runWriteShim(t, XclipShim, "xclip", false, true, payload, "-selection", "clipboard")
+
+	if r.exitCode != 0 {
+		t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+	}
+	posts := r.daemon.posts()
+	if len(posts) != 1 || posts[0] != payload {
+		t.Fatalf("daemon got %q, want %q", posts, payload)
+	}
+}
+
+// TestXclipShimWriteShapeGates: primary-selection writes and unrecognized
+// read shapes must never be forwarded.
+func TestXclipShimWriteShapeGates(t *testing.T) {
+	t.Run("primary selection passes through untouched", func(t *testing.T) {
+		r := runWriteShim(t, XclipShim, "xclip", true, true, "x\n", "-selection", "primary")
+		if r.exitCode != 0 {
+			t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+		}
+		if got := r.daemon.posts(); len(got) != 0 {
+			t.Fatalf("primary write must not be forwarded: %q", got)
+		}
+		if got := readLog(t, r.stdinLog); got != "x\n" {
+			t.Fatalf("real must receive the payload, got %q", got)
+		}
+	})
+	t.Run("unrecognized read shape falls back without forwarding", func(t *testing.T) {
+		r := runWriteShim(t, XclipShim, "xclip", true, true, "", "-selection", "clipboard", "-t", "text/html", "-o")
+		if r.exitCode != 0 {
+			t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+		}
+		if got := r.daemon.posts(); len(got) != 0 {
+			t.Fatalf("read shape must not be forwarded: %q", got)
+		}
+		if got := readLog(t, r.argvLog); !strings.Contains(got, "-t text/html -o") {
+			t.Fatalf("fallback must exec the real binary with original args, got %q", got)
+		}
+	})
+}
+
+// TestWlCopyShimWrites pins the Wayland write-side companion.
+func TestWlCopyShimWrites(t *testing.T) {
+	t.Run("stdin form dual-writes byte-exact", func(t *testing.T) {
+		payload := "wayland\ncopy\n"
+		r := runWriteShim(t, WlCopyShim, "wl-copy", true, true, payload)
+		if r.exitCode != 0 {
+			t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+		}
+		if posts := r.daemon.posts(); len(posts) != 1 || posts[0] != payload {
+			t.Fatalf("daemon got %q, want %q", posts, payload)
+		}
+		if got := readLog(t, r.stdinLog); got != payload {
+			t.Fatalf("real wl-copy stdin %q, want %q", got, payload)
+		}
+	})
+	t.Run("argument form joins with spaces, no trailing newline", func(t *testing.T) {
+		r := runWriteShim(t, WlCopyShim, "wl-copy", true, true, "", "hello", "wrapped", "world")
+		if r.exitCode != 0 {
+			t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+		}
+		if posts := r.daemon.posts(); len(posts) != 1 || posts[0] != "hello wrapped world" {
+			t.Fatalf("daemon got %q, want %q", posts, "hello wrapped world")
+		}
+		if got := readLog(t, r.argvLog); !strings.Contains(got, "hello wrapped world") {
+			t.Fatalf("real wl-copy argv %q must keep the text args", got)
+		}
+	})
+	t.Run("trim-newline mirrors on the forwarded payload", func(t *testing.T) {
+		r := runWriteShim(t, WlCopyShim, "wl-copy", true, true, "trimmed\n", "-n")
+		if r.exitCode != 0 {
+			t.Fatalf("exit=%d output=%q", r.exitCode, r.output)
+		}
+		if posts := r.daemon.posts(); len(posts) != 1 || posts[0] != "trimmed" {
+			t.Fatalf("daemon got %q, want %q (trailing newline trimmed)", posts, "trimmed")
+		}
+		// The real binary applies its own trim, so it receives the original.
+		if got := readLog(t, r.stdinLog); got != "trimmed\n" {
+			t.Fatalf("real wl-copy stdin %q, want original bytes", got)
+		}
+	})
+	t.Run("primary and non-text types pass through untouched", func(t *testing.T) {
+		for _, args := range [][]string{
+			{"--primary"},
+			{"-t", "image/png"},
+			{"--clear"},
+		} {
+			r := runWriteShim(t, WlCopyShim, "wl-copy", true, true, "p\n", args...)
+			if r.exitCode != 0 {
+				t.Fatalf("args %v: exit=%d output=%q", args, r.exitCode, r.output)
+			}
+			if got := r.daemon.posts(); len(got) != 0 {
+				t.Fatalf("args %v must not be forwarded: %q", args, got)
+			}
+		}
+	})
+}
+
+// TestInstallWaylandShipsWlCopyCompanion: the wayland target installs and
+// uninstalls the write-side shim alongside wl-paste.
+func TestInstallWaylandShipsWlCopyCompanion(t *testing.T) {
+	dir := t.TempDir()
+	res, err := Install(TargetWlPaste, dir, 18339)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Target != TargetWlPaste {
+		t.Fatalf("target = %v", res.Target)
+	}
+	wlCopy := filepath.Join(dir, "wl-copy")
+	data, err := os.ReadFile(wlCopy)
+	if err != nil {
+		t.Fatalf("wl-copy companion not installed: %v", err)
+	}
+	if !strings.Contains(string(data), "cc-clip wl-copy shim") {
+		t.Fatalf("companion content unexpected: %.80s", data)
+	}
+
+	if err := Uninstall(TargetWlPaste, dir); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if _, err := os.Stat(wlCopy); !os.IsNotExist(err) {
+		t.Fatalf("wl-copy companion must be removed with its sibling, stat err=%v", err)
+	}
+}


### PR DESCRIPTION
Phase 2 of #128, reframed by the owner's actual goal: copying in a remote session doesn't happen through pipes — neovim yanks via its clipboard provider, tmux copy-mode runs its `copy-command`, TUI agents shell out. All of those invoke `xclip` or `wl-copy`. This makes those writes land on the **local** clipboard by themselves, byte-exact, with `cc-clip copy` remaining as the explicit low-level primitive.

## Dual-write

Payload → temp file (byte-exact, `--data-binary`) → **POST to the local daemon** through the tunnel → **replay into the real binary**, so the remote clipboard behaves exactly as without the shim.

Exit contract (both proven by tests): success if **either** side takes the copy —

| Situation | Result |
|---|---|
| Headless remote (no real xclip) + tunnel up | forward-only, exit 0 — the primary use case |
| Tunnel down + real binary present | remote-only, exit 0 — the shim never breaks local-to-remote workflows |
| Both fail | real binary's exit code |

## Shapes

- **xclip**: new write branch on `-selection clipboard` without `-o`/`-out` in argv. `-selection primary` and unmatched read shapes keep the old fallback exactly.
- **wl-copy**: a separate binary on Wayland, so the wl-paste target now ships a **companion shim** (installed/uninstalled together, ours-only guard both ways). Only plain clipboard TEXT forwards; `--primary`, `--clear`, non-text `--type`, `-v`/`-h`, unknown options pass through. Argument-form text joins with single spaces, no trailing newline; `-n/--trim-newline` is mirrored on the forwarded payload while the replay feeds original bytes — local and remote clipboards end up byte-identical.

## Trust details

- The write notification body is now stable text so a yank burst collapses into one notification per dedup window instead of one per yank — poisoning visibility still guarantees at least one.
- `${arr[@]+...}` guards every array expansion: bash 3.2 under `set -u` kills the script otherwise (the test harness caught this on first run).

## Tests

Rendered scripts run under real bash against a mock daemon recording POST bodies + a fake real binary recording argv/stdin: byte-exactness with embedded and trailing newlines, tunnel-down, headless, primary/read-shape gates, wl-copy stdin/argument/trim forms, companion install/uninstall. Full race suite, vet, staticcheck, GOOS=linux build clean.

Remaining on #128 after this: reverse **image** copy (no motivating case yet) and the local-terminal mouse-selection caveat, which no SSH-side tool can fix — docs steer users to remote-side copy mechanisms instead.